### PR TITLE
fix(router): enforce segment-boundary path prefix matching

### DIFF
--- a/core/src/config/condition/request.rs
+++ b/core/src/config/condition/request.rs
@@ -67,7 +67,8 @@ pub struct ConditionMatch {
     #[serde(default)]
     pub path: Option<String>,
 
-    /// Request URI must start with this prefix.
+    /// Request URI must match this prefix at a segment boundary.
+    /// `/api` matches `/api`, `/api/`, `/api/v1` but NOT `/apikeys`.
     #[serde(default)]
     pub path_prefix: Option<String>,
 

--- a/core/src/config/route.rs
+++ b/core/src/config/route.rs
@@ -39,7 +39,8 @@ pub enum PathMatch {
         path: String,
     },
 
-    /// Prefix-based path match.
+    /// Segment-boundary prefix match (Gateway API semantics).
+    /// `/api` matches `/api`, `/api/`, `/api/v1` but NOT `/apikeys`.
     Prefix {
         /// Path prefix. The longest matching prefix wins.
         path_prefix: String,

--- a/filter/src/builtins/http/traffic_management/router/matching.rs
+++ b/filter/src/builtins/http/traffic_management/router/matching.rs
@@ -75,7 +75,10 @@ pub(super) fn update_best_match<'a>(
 
 /// Return `true` if shorter prefixes cannot improve on the current best.
 pub(super) fn should_stop_early(best: Option<(Specificity, &Route)>, route: &Route) -> bool {
-    let route_len = route.path_match.len();
+    let route_len = match &route.path_match {
+        PathMatch::Exact { path } => path.len(),
+        PathMatch::Prefix { path_prefix } => crate::path_match::path_prefix_specificity(path_prefix),
+    };
     best.is_some_and(|((_, bp, _), _)| route_len < bp)
 }
 

--- a/filter/src/builtins/http/traffic_management/router/matching.rs
+++ b/filter/src/builtins/http/traffic_management/router/matching.rs
@@ -30,7 +30,7 @@ pub(super) fn route_matches_request(
             }
         },
         PathMatch::Prefix { path_prefix } => {
-            if !path.starts_with(path_prefix.as_str()) {
+            if !crate::path_match::path_prefix_matches(path, path_prefix) {
                 return false;
             }
         },
@@ -52,7 +52,10 @@ pub(super) type Specificity = (bool, usize, usize);
 /// Computes the specificity of a route for comparison.
 fn route_specificity(route: &Route) -> Specificity {
     let is_exact = route.path_match.is_exact();
-    let path_len = route.path_match.len();
+    let path_len = match &route.path_match {
+        PathMatch::Exact { path } => path.len(),
+        PathMatch::Prefix { path_prefix } => crate::path_match::path_prefix_specificity(path_prefix),
+    };
     let constraints = usize::from(route.host.is_some()) + route.headers.as_ref().map_or(0, HashMap::len);
     (is_exact, path_len, constraints)
 }

--- a/filter/src/builtins/http/traffic_management/router/mod.rs
+++ b/filter/src/builtins/http/traffic_management/router/mod.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use http::{HeaderMap, header::HeaderName};
-use praxis_core::config::{PathMatch, Route};
+use praxis_core::config::Route;
 use tracing::{debug, trace};
 
 use self::{
@@ -116,8 +116,9 @@ struct ResolvedRoute {
 impl RouterFilter {
     /// Create a router from a list of routes with default alias options.
     ///
-    /// Returns an error if any `path_prefix` (other than `"/"`)
-    /// does not end with `'/'`.
+    /// Path prefix matching uses segment-boundary semantics per Gateway API:
+    /// `/api` matches `/api`, `/api/`, `/api/v1` but NOT `/apikeys`.
+    /// Trailing slashes on prefixes are ignored (`/api` ≡ `/api/`).
     ///
     /// ```
     /// use praxis_core::config::{PathMatch, Route};
@@ -134,7 +135,7 @@ impl RouterFilter {
     ///     },
     ///     Route {
     ///         path_match: PathMatch::Prefix {
-    ///             path_prefix: "/api/".to_owned(),
+    ///             path_prefix: "/api".to_owned(),
     ///         },
     ///         host: None,
     ///         headers: None,
@@ -144,24 +145,9 @@ impl RouterFilter {
     /// .unwrap();
     /// ```
     ///
-    /// ```
-    /// use praxis_core::config::{PathMatch, Route};
-    /// use praxis_filter::RouterFilter;
-    ///
-    /// let err = RouterFilter::new(vec![Route {
-    ///     path_match: PathMatch::Prefix {
-    ///         path_prefix: "/api".to_owned(),
-    ///     },
-    ///     host: None,
-    ///     headers: None,
-    ///     cluster: "api".into(),
-    /// }])
-    /// .unwrap_err();
-    /// assert!(err.to_string().contains("must end with '/'"));
-    /// ```
     /// # Errors
     ///
-    /// Returns [`FilterError`] if any route prefix does not end with `/`.
+    /// Returns [`FilterError`] if alias configuration is invalid.
     ///
     /// [`FilterError`]: crate::FilterError
     pub fn new(routes: Vec<Route>) -> Result<Self, FilterError> {
@@ -184,7 +170,6 @@ impl RouterFilter {
     ) -> Result<Self, FilterError> {
         let mut routes = routes;
         sort_routes(&mut routes);
-        validate_prefixes(&routes)?;
         validate_json_aliases(&routes)?;
         let json_alias_header = parse_json_alias_header(json_alias_header)?;
         validate_alias_options(&routes, json_alias_max_body_bytes)?;
@@ -262,25 +247,6 @@ fn sort_routes(routes: &mut [RouterRouteConfig]) {
             b_exact.cmp(&a_exact)
         })
     });
-}
-
-/// Validates that prefix-only routes have segment-bounded prefixes.
-fn validate_prefixes(routes: &[RouterRouteConfig]) -> Result<(), FilterError> {
-    for route_config in routes {
-        let route = &route_config.route;
-        if let PathMatch::Prefix { path_prefix } = &route.path_match
-            && path_prefix != "/"
-            && !path_prefix.ends_with('/')
-        {
-            return Err(format!(
-                "router: path_prefix '{path_prefix}' for cluster '{}' must end with '/' \
-                 to ensure segment-bounded matching",
-                route.cluster,
-            )
-            .into());
-        }
-    }
-    Ok(())
 }
 
 /// Validates JSON alias configuration on all routes.

--- a/filter/src/builtins/http/traffic_management/router/mod.rs
+++ b/filter/src/builtins/http/traffic_management/router/mod.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use http::{HeaderMap, header::HeaderName};
-use praxis_core::config::Route;
+use praxis_core::config::{PathMatch, Route};
 use tracing::{debug, trace};
 
 use self::{
@@ -118,7 +118,7 @@ impl RouterFilter {
     ///
     /// Path prefix matching uses segment-boundary semantics per Gateway API:
     /// `/api` matches `/api`, `/api/`, `/api/v1` but NOT `/apikeys`.
-    /// Trailing slashes on prefixes are ignored (`/api` ≡ `/api/`).
+    /// Trailing slashes on prefixes are ignored (`/api` is equivalent to `/api/`).
     ///
     /// ```
     /// use praxis_core::config::{PathMatch, Route};
@@ -241,7 +241,15 @@ impl RouterFilter {
 /// Sorts routes by specificity: exact paths first, then longest prefix.
 fn sort_routes(routes: &mut [RouterRouteConfig]) {
     routes.sort_by(|a, b| {
-        b.route.path_match.len().cmp(&a.route.path_match.len()).then_with(|| {
+        let a_len = match &a.route.path_match {
+            PathMatch::Exact { path } => path.len(),
+            PathMatch::Prefix { path_prefix } => crate::path_match::path_prefix_specificity(path_prefix),
+        };
+        let b_len = match &b.route.path_match {
+            PathMatch::Exact { path } => path.len(),
+            PathMatch::Prefix { path_prefix } => crate::path_match::path_prefix_specificity(path_prefix),
+        };
+        b_len.cmp(&a_len).then_with(|| {
             let a_exact = u8::from(a.route.path_match.is_exact());
             let b_exact = u8::from(b.route.path_match.is_exact());
             b_exact.cmp(&a_exact)

--- a/filter/src/builtins/http/traffic_management/router/tests.rs
+++ b/filter/src/builtins/http/traffic_management/router/tests.rs
@@ -724,7 +724,7 @@ fn should_stop_early_false_when_no_best() {
 fn prefix_without_trailing_slash_accepted() {
     let router = make_router(vec![prefix_route("/api", "api"), prefix_route("/", "default")]);
     let route = router.match_route("/api/v1", None, &HeaderMap::new()).unwrap();
-    assert_eq!(&*route.cluster, "api");
+    assert_eq!(&*route.cluster, "api", "/api/v1 should match /api prefix without trailing slash");
 }
 
 #[test]

--- a/filter/src/builtins/http/traffic_management/router/tests.rs
+++ b/filter/src/builtins/http/traffic_management/router/tests.rs
@@ -721,20 +721,46 @@ fn should_stop_early_false_when_no_best() {
 }
 
 #[test]
-fn non_segment_boundary_prefix_rejected() {
-    let err = RouterFilter::new(vec![Route {
-        path_match: PathMatch::Prefix {
-            path_prefix: "/api".to_owned(),
-        },
-        host: None,
-        headers: None,
-        cluster: "api".into(),
-    }])
-    .unwrap_err();
-    assert!(
-        err.to_string().contains("must end with '/'"),
-        "path_prefix without trailing slash should be rejected: {err}"
-    );
+fn prefix_without_trailing_slash_accepted() {
+    let router = make_router(vec![prefix_route("/api", "api"), prefix_route("/", "default")]);
+    let route = router.match_route("/api/v1", None, &HeaderMap::new()).unwrap();
+    assert_eq!(&*route.cluster, "api");
+}
+
+#[test]
+fn segment_boundary_rejects_non_segment_continuation() {
+    let router = make_router(vec![prefix_route("/api", "api"), prefix_route("/", "default")]);
+    let route = router.match_route("/apikeys", None, &HeaderMap::new()).unwrap();
+    assert_eq!(&*route.cluster, "default", "/apikeys must NOT match /api prefix");
+}
+
+#[test]
+fn segment_boundary_exact_path_match() {
+    let router = make_router(vec![prefix_route("/api", "api"), prefix_route("/", "default")]);
+    let route = router.match_route("/api", None, &HeaderMap::new()).unwrap();
+    assert_eq!(&*route.cluster, "api", "/api should match /api prefix exactly");
+}
+
+#[test]
+fn segment_boundary_trailing_slash_on_path() {
+    let router = make_router(vec![prefix_route("/api", "api"), prefix_route("/", "default")]);
+    let route = router.match_route("/api/", None, &HeaderMap::new()).unwrap();
+    assert_eq!(&*route.cluster, "api", "/api/ should match /api prefix");
+}
+
+#[test]
+fn prefix_with_and_without_trailing_slash_equivalent() {
+    let r1 = make_router(vec![prefix_route("/api", "api"), prefix_route("/", "default")]);
+    let r2 = make_router(vec![prefix_route("/api/", "api"), prefix_route("/", "default")]);
+
+    for path in &["/api", "/api/", "/api/v1", "/apikeys"] {
+        let m1 = r1.match_route(path, None, &HeaderMap::new()).unwrap();
+        let m2 = r2.match_route(path, None, &HeaderMap::new()).unwrap();
+        assert_eq!(
+            &*m1.cluster, &*m2.cluster,
+            "prefix /api and /api/ should behave identically for path {path}"
+        );
+    }
 }
 
 #[test]

--- a/filter/src/condition/request.rs
+++ b/filter/src/condition/request.rs
@@ -375,6 +375,15 @@ mod tests {
     }
 
     #[test]
+    fn when_path_prefix_rejects_non_segment_boundary() {
+        let req = make_request(Method::GET, "/apikeys", HeaderMap::new());
+        assert!(
+            !should_execute(&[when(path_match("/api"))], &req),
+            "path prefix /api must not match /apikeys (non-segment boundary)"
+        );
+    }
+
+    #[test]
     fn multiple_headers_one_missing_fails() {
         let mut headers = HeaderMap::new();
         headers.insert("x-a", HeaderValue::from_static("1"));

--- a/filter/src/condition/request.rs
+++ b/filter/src/condition/request.rs
@@ -76,7 +76,7 @@ fn matches_request(m: &ConditionMatch, req: &Request) -> bool {
     }
 
     if let Some(ref prefix) = m.path_prefix
-        && !req.uri.path().starts_with(prefix)
+        && !crate::path_match::path_prefix_matches(req.uri.path(), prefix)
     {
         return false;
     }

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -15,6 +15,7 @@ mod context;
 mod factory;
 mod filter;
 pub(crate) mod load_balancing;
+pub(crate) mod path_match;
 mod pipeline;
 mod registry;
 mod results;

--- a/filter/src/path_match.rs
+++ b/filter/src/path_match.rs
@@ -90,4 +90,20 @@ mod tests {
         assert_eq!(path_prefix_specificity("/api"), 4);
         assert_eq!(path_prefix_specificity("/api/v1"), 7);
     }
+
+    /// `"//"` strips to `"/"` which is non-empty, so it enters the
+    /// `starts_with` + segment-boundary check instead of the early
+    /// "empty means match everything" return. This means `"//"` only
+    /// matches paths whose second byte is `/`.
+    #[test]
+    fn double_slash_prefix() {
+        assert!(
+            !path_prefix_matches("/foo", "//"),
+            "/foo must not match // prefix"
+        );
+        assert!(
+            path_prefix_matches("//bar", "//"),
+            "//bar should match // prefix"
+        );
+    }
 }

--- a/filter/src/path_match.rs
+++ b/filter/src/path_match.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024 Shane Utt
+
+//! Segment-boundary path prefix matching per Gateway API semantics.
+//!
+//! A prefix `/api` matches `/api`, `/api/`, and `/api/v1` but NOT `/apikeys`.
+//! A trailing slash on the configured prefix is ignored (`/api` ≡ `/api/`).
+
+/// Returns `true` if `path` matches `prefix` at a segment boundary.
+///
+/// An empty or root-only prefix matches everything. Otherwise the prefix is
+/// trimmed of a trailing `/` and the path must either equal the trimmed prefix
+/// or continue with a `/` separator.
+pub(crate) fn path_prefix_matches(path: &str, prefix: &str) -> bool {
+    let trimmed = prefix.strip_suffix('/').unwrap_or(prefix);
+    if trimmed.is_empty() {
+        return true;
+    }
+    if path == trimmed {
+        return true;
+    }
+    path.starts_with(trimmed) && path.as_bytes().get(trimmed.len()) == Some(&b'/')
+}
+
+/// Returns the specificity (effective length) of a path prefix.
+///
+/// Trailing `/` is stripped so `/api/` and `/api` have equal specificity.
+/// An empty prefix gets specificity 1 (root `/`).
+pub(crate) fn path_prefix_specificity(prefix: &str) -> usize {
+    let trimmed = prefix.strip_suffix('/').unwrap_or(prefix);
+    if trimmed.is_empty() { 1 } else { trimmed.len() }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_matches_everything() {
+        assert!(path_prefix_matches("/anything", "/"));
+        assert!(path_prefix_matches("/", "/"));
+    }
+
+    #[test]
+    fn empty_prefix_matches_everything() {
+        assert!(path_prefix_matches("/foo", ""));
+        assert!(path_prefix_matches("/", ""));
+    }
+
+    #[test]
+    fn exact_match() {
+        assert!(path_prefix_matches("/api", "/api"));
+    }
+
+    #[test]
+    fn with_trailing_slash_on_path() {
+        assert!(path_prefix_matches("/api/", "/api"));
+    }
+
+    #[test]
+    fn subpath_match() {
+        assert!(path_prefix_matches("/api/v1", "/api"));
+    }
+
+    #[test]
+    fn no_segment_boundary_rejected() {
+        assert!(!path_prefix_matches("/apikeys", "/api"));
+    }
+
+    #[test]
+    fn prefix_with_trailing_slash_equivalent() {
+        assert!(path_prefix_matches("/api/v1", "/api/"));
+        assert!(path_prefix_matches("/api", "/api/"));
+    }
+
+    #[test]
+    fn specificity_trims_trailing_slash() {
+        assert_eq!(path_prefix_specificity("/api"), path_prefix_specificity("/api/"));
+    }
+
+    #[test]
+    fn specificity_root() {
+        assert_eq!(path_prefix_specificity("/"), 1);
+        assert_eq!(path_prefix_specificity(""), 1);
+    }
+
+    #[test]
+    fn specificity_value() {
+        assert_eq!(path_prefix_specificity("/api"), 4);
+        assert_eq!(path_prefix_specificity("/api/v1"), 7);
+    }
+}

--- a/filter/src/path_match.rs
+++ b/filter/src/path_match.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
+// Copyright (c) 2026 Praxis Contributors
 
 //! Segment-boundary path prefix matching per Gateway API semantics.
 //!


### PR DESCRIPTION
Path prefix /api now only matches /api, /api/, and /api/... — not /apikeys. Aligns with Gateway API HTTPPathMatch semantics (element-wise prefix matching). Also applies to the condition evaluator's path_prefix.