### PR TITLE
fix: make PRAXIS_LOG_FORMAT comparison case-insensitive

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -83,7 +83,7 @@ pub(crate) fn init_tracing(default_level: &str) {
     let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(default_level));
 
-    let json = std::env::var("PRAXIS_LOG_FORMAT").is_ok_and(|v| v == "json");
+    let json = std::env::var("PRAXIS_LOG_FORMAT").is_ok_and(|v| v.eq_ignore_ascii_case("json"));
 
     if json {
         tracing_subscriber::fmt().json().with_env_filter(env_filter).init();


### PR DESCRIPTION
## Summary

- Makes the `PRAXIS_LOG_FORMAT` environment variable comparison case-insensitive by using `eq_ignore_ascii_case("json")` instead of `== "json"` in `xtask/src/main.rs`.
- Previously, only the exact lowercase `json` value was recognized; now `JSON`, `Json`, etc. all work as expected.

## Test plan

- [x] `make fmt` passes
- [x] `make lint` passes
- [x] `cargo check -p xtask` passes