### PR TITLE
fix(makefile): add missing xtask lint-deps to lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,7 @@ fuzz-build:
 lint:
 	cargo clippy --workspace --all-targets -- -D warnings
 	cargo +nightly fmt --all -- --check
+	cargo xtask lint-deps
 
 fmt:
 	cargo +nightly fmt --all


### PR DESCRIPTION
## Summary

The `make lint` target was documented in CLAUDE.md as running `clippy + nightly fmt check + xtask lint-deps`, but the actual Makefile only ran clippy and fmt. This adds the missing `cargo xtask lint-deps` step so the target matches its documentation.