### PR TITLE
fix(test-utils): panic on unknown filter chain in test pipeline resolution

### DIFF
--- a/tests/utils/src/proxy.rs
+++ b/tests/utils/src/proxy.rs
@@ -36,9 +36,10 @@ fn resolve_listener_pipeline(config: &Config, listener: &Listener, registry: &Fi
 
     let mut entries = Vec::new();
     for chain_name in &listener.filter_chains {
-        if let Some(filters) = chains.get(chain_name.as_str()) {
-            entries.extend_from_slice(filters);
-        }
+        let filters = chains
+            .get(chain_name.as_str())
+            .unwrap_or_else(|| panic!("unknown filter chain: {chain_name}"));
+        entries.extend_from_slice(filters);
     }
 
     let mut pipeline = FilterPipeline::build_with_chains(&mut entries, registry, &chains).unwrap();


### PR DESCRIPTION
## Summary

`resolve_listener_pipeline` in the test utilities silently skipped unknown chain names via `if let Some`, producing an empty or incomplete filter pipeline. A typo in test YAML would result in mysterious 502 errors instead of a clear failure. This replaces the silent skip with a panic that names the unknown chain, matching the strictness of production code in `build_branch.rs`.

## Test plan

- [x] `cargo clippy -p praxis-test-utils` passes clean
- [ ] CI passes (existing integration tests exercise this path with valid chain names)