### PR TITLE
Stop threads started by test when each test completes

### DIFF
--- a/tests/configuration/tests/suite/examples/ai/model_to_header.rs
+++ b/tests/configuration/tests/suite/examples/ai/model_to_header.rs
@@ -4,7 +4,7 @@
 //! Model to header filter example tests.
 
 use praxis_core::config::Config;
-use praxis_test_utils::{free_port, http_post, start_backend, start_proxy};
+use praxis_test_utils::{free_port, http_post, start_backend_with_shutdown, start_proxy};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -12,10 +12,10 @@ use praxis_test_utils::{free_port, http_post, start_backend, start_proxy};
 
 #[test]
 fn model_to_header_routes_by_model_field() {
-    let port_a = start_backend("model-a-response");
-    let port_default = start_backend("default-response");
+    let backend_a = start_backend_with_shutdown("model-a-response");
+    let backend_default = start_backend_with_shutdown("default-response");
     let proxy_port = free_port();
-    let yaml = make_yaml(proxy_port, "mistral-large-latest", port_a, port_default);
+    let yaml = make_yaml(proxy_port, "mistral-large-latest", backend_a.port(), backend_default.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
     let (status, body) = http_post(
@@ -32,10 +32,10 @@ fn model_to_header_routes_by_model_field() {
 
 #[test]
 fn model_to_header_falls_through_on_unknown_model() {
-    let port_a = start_backend("model-a-response");
-    let port_default = start_backend("default-response");
+    let backend_a = start_backend_with_shutdown("model-a-response");
+    let backend_default = start_backend_with_shutdown("default-response");
     let proxy_port = free_port();
-    let yaml = make_yaml(proxy_port, "mistral-large-latest", port_a, port_default);
+    let yaml = make_yaml(proxy_port, "mistral-large-latest", backend_a.port(), backend_default.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
     let (status, body) = http_post(proxy.addr(), "/v1/chat", r#"{"model":"unknown","messages":[]}"#);
@@ -45,10 +45,10 @@ fn model_to_header_falls_through_on_unknown_model() {
 
 #[test]
 fn model_to_header_continues_without_model_field() {
-    let port_a = start_backend("model-a-response");
-    let port_default = start_backend("default-response");
+    let backend_a = start_backend_with_shutdown("model-a-response");
+    let backend_default = start_backend_with_shutdown("default-response");
     let proxy_port = free_port();
-    let yaml = make_yaml(proxy_port, "mistral-large-latest", port_a, port_default);
+    let yaml = make_yaml(proxy_port, "mistral-large-latest", backend_a.port(), backend_default.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
     let (status, body) = http_post(proxy.addr(), "/v1/chat", r#"{"messages":[]}"#);

--- a/tests/configuration/tests/suite/examples/ai/model_to_header.rs
+++ b/tests/configuration/tests/suite/examples/ai/model_to_header.rs
@@ -15,7 +15,12 @@ fn model_to_header_routes_by_model_field() {
     let backend_a = start_backend_with_shutdown("model-a-response");
     let backend_default = start_backend_with_shutdown("default-response");
     let proxy_port = free_port();
-    let yaml = make_yaml(proxy_port, "mistral-large-latest", backend_a.port(), backend_default.port());
+    let yaml = make_yaml(
+        proxy_port,
+        "mistral-large-latest",
+        backend_a.port(),
+        backend_default.port(),
+    );
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
     let (status, body) = http_post(
@@ -35,7 +40,12 @@ fn model_to_header_falls_through_on_unknown_model() {
     let backend_a = start_backend_with_shutdown("model-a-response");
     let backend_default = start_backend_with_shutdown("default-response");
     let proxy_port = free_port();
-    let yaml = make_yaml(proxy_port, "mistral-large-latest", backend_a.port(), backend_default.port());
+    let yaml = make_yaml(
+        proxy_port,
+        "mistral-large-latest",
+        backend_a.port(),
+        backend_default.port(),
+    );
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
     let (status, body) = http_post(proxy.addr(), "/v1/chat", r#"{"model":"unknown","messages":[]}"#);
@@ -48,7 +58,12 @@ fn model_to_header_continues_without_model_field() {
     let backend_a = start_backend_with_shutdown("model-a-response");
     let backend_default = start_backend_with_shutdown("default-response");
     let proxy_port = free_port();
-    let yaml = make_yaml(proxy_port, "mistral-large-latest", backend_a.port(), backend_default.port());
+    let yaml = make_yaml(
+        proxy_port,
+        "mistral-large-latest",
+        backend_a.port(),
+        backend_default.port(),
+    );
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
     let (status, body) = http_post(proxy.addr(), "/v1/chat", r#"{"messages":[]}"#);

--- a/tests/configuration/tests/suite/examples/api_key_filter.rs
+++ b/tests/configuration/tests/suite/examples/api_key_filter.rs
@@ -10,7 +10,7 @@ use praxis_filter::{
     FilterAction, FilterError, FilterFactory, FilterRegistry, HttpFilter, HttpFilterContext, Rejection,
 };
 use praxis_test_utils::{
-    free_port, http_get, http_send, parse_body, parse_status, start_backend, start_proxy_with_registry,
+    free_port, http_get, http_send, parse_body, parse_status, start_backend_with_shutdown, start_proxy_with_registry,
 };
 
 // -----------------------------------------------------------------------------
@@ -19,7 +19,8 @@ use praxis_test_utils::{
 
 #[test]
 fn api_key_filter() {
-    let backend_port = start_backend("protected");
+    let backend = start_backend_with_shutdown("protected");
+    let backend_port = backend.port();
     let proxy_port = free_port();
     let yaml = format!(
         r#"

--- a/tests/configuration/tests/suite/examples/max_body_guard.rs
+++ b/tests/configuration/tests/suite/examples/max_body_guard.rs
@@ -10,7 +10,7 @@ use praxis_filter::{
     FilterAction, FilterError, FilterFactory, FilterRegistry, HttpFilter, HttpFilterContext, Rejection,
 };
 use praxis_test_utils::{
-    free_port, http_get, http_send, parse_body, parse_status, start_backend, start_proxy_with_registry,
+    free_port, http_get, http_send, parse_body, parse_status, start_backend_with_shutdown, start_proxy_with_registry,
 };
 
 // -----------------------------------------------------------------------------
@@ -19,7 +19,8 @@ use praxis_test_utils::{
 
 #[test]
 fn max_body_guard() {
-    let backend_port = start_backend("accepted");
+    let backend = start_backend_with_shutdown("accepted");
+    let backend_port = backend.port();
     let proxy_port = free_port();
     let yaml = format!(
         r#"

--- a/tests/configuration/tests/suite/examples/observability/access_logging.rs
+++ b/tests/configuration/tests/suite/examples/observability/access_logging.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use praxis_test_utils::{free_port, http_send, parse_body, parse_header, parse_status, start_backend, start_proxy};
+use praxis_test_utils::{free_port, http_send, parse_body, parse_header, parse_status, start_backend_with_shutdown, start_proxy};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -13,12 +13,12 @@ use praxis_test_utils::{free_port, http_send, parse_body, parse_header, parse_st
 
 #[test]
 fn access_logging() {
-    let backend_port = start_backend("logged");
+    let backend = start_backend_with_shutdown("logged");
     let proxy_port = free_port();
     let config = crate::example_utils::load_example_config(
         "observability/access-logging.yaml",
         proxy_port,
-        HashMap::from([("127.0.0.1:3000", backend_port)]),
+        HashMap::from([("127.0.0.1:3000", backend.port())]),
     );
     let proxy = start_proxy(&config);
 

--- a/tests/configuration/tests/suite/examples/observability/access_logging.rs
+++ b/tests/configuration/tests/suite/examples/observability/access_logging.rs
@@ -5,7 +5,9 @@
 
 use std::collections::HashMap;
 
-use praxis_test_utils::{free_port, http_send, parse_body, parse_header, parse_status, start_backend_with_shutdown, start_proxy};
+use praxis_test_utils::{
+    free_port, http_send, parse_body, parse_header, parse_status, start_backend_with_shutdown, start_proxy,
+};
 
 // -----------------------------------------------------------------------------
 // Tests

--- a/tests/configuration/tests/suite/examples/observability/logging.rs
+++ b/tests/configuration/tests/suite/examples/observability/logging.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use praxis_test_utils::{free_port, http_send, parse_header, parse_status, start_backend, start_proxy};
+use praxis_test_utils::{free_port, http_send, parse_header, parse_status, start_backend_with_shutdown, start_proxy};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -13,12 +13,12 @@ use praxis_test_utils::{free_port, http_send, parse_header, parse_status, start_
 
 #[test]
 fn logging() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
     let config = crate::example_utils::load_example_config(
         "observability/logging.yaml",
         proxy_port,
-        HashMap::from([("127.0.0.1:3000", backend_port)]),
+        HashMap::from([("127.0.0.1:3000", backend.port())]),
     );
     let proxy = start_proxy(&config);
 

--- a/tests/configuration/tests/suite/examples/operations/multi_listener.rs
+++ b/tests/configuration/tests/suite/examples/operations/multi_listener.rs
@@ -4,7 +4,7 @@
 //! Multi-listener example tests.
 
 use praxis_core::config::Config;
-use praxis_test_utils::{free_port, http_get, start_backend, start_proxy, wait_for_tcp};
+use praxis_test_utils::{free_port, http_get, start_backend_with_shutdown, start_proxy, wait_for_tcp};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -12,8 +12,10 @@ use praxis_test_utils::{free_port, http_get, start_backend, start_proxy, wait_fo
 
 #[test]
 fn multi_listener() {
-    let api_port = start_backend("api");
-    let web_port = start_backend("web");
+    let api_backend = start_backend_with_shutdown("api");
+    let web_backend = start_backend_with_shutdown("web");
+    let api_port = api_backend.port();
+    let web_port = web_backend.port();
     let http_port = free_port();
     let admin_port = free_port();
 

--- a/tests/configuration/tests/suite/examples/payload_processing/stream_buffer.rs
+++ b/tests/configuration/tests/suite/examples/payload_processing/stream_buffer.rs
@@ -73,44 +73,6 @@ struct TinyStreamBufferFilter {
     max_bytes: usize,
 }
 
-/// Start a proxy with a tiny stream buffer filter and return the backend and proxy guards.
-fn setup(max_bytes: usize) -> (BackendGuard, ProxyGuard) {
-    let backend = start_backend_with_shutdown("ok");
-    let backend_port = backend.port();
-    let proxy_port = free_port();
-    let yaml = format!(
-        r#"
-listeners:
-  - name: default
-    address: "127.0.0.1:{proxy_port}"
-    filter_chains: [main]
-filter_chains:
-  - name: main
-    filters:
-      - filter: tiny_stream_buffer
-        max_bytes: {max_bytes}
-      - filter: router
-        routes:
-          - path_prefix: "/"
-            cluster: backend
-      - filter: load_balancer
-        clusters:
-          - name: backend
-            endpoints:
-              - "127.0.0.1:{backend_port}"
-"#
-    );
-    let config = Config::from_yaml(&yaml).unwrap();
-    let mut registry = FilterRegistry::with_builtins();
-    registry
-        .register(
-            "tiny_stream_buffer",
-            FilterFactory::Http(Arc::new(TinyStreamBufferFilter::from_config)),
-        )
-        .expect("duplicate filter name");
-    (backend, start_proxy_with_registry(&config, &registry))
-}
-
 impl TinyStreamBufferFilter {
     fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
         #[derive(serde::Deserialize)]
@@ -154,3 +116,40 @@ impl HttpFilter for TinyStreamBufferFilter {
     }
 }
 
+/// Start a proxy with a tiny stream buffer filter and return the backend and proxy guards.
+fn setup(max_bytes: usize) -> (BackendGuard, ProxyGuard) {
+    let backend = start_backend_with_shutdown("ok");
+    let backend_port = backend.port();
+    let proxy_port = free_port();
+    let yaml = format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: tiny_stream_buffer
+        max_bytes: {max_bytes}
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: backend
+      - filter: load_balancer
+        clusters:
+          - name: backend
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#
+    );
+    let config = Config::from_yaml(&yaml).unwrap();
+    let mut registry = FilterRegistry::with_builtins();
+    registry
+        .register(
+            "tiny_stream_buffer",
+            FilterFactory::Http(Arc::new(TinyStreamBufferFilter::from_config)),
+        )
+        .expect("duplicate filter name");
+    (backend, start_proxy_with_registry(&config, &registry))
+}

--- a/tests/configuration/tests/suite/examples/payload_processing/stream_buffer.rs
+++ b/tests/configuration/tests/suite/examples/payload_processing/stream_buffer.rs
@@ -11,7 +11,8 @@ use praxis_filter::{
     BodyAccess, BodyMode, FilterAction, FilterError, FilterFactory, FilterRegistry, HttpFilter, HttpFilterContext,
 };
 use praxis_test_utils::{
-    ProxyGuard, free_port, http_post, http_send, parse_status, start_backend, start_proxy_with_registry,
+    BackendGuard, ProxyGuard, free_port, http_post, http_send, parse_status, start_backend_with_shutdown,
+    start_proxy_with_registry,
 };
 
 // -----------------------------------------------------------------------------
@@ -20,7 +21,7 @@ use praxis_test_utils::{
 
 #[test]
 fn stream_buffer_within_limit_succeeds() {
-    let proxy = setup(256);
+    let (_backend, proxy) = setup(256);
     let body = "a".repeat(100);
     let (status, _) = http_post(proxy.addr(), "/", &body);
     assert_eq!(status, 200, "body within limit should be accepted");
@@ -28,7 +29,7 @@ fn stream_buffer_within_limit_succeeds() {
 
 #[test]
 fn stream_buffer_at_exact_limit_succeeds() {
-    let proxy = setup(64);
+    let (_backend, proxy) = setup(64);
     let body = "b".repeat(64);
     let (status, _) = http_post(proxy.addr(), "/", &body);
     assert_eq!(status, 200, "body at exact limit should be accepted");
@@ -36,7 +37,7 @@ fn stream_buffer_at_exact_limit_succeeds() {
 
 #[test]
 fn stream_buffer_exceeding_limit_returns_413() {
-    let proxy = setup(64);
+    let (_backend, proxy) = setup(64);
     let body = "c".repeat(128);
     let (status, _) = http_post(proxy.addr(), "/", &body);
     assert_eq!(status, 413, "body exceeding limit should be rejected with 413");
@@ -44,7 +45,7 @@ fn stream_buffer_exceeding_limit_returns_413() {
 
 #[test]
 fn stream_buffer_one_byte_over_returns_413() {
-    let proxy = setup(64);
+    let (_backend, proxy) = setup(64);
     let body = "d".repeat(65);
     let (status, _) = http_post(proxy.addr(), "/", &body);
     assert_eq!(status, 413, "body one byte over limit should be rejected with 413");
@@ -52,7 +53,7 @@ fn stream_buffer_one_byte_over_returns_413() {
 
 #[test]
 fn stream_buffer_empty_body_succeeds() {
-    let proxy = setup(64);
+    let (_backend, proxy) = setup(64);
     let raw = http_send(
         proxy.addr(),
         "POST / HTTP/1.1\r\n\
@@ -66,6 +67,44 @@ fn stream_buffer_empty_body_succeeds() {
 // -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
+
+/// Start a proxy with a tiny stream buffer filter and return the backend and proxy guards.
+fn setup(max_bytes: usize) -> (BackendGuard, ProxyGuard) {
+    let backend = start_backend_with_shutdown("ok");
+    let backend_port = backend.port();
+    let proxy_port = free_port();
+    let yaml = format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: tiny_stream_buffer
+        max_bytes: {max_bytes}
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: backend
+      - filter: load_balancer
+        clusters:
+          - name: backend
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#
+    );
+    let config = Config::from_yaml(&yaml).unwrap();
+    let mut registry = FilterRegistry::with_builtins();
+    registry
+        .register(
+            "tiny_stream_buffer",
+            FilterFactory::Http(Arc::new(TinyStreamBufferFilter::from_config)),
+        )
+        .expect("duplicate filter name");
+    (backend, start_proxy_with_registry(&config, &registry))
+}
 
 /// Declares StreamBuffer with a small max_bytes for testing 413 enforcement.
 struct TinyStreamBufferFilter {
@@ -115,39 +154,3 @@ impl HttpFilter for TinyStreamBufferFilter {
     }
 }
 
-/// Start a proxy with a tiny stream buffer filter and return the proxy guard.
-fn setup(max_bytes: usize) -> ProxyGuard {
-    let backend_port = start_backend("ok");
-    let proxy_port = free_port();
-    let yaml = format!(
-        r#"
-listeners:
-  - name: default
-    address: "127.0.0.1:{proxy_port}"
-    filter_chains: [main]
-filter_chains:
-  - name: main
-    filters:
-      - filter: tiny_stream_buffer
-        max_bytes: {max_bytes}
-      - filter: router
-        routes:
-          - path_prefix: "/"
-            cluster: backend
-      - filter: load_balancer
-        clusters:
-          - name: backend
-            endpoints:
-              - "127.0.0.1:{backend_port}"
-"#
-    );
-    let config = Config::from_yaml(&yaml).unwrap();
-    let mut registry = FilterRegistry::with_builtins();
-    registry
-        .register(
-            "tiny_stream_buffer",
-            FilterFactory::Http(Arc::new(TinyStreamBufferFilter::from_config)),
-        )
-        .expect("duplicate filter name");
-    start_proxy_with_registry(&config, &registry)
-}

--- a/tests/configuration/tests/suite/examples/payload_processing/stream_buffer.rs
+++ b/tests/configuration/tests/suite/examples/payload_processing/stream_buffer.rs
@@ -68,6 +68,11 @@ fn stream_buffer_empty_body_succeeds() {
 // Test Utilities
 // -----------------------------------------------------------------------------
 
+/// Declares StreamBuffer with a small max_bytes for testing 413 enforcement.
+struct TinyStreamBufferFilter {
+    max_bytes: usize,
+}
+
 /// Start a proxy with a tiny stream buffer filter and return the backend and proxy guards.
 fn setup(max_bytes: usize) -> (BackendGuard, ProxyGuard) {
     let backend = start_backend_with_shutdown("ok");
@@ -104,11 +109,6 @@ filter_chains:
         )
         .expect("duplicate filter name");
     (backend, start_proxy_with_registry(&config, &registry))
-}
-
-/// Declares StreamBuffer with a small max_bytes for testing 413 enforcement.
-struct TinyStreamBufferFilter {
-    max_bytes: usize,
 }
 
 impl TinyStreamBufferFilter {

--- a/tests/configuration/tests/suite/examples/pipeline/conditional_filters.rs
+++ b/tests/configuration/tests/suite/examples/pipeline/conditional_filters.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use praxis_test_utils::{free_port, http_send, parse_body, parse_status, start_backend, start_proxy};
+use praxis_test_utils::{free_port, http_send, parse_body, parse_status, start_backend_with_shutdown, start_proxy};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -13,12 +13,12 @@ use praxis_test_utils::{free_port, http_send, parse_body, parse_status, start_ba
 
 #[test]
 fn conditional_filters() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
     let config = crate::example_utils::load_example_config(
         "pipeline/conditional-filters.yaml",
         proxy_port,
-        HashMap::from([("127.0.0.1:3000", backend_port)]),
+        HashMap::from([("127.0.0.1:3000", backend.port())]),
     );
     let proxy = start_proxy(&config);
     let raw = http_send(

--- a/tests/configuration/tests/suite/examples/traffic_management/basic_reverse_proxy.rs
+++ b/tests/configuration/tests/suite/examples/traffic_management/basic_reverse_proxy.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use praxis_test_utils::{free_port, http_get, start_backend};
+use praxis_test_utils::{free_port, http_get, start_backend_with_shutdown};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -13,12 +13,12 @@ use praxis_test_utils::{free_port, http_get, start_backend};
 
 #[test]
 fn basic_reverse_proxy() {
-    let backend_port = start_backend("hello");
+    let backend = start_backend_with_shutdown("hello");
     let proxy_port = free_port();
     let config = crate::example_utils::load_example_config(
         "traffic-management/basic-reverse-proxy.yaml",
         proxy_port,
-        HashMap::from([("127.0.0.1:3000", backend_port)]),
+        HashMap::from([("127.0.0.1:3000", backend.port())]),
     );
     let proxy = praxis_test_utils::start_proxy(&config);
     let (status, body) = http_get(proxy.addr(), "/", None);

--- a/tests/configuration/tests/suite/examples/traffic_management/canary_routing.rs
+++ b/tests/configuration/tests/suite/examples/traffic_management/canary_routing.rs
@@ -19,7 +19,10 @@ fn canary_routing() {
     let config = crate::example_utils::load_example_config(
         "traffic-management/canary-routing.yaml",
         proxy_port,
-        HashMap::from([("127.0.0.1:3001", backend_stable.port()), ("127.0.0.1:3002", backend_canary.port())]),
+        HashMap::from([
+            ("127.0.0.1:3001", backend_stable.port()),
+            ("127.0.0.1:3002", backend_canary.port()),
+        ]),
     );
     let proxy = start_proxy(&config);
     let total = 200u32;

--- a/tests/configuration/tests/suite/examples/traffic_management/canary_routing.rs
+++ b/tests/configuration/tests/suite/examples/traffic_management/canary_routing.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use praxis_test_utils::{free_port, http_get, start_backend, start_proxy};
+use praxis_test_utils::{free_port, http_get, start_backend_with_shutdown, start_proxy};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -13,13 +13,13 @@ use praxis_test_utils::{free_port, http_get, start_backend, start_proxy};
 
 #[test]
 fn canary_routing() {
-    let port_stable = start_backend("stable");
-    let port_canary = start_backend("canary");
+    let backend_stable = start_backend_with_shutdown("stable");
+    let backend_canary = start_backend_with_shutdown("canary");
     let proxy_port = free_port();
     let config = crate::example_utils::load_example_config(
         "traffic-management/canary-routing.yaml",
         proxy_port,
-        HashMap::from([("127.0.0.1:3001", port_stable), ("127.0.0.1:3002", port_canary)]),
+        HashMap::from([("127.0.0.1:3001", backend_stable.port()), ("127.0.0.1:3002", backend_canary.port())]),
     );
     let proxy = start_proxy(&config);
     let total = 200u32;

--- a/tests/configuration/tests/suite/examples/traffic_management/least_connections.rs
+++ b/tests/configuration/tests/suite/examples/traffic_management/least_connections.rs
@@ -5,7 +5,7 @@
 
 use std::{collections::HashMap, thread, time::Duration};
 
-use praxis_test_utils::{free_port, http_get, start_backend, start_proxy, start_slow_backend};
+use praxis_test_utils::{free_port, http_get, start_backend_with_shutdown, start_proxy, start_slow_backend};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -13,17 +13,17 @@ use praxis_test_utils::{free_port, http_get, start_backend, start_proxy, start_s
 
 #[test]
 fn least_connections() {
-    let port_a = start_backend("lc-a");
-    let port_b = start_backend("lc-b");
-    let port_c = start_backend("lc-c");
+    let backend_a = start_backend_with_shutdown("lc-a");
+    let backend_b = start_backend_with_shutdown("lc-b");
+    let backend_c = start_backend_with_shutdown("lc-c");
     let proxy_port = free_port();
     let config = crate::example_utils::load_example_config(
         "traffic-management/least-connections.yaml",
         proxy_port,
         HashMap::from([
-            ("127.0.0.1:3001", port_a),
-            ("127.0.0.1:3002", port_b),
-            ("127.0.0.1:3003", port_c),
+            ("127.0.0.1:3001", backend_a.port()),
+            ("127.0.0.1:3002", backend_b.port()),
+            ("127.0.0.1:3003", backend_c.port()),
         ]),
     );
     let proxy = start_proxy(&config);

--- a/tests/configuration/tests/suite/examples/traffic_management/path_based_routing.rs
+++ b/tests/configuration/tests/suite/examples/traffic_management/path_based_routing.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use praxis_test_utils::{free_port, http_get_retry, start_backend, start_proxy};
+use praxis_test_utils::{free_port, http_get_retry, start_backend_with_shutdown, start_proxy};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -13,19 +13,19 @@ use praxis_test_utils::{free_port, http_get_retry, start_backend, start_proxy};
 
 #[test]
 fn path_based_routing() {
-    let api_port = start_backend("api");
-    let static_port = start_backend("static");
-    let default_port = start_backend("default");
+    let api_backend = start_backend_with_shutdown("api");
+    let static_backend = start_backend_with_shutdown("static");
+    let default_backend = start_backend_with_shutdown("default");
     let proxy_port = free_port();
     let config = crate::example_utils::load_example_config(
         "traffic-management/path-based-routing.yaml",
         proxy_port,
         HashMap::from([
-            ("127.0.0.1:3001", api_port),
-            ("127.0.0.1:3002", api_port),
-            ("127.0.0.1:3003", api_port),
-            ("127.0.0.1:4000", static_port),
-            ("127.0.0.1:5000", default_port),
+            ("127.0.0.1:3001", api_backend.port()),
+            ("127.0.0.1:3002", api_backend.port()),
+            ("127.0.0.1:3003", api_backend.port()),
+            ("127.0.0.1:4000", static_backend.port()),
+            ("127.0.0.1:5000", default_backend.port()),
         ]),
     );
     let proxy = start_proxy(&config);

--- a/tests/configuration/tests/suite/examples/traffic_management/round_robin.rs
+++ b/tests/configuration/tests/suite/examples/traffic_management/round_robin.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use praxis_test_utils::{free_port, http_get, start_backend, start_proxy};
+use praxis_test_utils::{free_port, http_get, start_backend_with_shutdown, start_proxy};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -13,17 +13,17 @@ use praxis_test_utils::{free_port, http_get, start_backend, start_proxy};
 
 #[test]
 fn round_robin() {
-    let port_a = start_backend("a");
-    let port_b = start_backend("b");
-    let port_c = start_backend("c");
+    let backend_a = start_backend_with_shutdown("a");
+    let backend_b = start_backend_with_shutdown("b");
+    let backend_c = start_backend_with_shutdown("c");
     let proxy_port = free_port();
     let config = crate::example_utils::load_example_config(
         "traffic-management/round-robin.yaml",
         proxy_port,
         HashMap::from([
-            ("127.0.0.1:3001", port_a),
-            ("127.0.0.1:3002", port_b),
-            ("127.0.0.1:3003", port_c),
+            ("127.0.0.1:3001", backend_a.port()),
+            ("127.0.0.1:3002", backend_b.port()),
+            ("127.0.0.1:3003", backend_c.port()),
         ]),
     );
     let proxy = start_proxy(&config);

--- a/tests/configuration/tests/suite/examples/traffic_management/session_affinity.rs
+++ b/tests/configuration/tests/suite/examples/traffic_management/session_affinity.rs
@@ -5,7 +5,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use praxis_test_utils::{free_port, http_send, parse_body, start_backend, start_proxy};
+use praxis_test_utils::{free_port, http_send, parse_body, start_backend_with_shutdown, start_proxy};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -13,17 +13,17 @@ use praxis_test_utils::{free_port, http_send, parse_body, start_backend, start_p
 
 #[test]
 fn session_affinity() {
-    let port_a = start_backend("sa-a");
-    let port_b = start_backend("sa-b");
-    let port_c = start_backend("sa-c");
+    let backend_a = start_backend_with_shutdown("sa-a");
+    let backend_b = start_backend_with_shutdown("sa-b");
+    let backend_c = start_backend_with_shutdown("sa-c");
     let proxy_port = free_port();
     let config = crate::example_utils::load_example_config(
         "traffic-management/session-affinity.yaml",
         proxy_port,
         HashMap::from([
-            ("127.0.0.1:3001", port_a),
-            ("127.0.0.1:3002", port_b),
-            ("127.0.0.1:3003", port_c),
+            ("127.0.0.1:3001", backend_a.port()),
+            ("127.0.0.1:3002", backend_b.port()),
+            ("127.0.0.1:3003", backend_c.port()),
         ]),
     );
     let proxy = start_proxy(&config);

--- a/tests/configuration/tests/suite/examples/traffic_management/timeout.rs
+++ b/tests/configuration/tests/suite/examples/traffic_management/timeout.rs
@@ -6,7 +6,7 @@
 use std::time::Duration;
 
 use praxis_core::config::Config;
-use praxis_test_utils::{free_port, http_get, start_backend, start_proxy, start_slow_backend};
+use praxis_test_utils::{free_port, http_get, start_backend_with_shutdown, start_proxy, start_slow_backend};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -14,7 +14,8 @@ use praxis_test_utils::{free_port, http_get, start_backend, start_proxy, start_s
 
 #[test]
 fn timeout() {
-    let fast_port = start_backend("fast");
+    let fast_backend = start_backend_with_shutdown("fast");
+    let fast_port = fast_backend.port();
     let proxy_port = free_port();
     let yaml = format!(
         r#"

--- a/tests/configuration/tests/suite/examples/traffic_management/virtual_hosts.rs
+++ b/tests/configuration/tests/suite/examples/traffic_management/virtual_hosts.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use praxis_test_utils::{free_port, http_get, start_backend, start_proxy};
+use praxis_test_utils::{free_port, http_get, start_backend_with_shutdown, start_proxy};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -13,18 +13,18 @@ use praxis_test_utils::{free_port, http_get, start_backend, start_proxy};
 
 #[test]
 fn virtual_hosts() {
-    let api_port = start_backend("api-host");
-    let web_port = start_backend("web-host");
-    let default_port = start_backend("default-host");
+    let api_backend = start_backend_with_shutdown("api-host");
+    let web_backend = start_backend_with_shutdown("web-host");
+    let default_backend = start_backend_with_shutdown("default-host");
     let proxy_port = free_port();
     let config = crate::example_utils::load_example_config(
         "traffic-management/hosts.yaml",
         proxy_port,
         HashMap::from([
-            ("127.0.0.1:3001", api_port),
-            ("127.0.0.1:3002", api_port),
-            ("127.0.0.1:4000", web_port),
-            ("127.0.0.1:5000", default_port),
+            ("127.0.0.1:3001", api_backend.port()),
+            ("127.0.0.1:3002", api_backend.port()),
+            ("127.0.0.1:4000", web_backend.port()),
+            ("127.0.0.1:5000", default_backend.port()),
         ]),
     );
     let proxy = start_proxy(&config);

--- a/tests/configuration/tests/suite/examples/traffic_management/weighted_load_balancing.rs
+++ b/tests/configuration/tests/suite/examples/traffic_management/weighted_load_balancing.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use praxis_test_utils::{free_port, http_get, start_backend, start_proxy};
+use praxis_test_utils::{free_port, http_get, start_backend_with_shutdown, start_proxy};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -13,13 +13,13 @@ use praxis_test_utils::{free_port, http_get, start_backend, start_proxy};
 
 #[test]
 fn weighted_load_balancing() {
-    let port_light = start_backend("light");
-    let port_heavy = start_backend("heavy");
+    let backend_light = start_backend_with_shutdown("light");
+    let backend_heavy = start_backend_with_shutdown("heavy");
     let proxy_port = free_port();
     let config = crate::example_utils::load_example_config(
         "traffic-management/weighted-load-balancing.yaml",
         proxy_port,
-        HashMap::from([("127.0.0.1:3001", port_light), ("127.0.0.1:3002", port_heavy)]),
+        HashMap::from([("127.0.0.1:3001", backend_light.port()), ("127.0.0.1:3002", backend_heavy.port())]),
     );
     let proxy = start_proxy(&config);
 

--- a/tests/configuration/tests/suite/examples/traffic_management/weighted_load_balancing.rs
+++ b/tests/configuration/tests/suite/examples/traffic_management/weighted_load_balancing.rs
@@ -19,7 +19,10 @@ fn weighted_load_balancing() {
     let config = crate::example_utils::load_example_config(
         "traffic-management/weighted-load-balancing.yaml",
         proxy_port,
-        HashMap::from([("127.0.0.1:3001", backend_light.port()), ("127.0.0.1:3002", backend_heavy.port())]),
+        HashMap::from([
+            ("127.0.0.1:3001", backend_light.port()),
+            ("127.0.0.1:3002", backend_heavy.port()),
+        ]),
     );
     let proxy = start_proxy(&config);
 

--- a/tests/configuration/tests/suite/examples/transformation/header_manipulation.rs
+++ b/tests/configuration/tests/suite/examples/transformation/header_manipulation.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use praxis_test_utils::{Backend, free_port, http_send, parse_header, start_backend, start_proxy};
+use praxis_test_utils::{Backend, free_port, http_send, parse_header, start_backend_with_shutdown, start_proxy};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -13,12 +13,12 @@ use praxis_test_utils::{Backend, free_port, http_send, parse_header, start_backe
 
 #[test]
 fn header_manipulation() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
     let config = crate::example_utils::load_example_config(
         "transformation/header-manipulation.yaml",
         proxy_port,
-        HashMap::from([("127.0.0.1:3000", backend_port)]),
+        HashMap::from([("127.0.0.1:3000", backend.port())]),
     );
     let proxy = start_proxy(&config);
     let raw = http_send(

--- a/tests/conformance/tests/suite/chunked.rs
+++ b/tests/conformance/tests/suite/chunked.rs
@@ -5,8 +5,8 @@
 
 use praxis_core::config::Config;
 use praxis_test_utils::{
-    free_port, http_get, http_send, parse_body, parse_status, simple_proxy_yaml, start_backend, start_echo_backend,
-    start_proxy,
+    free_port, http_get, http_send, parse_body, parse_status, simple_proxy_yaml, start_backend_with_shutdown,
+    start_echo_backend, start_proxy,
 };
 
 // -----------------------------------------------------------------------------
@@ -40,7 +40,8 @@ fn single_chunk_body_proxied() {
 
 #[test]
 fn multiple_chunks_proxied() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -105,7 +106,8 @@ fn empty_chunked_body_returns_200() {
 
 #[test]
 fn chunked_body_with_trailers_does_not_crash() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -135,7 +137,8 @@ fn chunked_body_with_trailers_does_not_crash() {
 
 #[test]
 fn recovery_after_chunked_request() {
-    let backend_port = start_backend("alive");
+    let _backend = start_backend_with_shutdown("alive");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();

--- a/tests/conformance/tests/suite/cors.rs
+++ b/tests/conformance/tests/suite/cors.rs
@@ -15,7 +15,7 @@
 //! [Fetch Standard Section 3.2.5]: https://fetch.spec.whatwg.org/#main-fetch
 
 use praxis_core::config::Config;
-use praxis_test_utils::{free_port, http_send, parse_header, parse_status, start_backend, start_proxy};
+use praxis_test_utils::{free_port, http_send, parse_header, parse_status, start_backend_with_shutdown, start_proxy};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -29,7 +29,8 @@ use praxis_test_utils::{free_port, http_send, parse_header, parse_status, start_
 /// [Fetch Standard Section 3.2.3]: https://fetch.spec.whatwg.org/#cors-preflight-request
 #[test]
 fn fetch_3_2_3_preflight_success_includes_required_headers() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = cors_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -65,7 +66,8 @@ fn fetch_3_2_3_preflight_success_includes_required_headers() {
 /// [Fetch Standard Section 3.2.3]: https://fetch.spec.whatwg.org/#cors-preflight-request
 #[test]
 fn fetch_3_2_3_preflight_disallowed_method_omits_acao() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = cors_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -87,7 +89,8 @@ fn fetch_3_2_3_preflight_disallowed_method_omits_acao() {
 /// [Fetch Standard Section 3.2.4]: https://fetch.spec.whatwg.org/#cors-preflight-cache
 #[test]
 fn fetch_3_2_4_preflight_includes_max_age() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = cors_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -111,7 +114,8 @@ fn fetch_3_2_4_preflight_includes_max_age() {
 /// [Fetch Standard Section 3.2.5]: https://fetch.spec.whatwg.org/#main-fetch
 #[test]
 fn fetch_3_2_5_simple_request_reflects_allowed_origin() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = cors_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -136,7 +140,8 @@ fn fetch_3_2_5_simple_request_reflects_allowed_origin() {
 /// [Fetch Standard Section 3.2.5]: https://fetch.spec.whatwg.org/#main-fetch
 #[test]
 fn fetch_3_2_5_simple_request_omits_acao_for_disallowed_origin() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = cors_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -160,7 +165,8 @@ fn fetch_3_2_5_simple_request_omits_acao_for_disallowed_origin() {
 /// [Fetch Standard Section 3.2.5]: https://fetch.spec.whatwg.org/#main-fetch
 #[test]
 fn fetch_3_2_5_vary_origin_on_non_cors_responses() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = cors_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -186,7 +192,8 @@ fn fetch_3_2_5_vary_origin_on_non_cors_responses() {
 /// [Fetch Standard Section 3.2.5]: https://fetch.spec.whatwg.org/#main-fetch
 #[test]
 fn fetch_3_2_5_credentials_on_simple_request() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = cors_credentials_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -217,7 +224,8 @@ fn fetch_3_2_5_credentials_on_simple_request() {
 /// [Fetch Standard Section 3.2.5]: https://fetch.spec.whatwg.org/#main-fetch
 #[test]
 fn fetch_3_2_5_expose_headers_on_actual_request() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = cors_expose_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -245,7 +253,8 @@ fn fetch_3_2_5_expose_headers_on_actual_request() {
 /// [Fetch Standard Section 3.2.5]: https://fetch.spec.whatwg.org/#main-fetch
 #[test]
 fn fetch_3_2_5_wildcard_origin_returns_star() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = cors_wildcard_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -271,7 +280,8 @@ fn fetch_3_2_5_wildcard_origin_returns_star() {
 /// [Fetch Standard Section 3.2.3]: https://fetch.spec.whatwg.org/#cors-preflight-request
 #[test]
 fn fetch_3_2_3_private_network_access_preflight() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = cors_pna_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -300,7 +310,8 @@ fn fetch_3_2_3_private_network_access_preflight() {
 /// [Fetch Standard Section 3.2.3]: https://fetch.spec.whatwg.org/#cors-preflight-request
 #[test]
 fn fetch_3_2_3_reject_mode_disallowed_origin_returns_403() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = cors_reject_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -328,7 +339,8 @@ fn fetch_3_2_3_reject_mode_disallowed_origin_returns_403() {
 /// [Fetch Standard Section 3.2.3]: https://fetch.spec.whatwg.org/#cors-preflight-request
 #[test]
 fn cors_successful_preflight_includes_vary_headers() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = cors_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();

--- a/tests/conformance/tests/suite/http.rs
+++ b/tests/conformance/tests/suite/http.rs
@@ -5,7 +5,8 @@
 
 use praxis_core::config::Config;
 use praxis_test_utils::{
-    free_port, http_get, http_send, parse_body, parse_status, simple_proxy_yaml, start_backend, start_proxy,
+    free_port, http_get, http_send, parse_body, parse_status, simple_proxy_yaml, start_backend_with_shutdown,
+    start_proxy,
 };
 
 // -----------------------------------------------------------------------------
@@ -14,7 +15,8 @@ use praxis_test_utils::{
 
 #[test]
 fn nonsense_method_does_not_crash() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -31,7 +33,8 @@ fn nonsense_method_does_not_crash() {
 
 #[test]
 fn missing_host_header_does_not_crash() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -48,7 +51,8 @@ fn missing_host_header_does_not_crash() {
 
 #[test]
 fn empty_request_line_no_crash() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -64,7 +68,8 @@ fn empty_request_line_no_crash() {
 
 #[test]
 fn garbage_bytes_no_crash() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -87,7 +92,8 @@ fn garbage_bytes_no_crash() {
 
 #[test]
 fn very_long_uri_handled() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -106,7 +112,8 @@ fn very_long_uri_handled() {
 
 #[test]
 fn very_long_header_value_handled() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -130,7 +137,8 @@ fn very_long_header_value_handled() {
 
 #[test]
 fn many_headers_handled() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -153,7 +161,8 @@ fn many_headers_handled() {
 
 #[test]
 fn content_length_zero_with_no_body() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -169,7 +178,8 @@ fn content_length_zero_with_no_body() {
 
 #[test]
 fn negative_content_length_rejected() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -189,7 +199,8 @@ fn negative_content_length_rejected() {
 
 #[test]
 fn duplicate_content_length_rejected() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -215,7 +226,8 @@ fn duplicate_content_length_rejected() {
 
 #[test]
 fn proxy_recovers_after_malformed_request() {
-    let backend_port = start_backend("recovered");
+    let _backend = start_backend_with_shutdown("recovered");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -230,7 +242,8 @@ fn proxy_recovers_after_malformed_request() {
 
 #[test]
 fn proxy_recovers_after_connection_reset() {
-    let backend_port = start_backend("alive");
+    let _backend = start_backend_with_shutdown("alive");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -248,7 +261,8 @@ fn proxy_recovers_after_connection_reset() {
 
 #[test]
 fn head_request_returns_no_body() {
-    let backend_port = start_backend("should-not-appear");
+    let _backend = start_backend_with_shutdown("should-not-appear");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -264,7 +278,8 @@ fn head_request_returns_no_body() {
 
 #[test]
 fn options_request_handled() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -279,7 +294,8 @@ fn options_request_handled() {
 
 #[test]
 fn handles_concurrent_requests() {
-    let backend_port = start_backend("concurrent");
+    let _backend = start_backend_with_shutdown("concurrent");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();

--- a/tests/conformance/tests/suite/ipv6.rs
+++ b/tests/conformance/tests/suite/ipv6.rs
@@ -5,8 +5,8 @@
 
 use praxis_core::{config::Config, connectivity::CidrRange};
 use praxis_test_utils::{
-    free_port, free_port_v6, http_get, http_get_v6, ipv6_available, start_backend, start_backend_v6, start_proxy,
-    wait_for_tcp,
+    free_port, free_port_v6, http_get, http_get_v6, ipv6_available, start_backend_v6,
+    start_backend_with_shutdown, start_proxy, wait_for_tcp,
 };
 
 // -----------------------------------------------------------------------------
@@ -20,7 +20,8 @@ fn ipv6_listener_serves_http() {
         return;
     }
 
-    let backend_port = start_backend("ipv6-listener-ok");
+    let _backend = start_backend_with_shutdown("ipv6-listener-ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port_v6();
 
     let yaml = format!(
@@ -102,7 +103,8 @@ fn ipv6_ip_acl_allow() {
         return;
     }
 
-    let backend_port = start_backend("ipv6-acl-ok");
+    let _backend = start_backend_with_shutdown("ipv6-acl-ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port_v6();
 
     let yaml = format!(
@@ -147,7 +149,8 @@ fn ipv6_ip_acl_deny() {
         return;
     }
 
-    let backend_port = start_backend("should-not-reach");
+    let _backend = start_backend_with_shutdown("should-not-reach");
+    let backend_port = _backend.port();
     let proxy_port = free_port_v6();
 
     let yaml = format!(
@@ -189,7 +192,8 @@ fn ipv6_access_log_records_client_address() {
         return;
     }
 
-    let backend_port = start_backend("logged-v6");
+    let _backend = start_backend_with_shutdown("logged-v6");
+    let backend_port = _backend.port();
     let proxy_port = free_port_v6();
 
     let yaml = format!(

--- a/tests/conformance/tests/suite/ipv6.rs
+++ b/tests/conformance/tests/suite/ipv6.rs
@@ -5,8 +5,8 @@
 
 use praxis_core::{config::Config, connectivity::CidrRange};
 use praxis_test_utils::{
-    free_port, free_port_v6, http_get, http_get_v6, ipv6_available, start_backend_v6,
-    start_backend_with_shutdown, start_proxy, wait_for_tcp,
+    free_port, free_port_v6, http_get, http_get_v6, ipv6_available, start_backend_v6, start_backend_with_shutdown,
+    start_proxy, wait_for_tcp,
 };
 
 // -----------------------------------------------------------------------------

--- a/tests/conformance/tests/suite/rfcs/rfc9110.rs
+++ b/tests/conformance/tests/suite/rfcs/rfc9110.rs
@@ -9,8 +9,9 @@ use std::time::Duration;
 
 use praxis_core::config::Config;
 use praxis_test_utils::{
-    free_port, http_get, http_send, parse_body, parse_header, parse_status, simple_proxy_yaml, start_backend,
-    start_header_echo_backend, start_header_echo_backend_with_shutdown, start_slow_backend, wait_for_http2,
+    free_port, http_get, http_send, parse_body, parse_header, parse_status, simple_proxy_yaml,
+    start_backend_with_shutdown, start_header_echo_backend, start_header_echo_backend_with_shutdown,
+    start_slow_backend, wait_for_http2,
 };
 
 use super::test_utils::{
@@ -29,7 +30,8 @@ use super::test_utils::{
 /// [RFC 9110 Section 7.2]: https://datatracker.ietf.org/doc/html/rfc9110#section-7.2
 #[test]
 fn rfc9110_multiple_host_headers_rejected() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -58,7 +60,8 @@ fn rfc9110_multiple_host_headers_rejected() {
 /// [RFC 9110 Section 7.2]: https://datatracker.ietf.org/doc/html/rfc9110#section-7.2
 #[test]
 fn rfc9110_host_mismatch_with_absolute_uri() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -89,7 +92,8 @@ fn rfc9110_host_mismatch_with_absolute_uri() {
 /// [RFC 9110 Section 9.3.8]: https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.8
 #[test]
 fn rfc9110_trace_request_handled() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -119,7 +123,8 @@ fn rfc9110_trace_request_handled() {
 /// [RFC 9110 Section 8.6]: https://datatracker.ietf.org/doc/html/rfc9110#section-8.6
 #[test]
 fn rfc9110_duplicate_cl_different_values_rejected() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -150,7 +155,8 @@ fn rfc9110_duplicate_cl_different_values_rejected() {
 /// [RFC 9110 Section 8.6]: https://datatracker.ietf.org/doc/html/rfc9110#section-8.6
 #[test]
 fn rfc9110_duplicate_cl_same_value_rejected() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -266,7 +272,8 @@ fn rfc9110_upstream_timeout_returns_504() {
 /// [RFC 9110 Section 15.6.5]: https://datatracker.ietf.org/doc/html/rfc9110#section-15.6.5
 #[test]
 fn rfc9110_upstream_within_timeout_succeeds() {
-    let backend_port = start_backend("fast-response");
+    let _backend = start_backend_with_shutdown("fast-response");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = timeout_filter_yaml(proxy_port, backend_port, 5000);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -774,7 +781,8 @@ fn rfc9110_via_header_added_to_request() {
 /// [RFC 9110 Section 7.6.3]: https://datatracker.ietf.org/doc/html/rfc9110#section-7.6.3
 #[test]
 fn rfc9110_via_header_added_to_response() {
-    let backend_port = start_backend("via-test");
+    let _backend = start_backend_with_shutdown("via-test");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -832,7 +840,8 @@ fn rfc9110_via_header_appended_not_replaced() {
 /// [RFC 9110 Section 7.6.3]: https://datatracker.ietf.org/doc/html/rfc9110#section-7.6.3
 #[test]
 fn rfc9110_via_header_h2_client_gets_2_0() {
-    let backend_port = start_backend("via-h2-test");
+    let _backend = start_backend_with_shutdown("via-h2-test");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -888,7 +897,8 @@ fn rfc9110_max_forwards_decremented_on_options() {
 /// [RFC 9110 Section 7.6.2]: https://datatracker.ietf.org/doc/html/rfc9110#section-7.6.2
 #[test]
 fn rfc9110_max_forwards_zero_trace_returns_200() {
-    let backend_port = start_backend("should-not-reach");
+    let _backend = start_backend_with_shutdown("should-not-reach");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -921,7 +931,8 @@ fn rfc9110_max_forwards_zero_trace_returns_200() {
 /// [RFC 9110 Section 7.6.2]: https://datatracker.ietf.org/doc/html/rfc9110#section-7.6.2
 #[test]
 fn rfc9110_no_max_forwards_forwarded_normally() {
-    let backend_port = start_backend("normal-forward");
+    let _backend = start_backend_with_shutdown("normal-forward");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -987,7 +998,8 @@ fn rfc9110_te_header_stripped_from_upstream_request() {
 /// [RFC 9110 Section 15.2]: https://datatracker.ietf.org/doc/html/rfc9110#section-15.2
 #[test]
 fn rfc9110_100_continue_allows_body_upload() {
-    let backend_port = start_backend("upload-ok");
+    let _backend = start_backend_with_shutdown("upload-ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -1031,7 +1043,8 @@ fn rfc9110_100_continue_allows_body_upload() {
 /// [RFC 9110 Section 7.6.2]: https://datatracker.ietf.org/doc/html/rfc9110#section-7.6.2
 #[test]
 fn rfc9110_max_forwards_ignored_on_get() {
-    let backend_port = start_backend("max-fwd-get");
+    let _backend = start_backend_with_shutdown("max-fwd-get");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();

--- a/tests/conformance/tests/suite/rfcs/rfc9112.rs
+++ b/tests/conformance/tests/suite/rfcs/rfc9112.rs
@@ -13,7 +13,7 @@ use std::{
 
 use praxis_core::config::Config;
 use praxis_test_utils::{
-    free_port, http_get, http_send, parse_body, parse_status, simple_proxy_yaml, start_backend,
+    free_port, http_get, http_send, parse_body, parse_status, simple_proxy_yaml, start_backend_with_shutdown,
     start_header_echo_backend, start_proxy,
 };
 
@@ -31,7 +31,8 @@ use super::test_utils::{start_417_backend, start_crlf_response_backend, start_re
 /// [RFC 9112 Section 6.1]: https://datatracker.ietf.org/doc/html/rfc9112#section-6.1
 #[test]
 fn rfc9112_te_and_cl_conflict() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -66,7 +67,8 @@ fn rfc9112_te_and_cl_conflict() {
 /// [RFC 9112 Section 2.2]: https://datatracker.ietf.org/doc/html/rfc9112#section-2.2
 #[test]
 fn rfc9112_bare_cr_in_header_rejected() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -101,7 +103,8 @@ fn rfc9112_bare_cr_in_header_rejected() {
 /// [RFC 9112 Section 3.2.1]: https://datatracker.ietf.org/doc/html/rfc9112#section-3.2.1
 #[test]
 fn rfc9112_absolute_form_request_uri() {
-    let backend_port = start_backend("absolute");
+    let _backend = start_backend_with_shutdown("absolute");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -133,7 +136,8 @@ fn rfc9112_absolute_form_request_uri() {
 /// [RFC 9112 Section 9.6]: https://datatracker.ietf.org/doc/html/rfc9112#section-9.6
 #[test]
 fn rfc9112_connection_close_respected() {
-    let backend_port = start_backend("close-me");
+    let _backend = start_backend_with_shutdown("close-me");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -171,7 +175,8 @@ fn rfc9112_connection_close_respected() {
 /// [RFC 9112 Section 6.1]: https://datatracker.ietf.org/doc/html/rfc9112#section-6.1
 #[test]
 fn rfc9112_te_overrides_cl_chunked_body() {
-    let backend_port = start_backend("te-wins");
+    let _backend = start_backend_with_shutdown("te-wins");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -370,7 +375,8 @@ fn rfc9112_proxy_sends_http11_to_upstream() {
 /// [RFC 9112 Section 9.3]: https://datatracker.ietf.org/doc/html/rfc9112#section-9.3
 #[test]
 fn rfc9112_expect_100_continue_post_succeeds() {
-    let backend_port = start_backend("continue-ok");
+    let _backend = start_backend_with_shutdown("continue-ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -447,7 +453,8 @@ fn rfc9112_expect_100_continue_417_forwarded() {
 /// [RFC 9112 Section 5.2]: https://datatracker.ietf.org/doc/html/rfc9112#section-5.2
 #[test]
 fn rfc9112_obs_fold_sp_rejected() {
-    let backend_port = start_backend("should-not-reach");
+    let _backend = start_backend_with_shutdown("should-not-reach");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -475,7 +482,8 @@ fn rfc9112_obs_fold_sp_rejected() {
 /// [RFC 9112 Section 5.2]: https://datatracker.ietf.org/doc/html/rfc9112#section-5.2
 #[test]
 fn rfc9112_obs_fold_htab_rejected() {
-    let backend_port = start_backend("should-not-reach");
+    let _backend = start_backend_with_shutdown("should-not-reach");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -507,7 +515,8 @@ fn rfc9112_obs_fold_htab_rejected() {
 /// [RFC 9112 Section 5.4]: https://datatracker.ietf.org/doc/html/rfc9112#section-5.4
 #[test]
 fn rfc9112_http10_without_host_accepted() {
-    let backend_port = start_backend("http10-ok");
+    let _backend = start_backend_with_shutdown("http10-ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -540,7 +549,8 @@ fn rfc9112_http10_without_host_accepted() {
 /// [RFC 9112 Section 3.2]: https://datatracker.ietf.org/doc/html/rfc9112#section-3.2
 #[test]
 fn rfc9112_options_asterisk_form_handled() {
-    let backend_port = start_backend("asterisk");
+    let _backend = start_backend_with_shutdown("asterisk");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();

--- a/tests/conformance/tests/suite/tls.rs
+++ b/tests/conformance/tests/suite/tls.rs
@@ -14,8 +14,8 @@ use std::sync::Arc;
 
 use praxis_core::config::Config;
 use praxis_test_utils::{
-    TestCertificates, free_port, https_get, start_backend, start_tls_proxy, start_tls_proxy_no_wait,
-    tls_connection_rejected, wait_for_https,
+    TestCertificates, free_port, https_get, start_backend_with_shutdown, start_tls_proxy,
+    start_tls_proxy_no_wait, tls_connection_rejected, wait_for_https,
 };
 
 // -----------------------------------------------------------------------------
@@ -31,7 +31,8 @@ fn rfc8446_tls_12_connection_accepted() {
     let certs = TestCertificates::generate();
     let client_config = build_tls12_client_config(&certs);
 
-    let backend_port = start_backend("tls12-ok");
+    let _backend = start_backend_with_shutdown("tls12-ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = tls_proxy_yaml(proxy_port, backend_port, &certs);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -52,7 +53,8 @@ fn rfc8446_tls_13_connection_accepted() {
     let certs = TestCertificates::generate();
     let client_config = build_tls13_client_config(&certs);
 
-    let backend_port = start_backend("tls13-ok");
+    let _backend = start_backend_with_shutdown("tls13-ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = tls_proxy_yaml(proxy_port, backend_port, &certs);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -71,7 +73,8 @@ fn rfc8446_tls_13_connection_accepted() {
 #[test]
 fn rfc8446_tls_10_connection_rejected() {
     let certs = TestCertificates::generate();
-    let backend_port = start_backend("should-not-reach");
+    let _backend = start_backend_with_shutdown("should-not-reach");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = tls_proxy_yaml(proxy_port, backend_port, &certs);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -87,7 +90,8 @@ fn rfc8446_tls_10_connection_rejected() {
 #[test]
 fn rfc8446_tls_11_connection_rejected() {
     let certs = TestCertificates::generate();
-    let backend_port = start_backend("should-not-reach");
+    let _backend = start_backend_with_shutdown("should-not-reach");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = tls_proxy_yaml(proxy_port, backend_port, &certs);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -105,7 +109,8 @@ fn rfc8446_tls_11_connection_rejected() {
 #[test]
 fn rfc8446_alpn_h2_accepted() {
     let certs = TestCertificates::generate();
-    let backend_port = start_backend("alpn-h2");
+    let _backend = start_backend_with_shutdown("alpn-h2");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = tls_proxy_yaml(proxy_port, backend_port, &certs);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -123,7 +128,8 @@ fn rfc8446_alpn_h2_accepted() {
 #[test]
 fn rfc8446_alpn_http11_tls_handshake_accepted() {
     let certs = TestCertificates::generate();
-    let backend_port = start_backend("alpn-h1");
+    let _backend = start_backend_with_shutdown("alpn-h1");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = tls_proxy_yaml(proxy_port, backend_port, &certs);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -149,7 +155,8 @@ fn rfc8446_invalid_client_cert_rejected_with_mtls() {
     let valid_client_cert = server_certs.generate_client_cert();
     let valid_client_config = server_certs.client_config_with_cert(&valid_client_cert);
 
-    let backend_port = start_backend("should-not-reach");
+    let _backend = start_backend_with_shutdown("should-not-reach");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = mtls_proxy_yaml(proxy_port, backend_port, &server_certs);
     let config = Config::from_yaml(&yaml).unwrap();

--- a/tests/conformance/tests/suite/tls.rs
+++ b/tests/conformance/tests/suite/tls.rs
@@ -14,8 +14,8 @@ use std::sync::Arc;
 
 use praxis_core::config::Config;
 use praxis_test_utils::{
-    TestCertificates, free_port, https_get, start_backend_with_shutdown, start_tls_proxy,
-    start_tls_proxy_no_wait, tls_connection_rejected, wait_for_https,
+    TestCertificates, free_port, https_get, start_backend_with_shutdown, start_tls_proxy, start_tls_proxy_no_wait,
+    tls_connection_rejected, wait_for_https,
 };
 
 // -----------------------------------------------------------------------------

--- a/tests/resilience/tests/suite/backend_failure.rs
+++ b/tests/resilience/tests/suite/backend_failure.rs
@@ -11,7 +11,7 @@ use std::{
 
 use praxis_core::config::Config;
 use praxis_test_utils::{
-    free_port, http_get, http_post, http_send, parse_status, simple_proxy_yaml, start_backend, start_proxy,
+    free_port, http_get, http_post, http_send, parse_status, simple_proxy_yaml, start_backend_with_shutdown, start_proxy,
     start_slow_backend,
 };
 
@@ -103,7 +103,8 @@ fn slow_backend_with_timeout_filter_returns_504() {
 
 #[test]
 fn fast_backend_with_timeout_filter_succeeds() {
-    let backend_port = start_backend("fast");
+    let _backend = start_backend_with_shutdown("fast");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = timeout_filter_yaml(proxy_port, backend_port, 5000);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -134,7 +135,8 @@ fn repeated_requests_to_dead_backend_all_return_502() {
 #[test]
 fn proxy_remains_healthy_after_backend_failures() {
     let dead_port = free_port();
-    let live_port = start_backend("alive");
+    let _live_backend = start_backend_with_shutdown("alive");
+    let live_port = _live_backend.port();
     let proxy_port = free_port();
 
     let yaml = format!(
@@ -241,7 +243,8 @@ fn client_disconnect_during_slow_response_does_not_crash_proxy() {
 
     std::thread::sleep(Duration::from_millis(200));
 
-    let live_port = start_backend("still-alive");
+    let _live_backend = start_backend_with_shutdown("still-alive");
+    let live_port = _live_backend.port();
     let proxy_port2 = free_port();
     let yaml2 = simple_proxy_yaml(proxy_port2, live_port);
     let config2 = Config::from_yaml(&yaml2).unwrap();

--- a/tests/resilience/tests/suite/backend_failure.rs
+++ b/tests/resilience/tests/suite/backend_failure.rs
@@ -11,8 +11,8 @@ use std::{
 
 use praxis_core::config::Config;
 use praxis_test_utils::{
-    free_port, http_get, http_post, http_send, parse_status, simple_proxy_yaml, start_backend_with_shutdown, start_proxy,
-    start_slow_backend,
+    free_port, http_get, http_post, http_send, parse_status, simple_proxy_yaml, start_backend_with_shutdown,
+    start_proxy, start_slow_backend,
 };
 
 // -----------------------------------------------------------------------------

--- a/tests/resilience/tests/suite/backend_recovery.rs
+++ b/tests/resilience/tests/suite/backend_recovery.rs
@@ -15,7 +15,7 @@ use std::{
 };
 
 use praxis_core::config::Config;
-use praxis_test_utils::{free_port, http_get, start_backend, start_proxy, wait_for_http};
+use praxis_test_utils::{free_port, http_get, start_backend_with_shutdown, start_proxy, wait_for_http};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -131,7 +131,8 @@ filter_chains:
 
 #[test]
 fn mixed_healthy_unhealthy_endpoints_serve_from_healthy() {
-    let live_port = start_backend("live-endpoint");
+    let _live_backend = start_backend_with_shutdown("live-endpoint");
+    let live_port = _live_backend.port();
     let dead_port = free_port();
     let proxy_port = free_port();
 

--- a/tests/resilience/tests/suite/concurrent_load.rs
+++ b/tests/resilience/tests/suite/concurrent_load.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use praxis_core::config::Config;
-use praxis_test_utils::{free_port, http_get, simple_proxy_yaml, start_backend, start_proxy};
+use praxis_test_utils::{free_port, http_get, simple_proxy_yaml, start_backend_with_shutdown, start_proxy};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -17,7 +17,8 @@ use praxis_test_utils::{free_port, http_get, simple_proxy_yaml, start_backend, s
 
 #[test]
 fn concurrent_requests_all_succeed() {
-    let backend_port = start_backend("concurrent-ok");
+    let _backend = start_backend_with_shutdown("concurrent-ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -78,7 +79,8 @@ fn concurrent_requests_to_dead_backend_all_return_502() {
 
 #[test]
 fn sequential_burst_all_succeed() {
-    let backend_port = start_backend("burst-ok");
+    let _backend = start_backend_with_shutdown("burst-ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -93,8 +95,10 @@ fn sequential_burst_all_succeed() {
 
 #[test]
 fn concurrent_requests_to_multiple_routes() {
-    let api_port = start_backend("api-response");
-    let web_port = start_backend("web-response");
+    let _api_backend = start_backend_with_shutdown("api-response");
+    let api_port = _api_backend.port();
+    let _web_backend = start_backend_with_shutdown("web-response");
+    let web_port = _web_backend.port();
     let proxy_port = free_port();
 
     let yaml = format!(
@@ -159,7 +163,8 @@ filter_chains:
 
 #[test]
 fn concurrent_requests_with_mixed_live_dead_backends() {
-    let live_port = start_backend("live");
+    let _live_backend = start_backend_with_shutdown("live");
+    let live_port = _live_backend.port();
     let dead_port = free_port();
     let proxy_port = free_port();
 

--- a/tests/resilience/tests/suite/large_payload.rs
+++ b/tests/resilience/tests/suite/large_payload.rs
@@ -132,7 +132,8 @@ fn empty_body_post_succeeds() {
 #[test]
 fn response_body_over_limit_handled() {
     let large_body = "r".repeat(2048);
-    let backend_port = praxis_test_utils::start_backend(&large_body);
+    let _backend = praxis_test_utils::start_backend_with_shutdown(&large_body);
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = response_limit_yaml(proxy_port, backend_port, 1024);
     let config = Config::from_yaml(&yaml).unwrap();

--- a/tests/resilience/tests/suite/multi_listener_isolation.rs
+++ b/tests/resilience/tests/suite/multi_listener_isolation.rs
@@ -6,7 +6,7 @@
 //! not affect traffic on another.
 
 use praxis_core::config::Config;
-use praxis_test_utils::{free_port, http_get, start_backend, start_proxy, wait_for_http, wait_for_tcp};
+use praxis_test_utils::{free_port, http_get, start_backend_with_shutdown, start_proxy, wait_for_http, wait_for_tcp};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -14,7 +14,8 @@ use praxis_test_utils::{free_port, http_get, start_backend, start_proxy, wait_fo
 
 #[test]
 fn dead_backend_on_one_listener_does_not_affect_other() {
-    let live_port = start_backend("listener-b-ok");
+    let _live_backend = start_backend_with_shutdown("listener-b-ok");
+    let live_port = _live_backend.port();
     let dead_port = free_port();
     let port_a = free_port();
     let port_b = free_port();
@@ -71,7 +72,8 @@ filter_chains:
 
 #[test]
 fn independent_pipelines_per_listener() {
-    let backend_port = start_backend("shared-backend");
+    let _backend = start_backend_with_shutdown("shared-backend");
+    let backend_port = _backend.port();
     let port_a = free_port();
     let port_b = free_port();
 
@@ -144,9 +146,12 @@ filter_chains:
 
 #[test]
 fn three_listeners_independent_routing() {
-    let api_port = start_backend("api-data");
-    let web_port = start_backend("web-page");
-    let internal_port = start_backend("internal-service");
+    let _api_backend = start_backend_with_shutdown("api-data");
+    let api_port = _api_backend.port();
+    let _web_backend = start_backend_with_shutdown("web-page");
+    let web_port = _web_backend.port();
+    let _internal_backend = start_backend_with_shutdown("internal-service");
+    let internal_port = _internal_backend.port();
     let listen_a = free_port();
     let listen_b = free_port();
     let listen_c = free_port();
@@ -223,7 +228,8 @@ filter_chains:
 
 #[test]
 fn listener_with_dead_backend_does_not_stall_other_listeners() {
-    let live_port = start_backend("fast-response");
+    let _live_backend = start_backend_with_shutdown("fast-response");
+    let live_port = _live_backend.port();
     let dead_port = free_port();
     let port_fast = free_port();
     let port_dead = free_port();

--- a/tests/resilience/tests/suite/rate_limit_burst.rs
+++ b/tests/resilience/tests/suite/rate_limit_burst.rs
@@ -4,7 +4,9 @@
 //! Tests for rate limiter behavior under burst conditions.
 
 use praxis_core::config::Config;
-use praxis_test_utils::{free_port, http_get, http_send, parse_header, parse_status, start_backend_with_shutdown, start_proxy};
+use praxis_test_utils::{
+    free_port, http_get, http_send, parse_header, parse_status, start_backend_with_shutdown, start_proxy,
+};
 
 // -----------------------------------------------------------------------------
 // Tests

--- a/tests/resilience/tests/suite/rate_limit_burst.rs
+++ b/tests/resilience/tests/suite/rate_limit_burst.rs
@@ -4,7 +4,7 @@
 //! Tests for rate limiter behavior under burst conditions.
 
 use praxis_core::config::Config;
-use praxis_test_utils::{free_port, http_get, http_send, parse_header, parse_status, start_backend, start_proxy};
+use praxis_test_utils::{free_port, http_get, http_send, parse_header, parse_status, start_backend_with_shutdown, start_proxy};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -12,7 +12,8 @@ use praxis_test_utils::{free_port, http_get, http_send, parse_header, parse_stat
 
 #[test]
 fn burst_exhaustion_then_rejection() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let usable = 4u32;
     let burst = usable + 2;
@@ -46,7 +47,8 @@ fn burst_exhaustion_then_rejection() {
 
 #[test]
 fn rejection_includes_retry_after_header() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = rate_limit_yaml(proxy_port, backend_port, "global", 1.0, 2);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -73,7 +75,8 @@ fn rejection_includes_retry_after_header() {
 
 #[test]
 fn rate_limit_headers_present_on_success() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = rate_limit_yaml(proxy_port, backend_port, "global", 100.0, 200);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -101,7 +104,8 @@ fn rate_limit_headers_present_on_success() {
 
 #[test]
 fn rate_limit_remaining_decreases() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = rate_limit_yaml(proxy_port, backend_port, "global", 0.1, 10);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -133,7 +137,8 @@ fn rate_limit_remaining_decreases() {
 
 #[test]
 fn rate_limit_headers_present_on_rejection() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = rate_limit_yaml(proxy_port, backend_port, "global", 0.1, 2);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -165,7 +170,8 @@ fn rate_limit_headers_present_on_rejection() {
 
 #[test]
 fn per_ip_burst_exhaustion() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = rate_limit_yaml(proxy_port, backend_port, "per_ip", 0.1, 5);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -189,7 +195,8 @@ fn per_ip_burst_exhaustion() {
 
 #[test]
 fn rapid_burst_uses_all_tokens() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let burst: u32 = 8;
     let yaml = rate_limit_yaml(proxy_port, backend_port, "global", 0.1, burst);

--- a/tests/resilience/tests/suite/throughput_filter_chain.rs
+++ b/tests/resilience/tests/suite/throughput_filter_chain.rs
@@ -4,7 +4,7 @@
 //! Filter chain depth benchmarks.
 
 use praxis_core::config::Config;
-use praxis_test_utils::{free_port, start_backend, start_proxy};
+use praxis_test_utils::{free_port, start_backend_with_shutdown, start_proxy};
 
 use crate::throughput_utils::{BenchConfig, assert_performance, report_results, run_get_benchmark};
 
@@ -14,7 +14,8 @@ use crate::throughput_utils::{BenchConfig, assert_performance, report_results, r
 
 #[test]
 fn bench_pipeline_4_filters() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = multi_filter_yaml(proxy_port, backend_port, 1);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -28,7 +29,8 @@ fn bench_pipeline_4_filters() {
 
 #[test]
 fn bench_pipeline_8_filters() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = multi_filter_yaml(proxy_port, backend_port, 5);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -42,7 +44,8 @@ fn bench_pipeline_8_filters() {
 
 #[test]
 fn bench_pipeline_15_filters() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = multi_filter_yaml(proxy_port, backend_port, 12);
     let config = Config::from_yaml(&yaml).unwrap();

--- a/tests/resilience/tests/suite/throughput_simple.rs
+++ b/tests/resilience/tests/suite/throughput_simple.rs
@@ -4,7 +4,7 @@
 //! Simple proxy throughput benchmarks.
 
 use praxis_core::config::Config;
-use praxis_test_utils::{free_port, start_backend, start_proxy};
+use praxis_test_utils::{free_port, start_backend_with_shutdown, start_proxy};
 
 use crate::throughput_utils::{BenchConfig, assert_performance, report_results, run_get_benchmark};
 
@@ -14,7 +14,8 @@ use crate::throughput_utils::{BenchConfig, assert_performance, report_results, r
 
 #[test]
 fn bench_simple_proxy_serial() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = praxis_test_utils::simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -29,7 +30,8 @@ fn bench_simple_proxy_serial() {
 
 #[test]
 fn bench_simple_proxy_concurrent() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = praxis_test_utils::simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();
@@ -44,7 +46,8 @@ fn bench_simple_proxy_concurrent() {
 
 #[test]
 fn bench_simple_proxy_high_concurrency() {
-    let backend_port = start_backend("ok");
+    let _backend = start_backend_with_shutdown("ok");
+    let backend_port = _backend.port();
     let proxy_port = free_port();
     let yaml = praxis_test_utils::simple_proxy_yaml(proxy_port, backend_port);
     let config = Config::from_yaml(&yaml).unwrap();

--- a/tests/security/tests/suite/filter_leakage.rs
+++ b/tests/security/tests/suite/filter_leakage.rs
@@ -4,7 +4,7 @@
 //! Filter header leakage security tests.
 
 use praxis_core::config::Config;
-use praxis_test_utils::{free_port, http_send, parse_header, start_backend, start_proxy};
+use praxis_test_utils::{free_port, http_send, parse_header, start_backend_with_shutdown, start_proxy};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -12,9 +12,9 @@ use praxis_test_utils::{free_port, http_send, parse_header, start_backend, start
 
 #[test]
 fn forwarded_headers_not_leaked_to_client() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = fwd_only_yaml(proxy_port, backend_port);
+    let yaml = fwd_only_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -41,9 +41,9 @@ fn forwarded_headers_not_leaked_to_client() {
 
 #[test]
 fn headers_request_add_not_leaked_to_client() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = headers_request_add_yaml(proxy_port, backend_port);
+    let yaml = headers_request_add_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -62,9 +62,9 @@ fn headers_request_add_not_leaked_to_client() {
 
 #[test]
 fn request_id_not_leaked_to_client() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = request_id_yaml(proxy_port, backend_port);
+    let yaml = request_id_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -83,9 +83,9 @@ fn request_id_not_leaked_to_client() {
 
 #[test]
 fn combined_request_headers_not_leaked_to_client() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = combined_yaml(proxy_port, backend_port);
+    let yaml = combined_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 

--- a/tests/security/tests/suite/host_header.rs
+++ b/tests/security/tests/suite/host_header.rs
@@ -5,7 +5,7 @@
 
 use praxis_core::config::Config;
 use praxis_test_utils::{
-    free_port, http_send, parse_body, parse_status, simple_proxy_yaml, start_backend, start_proxy,
+    free_port, http_send, parse_body, parse_status, simple_proxy_yaml, start_backend_with_shutdown, start_proxy,
 };
 
 // -----------------------------------------------------------------------------
@@ -14,9 +14,9 @@ use praxis_test_utils::{
 
 #[test]
 fn duplicate_host_headers_do_not_crash() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = simple_proxy_yaml(proxy_port, backend_port);
+    let yaml = simple_proxy_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -37,9 +37,9 @@ fn duplicate_host_headers_do_not_crash() {
 
 #[test]
 fn conflicting_host_headers_rejected_or_safe() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = simple_proxy_yaml(proxy_port, backend_port);
+    let yaml = simple_proxy_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -57,9 +57,9 @@ fn conflicting_host_headers_rejected_or_safe() {
 
 #[test]
 fn host_port_mismatch_handled_gracefully() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = simple_proxy_yaml(proxy_port, backend_port);
+    let yaml = simple_proxy_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -77,9 +77,9 @@ fn host_port_mismatch_handled_gracefully() {
 
 #[test]
 fn empty_host_header_handled_gracefully() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = simple_proxy_yaml(proxy_port, backend_port);
+    let yaml = simple_proxy_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -97,9 +97,9 @@ fn empty_host_header_handled_gracefully() {
 
 #[test]
 fn host_with_special_characters_handled() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = simple_proxy_yaml(proxy_port, backend_port);
+    let yaml = simple_proxy_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -116,10 +116,12 @@ fn host_with_special_characters_handled() {
 
 #[test]
 fn conflicting_hosts_do_not_route_to_attacker_backend() {
-    let victim_port = start_backend("victim-response");
-    let attacker_port = start_backend("attacker-response");
+    let victim = start_backend_with_shutdown("victim-response");
+    let attacker = start_backend_with_shutdown("attacker-response");
     let proxy_port = free_port();
 
+    let victim_port = victim.port();
+    let attacker_port = attacker.port();
     let yaml = format!(
         r#"
 listeners:

--- a/tests/security/tests/suite/info_leakage.rs
+++ b/tests/security/tests/suite/info_leakage.rs
@@ -4,7 +4,9 @@
 //! Information leakage adversarial tests.
 
 use praxis_core::config::Config;
-use praxis_test_utils::{free_port, http_send, parse_body, parse_header, parse_status, start_backend_with_shutdown, start_proxy};
+use praxis_test_utils::{
+    free_port, http_send, parse_body, parse_header, parse_status, start_backend_with_shutdown, start_proxy,
+};
 
 // -----------------------------------------------------------------------------
 // Tests

--- a/tests/security/tests/suite/info_leakage.rs
+++ b/tests/security/tests/suite/info_leakage.rs
@@ -4,7 +4,7 @@
 //! Information leakage adversarial tests.
 
 use praxis_core::config::Config;
-use praxis_test_utils::{free_port, http_send, parse_body, parse_header, parse_status, start_backend, start_proxy};
+use praxis_test_utils::{free_port, http_send, parse_body, parse_header, parse_status, start_backend_with_shutdown, start_proxy};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -12,9 +12,9 @@ use praxis_test_utils::{free_port, http_send, parse_body, parse_header, parse_st
 
 #[test]
 fn error_responses_have_no_stack_traces() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = deny_all_yaml(proxy_port, backend_port);
+    let yaml = deny_all_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -48,9 +48,9 @@ fn error_responses_have_no_stack_traces() {
 
 #[test]
 fn backend_server_header_not_leaked_in_rejection() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = deny_all_yaml(proxy_port, backend_port);
+    let yaml = deny_all_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -117,9 +117,9 @@ filter_chains:
 
 #[test]
 fn rejection_responses_include_connection_close() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = deny_all_yaml(proxy_port, backend_port);
+    let yaml = deny_all_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 

--- a/tests/security/tests/suite/ip_acl.rs
+++ b/tests/security/tests/suite/ip_acl.rs
@@ -5,8 +5,8 @@
 
 use praxis_core::config::Config;
 use praxis_test_utils::{
-    free_port, http_get, http_send, parse_body, parse_header, parse_status, start_backend, start_header_echo_backend,
-    start_proxy,
+    free_port, http_get, http_send, parse_body, parse_header, parse_status, start_backend_with_shutdown,
+    start_header_echo_backend_with_shutdown, start_proxy,
 };
 
 // -----------------------------------------------------------------------------
@@ -15,9 +15,9 @@ use praxis_test_utils::{
 
 #[test]
 fn deny_all_blocks_loopback() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = acl_yaml(proxy_port, backend_port, &[], &["0.0.0.0/0"]);
+    let yaml = acl_yaml(proxy_port, backend.port(), &[], &["0.0.0.0/0"]);
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -27,9 +27,9 @@ fn deny_all_blocks_loopback() {
 
 #[test]
 fn allow_loopback_with_deny_all() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = acl_yaml(proxy_port, backend_port, &["127.0.0.0/8"], &["0.0.0.0/0"]);
+    let yaml = acl_yaml(proxy_port, backend.port(), &["127.0.0.0/8"], &["0.0.0.0/0"]);
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -39,9 +39,9 @@ fn allow_loopback_with_deny_all() {
 
 #[test]
 fn deny_loopback_blocks_request() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = acl_yaml(proxy_port, backend_port, &[], &["127.0.0.0/8"]);
+    let yaml = acl_yaml(proxy_port, backend.port(), &[], &["127.0.0.0/8"]);
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -51,9 +51,9 @@ fn deny_loopback_blocks_request() {
 
 #[test]
 fn empty_acl_allows_all() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = acl_yaml(proxy_port, backend_port, &[], &[]);
+    let yaml = acl_yaml(proxy_port, backend.port(), &[], &[]);
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -63,9 +63,9 @@ fn empty_acl_allows_all() {
 
 #[test]
 fn allow_list_only_rejects_non_matching() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = acl_yaml(proxy_port, backend_port, &["10.0.0.0/8"], &[]);
+    let yaml = acl_yaml(proxy_port, backend.port(), &["10.0.0.0/8"], &[]);
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -75,9 +75,9 @@ fn allow_list_only_rejects_non_matching() {
 
 #[test]
 fn acl_rejection_has_no_body_leakage() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = acl_yaml(proxy_port, backend_port, &[], &["0.0.0.0/0"]);
+    let yaml = acl_yaml(proxy_port, backend.port(), &[], &["0.0.0.0/0"]);
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -100,9 +100,9 @@ fn acl_rejection_has_no_body_leakage() {
 
 #[test]
 fn acl_applies_to_all_methods() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = acl_yaml(proxy_port, backend_port, &[], &["0.0.0.0/0"]);
+    let yaml = acl_yaml(proxy_port, backend.port(), &[], &["0.0.0.0/0"]);
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -119,9 +119,9 @@ fn acl_applies_to_all_methods() {
 
 #[test]
 fn acl_before_router_means_no_routing_on_denied() {
-    let backend_port = start_header_echo_backend();
+    let backend = start_header_echo_backend_with_shutdown();
     let proxy_port = free_port();
-    let yaml = acl_yaml(proxy_port, backend_port, &[], &["0.0.0.0/0"]);
+    let yaml = acl_yaml(proxy_port, backend.port(), &[], &["0.0.0.0/0"]);
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 

--- a/tests/security/tests/suite/request_smuggling.rs
+++ b/tests/security/tests/suite/request_smuggling.rs
@@ -5,7 +5,7 @@
 
 use praxis_core::config::Config;
 use praxis_test_utils::{
-    free_port, http_send, parse_body, parse_status, simple_proxy_yaml, start_backend, start_proxy,
+    free_port, http_send, parse_body, parse_status, simple_proxy_yaml, start_backend_with_shutdown, start_proxy,
 };
 
 // -----------------------------------------------------------------------------
@@ -14,9 +14,9 @@ use praxis_test_utils::{
 
 #[test]
 fn conflicting_host_headers_rejected() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = simple_proxy_yaml(proxy_port, backend_port);
+    let yaml = simple_proxy_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -37,9 +37,9 @@ fn conflicting_host_headers_rejected() {
 
 #[test]
 fn duplicate_identical_host_headers_accepted() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = simple_proxy_yaml(proxy_port, backend_port);
+    let yaml = simple_proxy_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -66,9 +66,9 @@ fn duplicate_identical_host_headers_accepted() {
 /// [RFC 9112 Section 3.2]: https://datatracker.ietf.org/doc/html/rfc9112#section-3.2
 #[test]
 fn missing_host_header_http11_rejected() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = simple_proxy_yaml(proxy_port, backend_port);
+    let yaml = simple_proxy_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -87,9 +87,9 @@ fn missing_host_header_http11_rejected() {
 
 #[test]
 fn host_with_port_vs_without_port_considered_different() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = simple_proxy_yaml(proxy_port, backend_port);
+    let yaml = simple_proxy_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -114,9 +114,9 @@ fn host_with_port_vs_without_port_considered_different() {
 
 #[test]
 fn cl_te_desync_does_not_poison_connection() {
-    let backend_port = start_backend("clean");
+    let backend = start_backend_with_shutdown("clean");
     let proxy_port = free_port();
-    let yaml = simple_proxy_yaml(proxy_port, backend_port);
+    let yaml = simple_proxy_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -176,9 +176,9 @@ fn cl_te_desync_does_not_poison_connection() {
 /// [RFC 9112]: https://datatracker.ietf.org/doc/html/rfc9112
 #[test]
 fn te_chunked_case_insensitive() {
-    let backend_port = start_backend("chunked-ok");
+    let backend = start_backend_with_shutdown("chunked-ok");
     let proxy_port = free_port();
-    let yaml = simple_proxy_yaml(proxy_port, backend_port);
+    let yaml = simple_proxy_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -204,9 +204,9 @@ fn te_chunked_case_insensitive() {
 
 #[test]
 fn te_with_whitespace_padding() {
-    let backend_port = start_backend("ws-ok");
+    let backend = start_backend_with_shutdown("ws-ok");
     let proxy_port = free_port();
-    let yaml = simple_proxy_yaml(proxy_port, backend_port);
+    let yaml = simple_proxy_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -236,9 +236,9 @@ fn te_with_whitespace_padding() {
 
 #[test]
 fn cl_with_leading_zeros() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = simple_proxy_yaml(proxy_port, backend_port);
+    let yaml = simple_proxy_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -265,9 +265,9 @@ fn cl_with_leading_zeros() {
 /// [RFC 9110 Section 8.6]: https://datatracker.ietf.org/doc/html/rfc9110#section-8.6
 #[test]
 fn negative_content_length_rejected() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = simple_proxy_yaml(proxy_port, backend_port);
+    let yaml = simple_proxy_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -289,9 +289,9 @@ fn negative_content_length_rejected() {
 
 #[test]
 fn content_length_overflow_rejected() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = simple_proxy_yaml(proxy_port, backend_port);
+    let yaml = simple_proxy_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -317,9 +317,9 @@ fn content_length_overflow_rejected() {
 /// [RFC 9112]: https://datatracker.ietf.org/doc/html/rfc9112
 #[test]
 fn empty_transfer_encoding_rejected() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
-    let yaml = simple_proxy_yaml(proxy_port, backend_port);
+    let yaml = simple_proxy_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 

--- a/tests/smoke/tests/suite/smoke.rs
+++ b/tests/smoke/tests/suite/smoke.rs
@@ -10,7 +10,9 @@ use std::{
 };
 
 use praxis_core::config::Config;
-use praxis_test_utils::{free_port, http_get, simple_proxy_yaml, start_backend_with_shutdown, start_proxy, wait_for_tcp};
+use praxis_test_utils::{
+    free_port, http_get, simple_proxy_yaml, start_backend_with_shutdown, start_proxy, wait_for_tcp,
+};
 
 // -----------------------------------------------------------------------------
 // Tests

--- a/tests/smoke/tests/suite/smoke.rs
+++ b/tests/smoke/tests/suite/smoke.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use praxis_core::config::Config;
-use praxis_test_utils::{free_port, http_get, simple_proxy_yaml, start_backend, start_proxy, wait_for_tcp};
+use praxis_test_utils::{free_port, http_get, simple_proxy_yaml, start_backend_with_shutdown, start_proxy, wait_for_tcp};
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -18,9 +18,9 @@ use praxis_test_utils::{free_port, http_get, simple_proxy_yaml, start_backend, s
 
 #[test]
 fn server_starts_and_serves_request() {
-    let backend_port = start_backend("smoke");
+    let backend = start_backend_with_shutdown("smoke");
     let proxy_port = free_port();
-    let yaml = simple_proxy_yaml(proxy_port, backend_port);
+    let yaml = simple_proxy_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 
@@ -31,10 +31,11 @@ fn server_starts_and_serves_request() {
 
 #[test]
 fn health_endpoints_return_200() {
-    let backend_port = start_backend("ok");
+    let backend = start_backend_with_shutdown("ok");
     let proxy_port = free_port();
     let admin_port = free_port();
 
+    let backend_port = backend.port();
     let yaml = format!(
         r#"
 admin:
@@ -72,9 +73,9 @@ filter_chains:
 
 #[test]
 fn http_round_trip_preserves_body() {
-    let backend_port = start_backend("hello from backend");
+    let backend = start_backend_with_shutdown("hello from backend");
     let proxy_port = free_port();
-    let yaml = simple_proxy_yaml(proxy_port, backend_port);
+    let yaml = simple_proxy_yaml(proxy_port, backend.port());
     let config = Config::from_yaml(&yaml).unwrap();
     let proxy = start_proxy(&config);
 

--- a/tests/utils/src/net/backend/mod.rs
+++ b/tests/utils/src/net/backend/mod.rs
@@ -11,5 +11,5 @@ pub use echo::{
     start_echo_backend, start_echo_backend_with_shutdown, start_header_echo_backend,
     start_header_echo_backend_with_shutdown, start_uri_echo_backend, start_uri_echo_backend_with_shutdown,
 };
-pub use simple::{Backend, RoutedBackend, start_backend, start_backend_v6, start_backend_with_shutdown};
+pub use simple::{Backend, RoutedBackend, start_backend_v6, start_backend_with_shutdown};
 pub use specialized::{BackendGuard, start_hop_by_hop_response_backend, start_slow_backend};

--- a/tests/utils/src/net/backend/simple.rs
+++ b/tests/utils/src/net/backend/simple.rs
@@ -236,11 +236,6 @@ fn handle_v6_connection(mut stream: TcpStream, body: &str) {
     let _sent = stream.write_all(response.as_bytes());
 }
 
-/// Start a mock HTTP backend returning a fixed body.
-pub fn start_backend(body: &str) -> u16 {
-    Backend::fixed(body).start()
-}
-
 /// Start a mock HTTP backend returning a fixed body,
 /// with a [`BackendGuard`] that shuts down the listener
 /// thread when dropped.

--- a/tests/utils/src/net/mod.rs
+++ b/tests/utils/src/net/mod.rs
@@ -11,10 +11,10 @@ pub mod tls;
 pub mod wait;
 
 pub use backend::{
-    Backend, BackendGuard, RoutedBackend, start_backend_v6, start_backend_with_shutdown,
-    start_echo_backend, start_echo_backend_with_shutdown, start_header_echo_backend,
-    start_header_echo_backend_with_shutdown, start_hop_by_hop_response_backend, start_slow_backend,
-    start_uri_echo_backend, start_uri_echo_backend_with_shutdown,
+    Backend, BackendGuard, RoutedBackend, start_backend_v6, start_backend_with_shutdown, start_echo_backend,
+    start_echo_backend_with_shutdown, start_header_echo_backend, start_header_echo_backend_with_shutdown,
+    start_hop_by_hop_response_backend, start_slow_backend, start_uri_echo_backend,
+    start_uri_echo_backend_with_shutdown,
 };
 pub use http_client::{
     http_get, http_get_retry, http_get_v6, http_post, http_send, json_post, parse_body, parse_header, parse_header_all,

--- a/tests/utils/src/net/mod.rs
+++ b/tests/utils/src/net/mod.rs
@@ -11,7 +11,7 @@ pub mod tls;
 pub mod wait;
 
 pub use backend::{
-    Backend, BackendGuard, RoutedBackend, start_backend, start_backend_v6, start_backend_with_shutdown,
+    Backend, BackendGuard, RoutedBackend, start_backend_v6, start_backend_with_shutdown,
     start_echo_backend, start_echo_backend_with_shutdown, start_header_echo_backend,
     start_header_echo_backend_with_shutdown, start_hop_by_hop_response_backend, start_slow_backend,
     start_uri_echo_backend, start_uri_echo_backend_with_shutdown,


### PR DESCRIPTION
This PR completes the work that CoPilot requested at https://github.com/praxis-proxy/praxis/pull/64#discussion_r3126252364

The rationale is that new tests will follow the example of old tests -- thus we don't want any tests that leak resources.

I expected this code to run perfectly on the Mac.  It did earlier in the week.  Today three throughput tests fail

- throughput_filter_chain::bench_pipeline_4_filters
  - `throughput 390 req/s below minimum 500 req/s`
- throughput_simple::bench_simple_proxy_concurrent
  - `throughput 392 req/s below minimum 500 req/s`
- throughput_tcp::bench_tcp_proxy_concurrent
  - `throughput 412 req/s below minimum 500 req/s`

These are not regressions caused by this PR.  Probably the problem is related to other things running today on my Mac.

@shaneutt We may wish to make the throughput threshold configurable in a follow-up.

Regarding the size, this code is mostly the same refactor.  I also ran `cargo +nightly fmt --all`.
