### PR TITLE
fix(makefile): detect container engine once instead of fallback chaining

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,10 @@
 # Configuration
 # -------------------------------------------------------------------
 
-VERSION ?= $(shell perl -ne 'print $$1 if /^version\s*=\s*"(.+)"/' Cargo.toml)
-IMAGE   ?= praxis
-V       ?=
+VERSION          ?= $(shell perl -ne 'print $$1 if /^version\s*=\s*"(.+)"/' Cargo.toml)
+IMAGE            ?= praxis
+CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
+V                ?=
 
 UNAME_S := $(shell uname -s | tr A-Z a-z)
 UNAME_M := $(shell uname -m)
@@ -20,6 +21,7 @@ endif
 	bench \
 	lint fmt doc audit coverage coverage-check \
 	fuzz fuzz-build \
+	require-container-engine \
 	container container-run \
 	test-container test-container-run \
 	run-echo run-debug \
@@ -54,27 +56,28 @@ clean:
 # Container
 # -------------------------------------------------------------------
 
-container:
-	podman build -t $(IMAGE):$(VERSION) -f Containerfile . || \
-	docker build -t $(IMAGE):$(VERSION) -f Containerfile .
+require-container-engine:
+ifndef CONTAINER_ENGINE
+	$(error No container engine found — install podman or docker)
+endif
 
-container-run:
-	podman run --rm --network=host $(IMAGE):$(VERSION) 2>&1 || \
-	docker run --rm --network=host $(IMAGE):$(VERSION) 2>&1
+container: | require-container-engine
+	$(CONTAINER_ENGINE) build -t $(IMAGE):$(VERSION) -f Containerfile .
+
+container-run: | require-container-engine
+	$(CONTAINER_ENGINE) run --rm --network=host $(IMAGE):$(VERSION) 2>&1
 
 # -------------------------------------------------------------------
 # Test Container
 # -------------------------------------------------------------------
 
-test-container:
-	podman build --ignorefile Containerfile.test.dockerignore \
-		-t $(IMAGE)-test:$(VERSION) -f Containerfile.test . || \
-	docker build -t $(IMAGE)-test:$(VERSION) -f Containerfile.test .
+test-container: | require-container-engine
+	$(CONTAINER_ENGINE) build \
+		$(if $(findstring podman,$(CONTAINER_ENGINE)),--ignorefile Containerfile.test.dockerignore) \
+		-t $(IMAGE)-test:$(VERSION) -f Containerfile.test .
 
 test-container-run: test-container
-	podman run --rm -v $(CURDIR):/src -v praxis-test-cache:/cache \
-		$(IMAGE)-test:$(VERSION) 2>&1 || \
-	docker run --rm -v $(CURDIR):/src -v praxis-test-cache:/cache \
+	$(CONTAINER_ENGINE) run --rm -v $(CURDIR):/src -v praxis-test-cache:/cache \
 		$(IMAGE)-test:$(VERSION) 2>&1
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The `podman ... || docker ...` fallback pattern in all four container
targets masked build failures — if podman was installed but the build
failed (bad base image, network issue), it silently retried with docker
instead of surfacing the error.

This PR detects the container engine once via a `CONTAINER_ENGINE`
variable (auto-detected, overridable) and uses it consistently across
all container targets. A `require-container-engine` prerequisite fails
clearly if neither engine is found. The podman-specific `--ignorefile`
flag is conditionally included only when podman is the engine.

## Test plan

- [ ] `make -n container` uses the detected engine
- [ ] `make -n container CONTAINER_ENGINE=docker` respects the override
- [ ] `make -n test-container` includes `--ignorefile` for podman, omits it for docker
- [ ] `make container` with neither engine installed produces a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)