### PR TITLE
Disable the certificate rotation test on macOS

### DIFF
--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [features]
 default = ["ai-inference"]
 ai-inference = ["praxis-filter/ai-inference"]
+no-mac-cert-rotation-tests = [] # We use this to disable testing cert rotation on macOS
 
 [lints]
 workspace = true

--- a/tests/integration/tests/suite/tls.rs
+++ b/tests/integration/tests/suite/tls.rs
@@ -1779,6 +1779,7 @@ filter_chains:
     );
 }
 
+#[cfg(any(not(target_os = "macos"), feature = "no-mac-cert-rotation-tests"))]
 #[test]
 fn hot_reload_serves_rotated_certificate() {
     let original = TestCertificates::generate();


### PR DESCRIPTION
Resolves #54

This "resolves" the testing problem on macOS by disabling the certificate rotation test on macOS.

The Mac's fsNotify is weird, especially on temp directories.  Multiple attempts (including with Opus 4.6) to get directory watching to work failed.

(Getting a clean test run on the Mac, even if it skips this one test, seems important because every fix I make with Claude notices that one of the tests is broken and Claude gets concerned that an unrelated change broke the cert rotation test.)