### PR TITLE
fix(test-utils): use unique filenames for generated client certificates

### DIFF
--- a/tests/utils/src/net/tls.rs
+++ b/tests/utils/src/net/tls.rs
@@ -7,7 +7,10 @@ use std::{
     io::{Read, Write},
     net::TcpStream,
     path::PathBuf,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 
@@ -41,6 +44,9 @@ pub struct TestCertificates {
 
     /// The rcgen CA key pair for signing additional certificates.
     ca_key: KeyPair,
+
+    /// Counter for generating unique client certificate filenames.
+    client_cert_counter: AtomicUsize,
 
     /// Temporary directory holding cert files; cleaned up on drop.
     temp_dir: TempDir,
@@ -83,6 +89,7 @@ impl TestCertificates {
             server_cert_der,
             ca_params,
             ca_key,
+            client_cert_counter: AtomicUsize::new(0),
             temp_dir,
         }
     }
@@ -127,6 +134,7 @@ impl TestCertificates {
             server_cert_der,
             ca_params,
             ca_key,
+            client_cert_counter: AtomicUsize::new(0),
             temp_dir,
         }
     }
@@ -186,8 +194,9 @@ impl TestCertificates {
         client_params.distinguished_name.push(DnType::CommonName, "Test Client");
         let client_cert = client_params.signed_by(&client_key, &issuer).expect("client cert sign");
 
-        let cert_path = self.temp_dir.path().join("client.pem");
-        let key_path = self.temp_dir.path().join("client-key.pem");
+        let n = self.client_cert_counter.fetch_add(1, Ordering::Relaxed);
+        let cert_path = self.temp_dir.path().join(format!("client-{n}.pem"));
+        let key_path = self.temp_dir.path().join(format!("client-{n}-key.pem"));
 
         std::fs::write(&cert_path, client_cert.pem()).expect("write client cert PEM");
         std::fs::write(&key_path, client_key.serialize_pem()).expect("write client key PEM");

--- a/tests/utils/src/net/tls.rs
+++ b/tests/utils/src/net/tls.rs
@@ -8,8 +8,8 @@ use std::{
     net::TcpStream,
     path::PathBuf,
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicUsize, Ordering},
     },
     time::Duration,
 };


### PR DESCRIPTION
## Summary

- Add an `AtomicUsize` counter to `TestCertificates` so each `generate_client_cert()` call produces uniquely named files (`client-{n}.pem` / `client-{n}-key.pem`)
- Prevents silent file overwrite if the method is called multiple times on the same instance (e.g. testing two distinct client identities in an mTLS scenario)
- Counter is initialized in both `generate()` and `generate_for_san()` constructors

## Test plan

- [ ] Verify `cargo check -p praxis-test-utils` passes
- [ ] Verify existing mTLS integration tests still pass
- [ ] Confirm calling `generate_client_cert()` twice on the same instance produces two distinct file pairs

🤖 Generated with [Claude Code](https://claude.com/claude-code)