### PR TITLE
fix: rename server package from praxis-proxy-server to praxis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1671,6 +1671,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "praxis"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "nix",
+ "praxis-proxy-core",
+ "praxis-proxy-filter",
+ "praxis-proxy-protocol",
+ "tikv-jemallocator",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "praxis-proxy-core"
 version = "0.1.0"
 dependencies = [
@@ -1728,21 +1743,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "praxis-proxy-server"
-version = "0.1.0"
-dependencies = [
- "clap",
- "nix",
- "praxis-proxy-core",
- "praxis-proxy-filter",
- "praxis-proxy-protocol",
- "tikv-jemallocator",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "praxis-proxy-tls"
 version = "0.1.0"
 dependencies = [
@@ -1762,10 +1762,10 @@ version = "0.1.0"
 dependencies = [
  "h2",
  "http",
+ "praxis",
  "praxis-proxy-core",
  "praxis-proxy-filter",
  "praxis-proxy-protocol",
- "praxis-proxy-server",
  "rcgen",
  "rustls",
  "rustls-pemfile",
@@ -1831,10 +1831,10 @@ dependencies = [
  "async-trait",
  "benchmarks",
  "bytes",
+ "praxis",
  "praxis-proxy-core",
  "praxis-proxy-filter",
  "praxis-proxy-protocol",
- "praxis-proxy-server",
  "praxis-test-utils",
  "serde_yaml",
  "tokio",
@@ -1854,8 +1854,8 @@ dependencies = [
 name = "praxis-tests-smoke"
 version = "0.1.0"
 dependencies = [
+ "praxis",
  "praxis-proxy-core",
- "praxis-proxy-server",
  "praxis-test-utils",
 ]
 
@@ -3150,8 +3150,8 @@ dependencies = [
  "clap",
  "nix",
  "plotters",
+ "praxis",
  "praxis-proxy-core",
- "praxis-proxy-server",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ pingora-http = { version = "0.8.0", git = "https://github.com/praxis-proxy/pingo
 pingora-proxy = { version = "0.8.0", git = "https://github.com/praxis-proxy/pingora.git", rev = "b2fa2c9a8d4074e2a2a42e70ab4c17f8c61a566d", features = ["rustls"] }
 percent-encoding = "2.3.2"
 plotters = { version = "0.3.7", default-features = false, features = ["svg_backend", "line_series"] }
-praxis = { path = "server", package = "praxis-proxy-server" }
+praxis = { path = "server" }
 praxis-core = { version = "0.1.0", path = "core", package = "praxis-proxy-core" }
 praxis-filter = { version = "0.1.0", path = "filter", package = "praxis-proxy-filter" }
 praxis-protocol = { version = "0.1.0", path = "protocol", package = "praxis-proxy-protocol" }

--- a/Containerfile
+++ b/Containerfile
@@ -45,7 +45,7 @@ RUN mkdir -p core/src \
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/src/target \
-    cargo build --release -p praxis-proxy-server
+    cargo build --release -p praxis
 
 # ------------------------------------------------------------------------------
 # Cache Tricks
@@ -72,7 +72,7 @@ RUN find core/src filter/src \
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/src/target \
-    cargo build --release -p praxis-proxy-server \
+    cargo build --release -p praxis \
     && cp target/release/praxis /usr/local/bin/praxis
 
 # ------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ test-unit:
 	cargo test -p praxis-proxy-core $(_NOCAPTURE)
 	cargo test -p praxis-proxy-filter $(_NOCAPTURE)
 	cargo test -p praxis-proxy-protocol $(_NOCAPTURE)
-	cargo test -p praxis-proxy-server $(_NOCAPTURE)
+	cargo test -p praxis $(_NOCAPTURE)
 
 test-configuration:
 	cargo test -p praxis-tests-configuration $(_NOCAPTURE)

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "praxis-proxy-server"
+name = "praxis"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/xtask/src/benchmark/flamegraph.rs
+++ b/xtask/src/benchmark/flamegraph.rs
@@ -93,7 +93,7 @@ fn require_tool(name: &str, hint: &str) {
 /// Build the profiling binary and return its path.
 fn build_profiling_binary() -> PathBuf {
     let status = Command::new("cargo")
-        .args(["build", "--profile", "profiling", "-p", "praxis-proxy-server"])
+        .args(["build", "--profile", "profiling", "-p", "praxis"])
         .env("RUSTFLAGS", "-C force-frame-pointers=yes")
         .status()
         .expect("failed to run cargo build");


### PR DESCRIPTION
Resolving the build package name resulting in `which failed with package(s) 'praxis' not found in workspace`. Taking a guess the package is intended to be praxis since all of the docs/example configs reference it. Swapped it to praxis to get `cargo run -p xxx` working.

I went the path of least resistance with the name and files to touch 5 vs. 50. If you want it named praxis-proxy-server just say!

Ty!