### PR TITLE
chore: remove stale RUSTSEC-2024-0384 advisory ignore

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -8,8 +8,6 @@ ignore = [
     "RUSTSEC-2024-0388",
     # rustls-pemfile 2.2.0: unmaintained (via pingora-rustls)
     "RUSTSEC-2025-0134",
-    # instant 0.1.13: unmaintained (via notify -> notify-types)
-    "RUSTSEC-2024-0384",
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

Remove the stale `RUSTSEC-2024-0384` ignore entry from `deny.toml`. The `instant` crate (0.1.13) no longer appears in `Cargo.lock` since `notify` v8.2.0 dropped it as a transitive dependency. The ignore does nothing but could confuse maintainers or mask a future advisory reusing that ID.

## Pre-Landing Review

No issues found.

## Test plan

- [x] Build passes (`make build`)
- [x] Verified `instant` is absent from `Cargo.lock` (`grep -c "instant" Cargo.lock` returns 0)
- [x] Unit tests: 38 passed, 2 pre-existing flaky failures in watcher tests (unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)