### PR TITLE
feat(guardrails): add built-in PII detection

### DIFF
--- a/filter/src/builtins/http/mod.rs
+++ b/filter/src/builtins/http/mod.rs
@@ -18,8 +18,8 @@ pub use ai::{A2aFilter, JsonRpcFilter, McpFilter};
 pub use observability::{AccessLogFilter, RequestIdFilter};
 pub use payload_processing::{CompressionFilter, JsonBodyFieldFilter};
 pub use security::{
-    CorsFilter, CredentialInjectionFilter, CsrfFilter, DisallowedOriginMode, ForwardedHeadersFilter, GuardrailsAction,
-    GuardrailsFilter, IpAclFilter, RuleTargetKind,
+    ContainsValue, CorsFilter, CredentialInjectionFilter, CsrfFilter, DisallowedOriginMode, ForwardedHeadersFilter,
+    GuardrailsAction, GuardrailsFilter, IpAclFilter, PiiKind, RuleTargetKind,
 };
 pub use traffic_management::{
     CircuitBreakerFilter, GrpcDetectionFilter, LoadBalancerFilter, RateLimitFilter, RateLimitMode, RedirectFilter,

--- a/filter/src/builtins/http/security/guardrails/config.rs
+++ b/filter/src/builtins/http/security/guardrails/config.rs
@@ -5,6 +5,48 @@
 
 use serde::Deserialize;
 
+use super::pii::PiiKind;
+
+// -----------------------------------------------------------------------------
+// ContainsValue
+// -----------------------------------------------------------------------------
+
+/// The value of a `contains` rule field — either a literal substring or a
+/// list of built-in PII categories.
+///
+/// In YAML, use the variant name as the key:
+///
+/// ```yaml
+/// # Literal substring
+/// contains:
+///   literal: "DROP TABLE"
+///
+/// # PII category list
+/// contains:
+///   pii: [ssn, credit_card, email]
+/// ```
+///
+/// ```
+/// use praxis_filter::ContainsValue;
+///
+/// // Literal substring
+/// let v: ContainsValue = serde_yaml::from_str("literal: \"DROP TABLE\"").unwrap();
+/// assert!(matches!(v, ContainsValue::Literal(_)));
+///
+/// // PII category list
+/// let v: ContainsValue = serde_yaml::from_str("pii: [ssn, email]").unwrap();
+/// assert!(matches!(v, ContainsValue::Pii(_)));
+/// ```
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ContainsValue {
+    /// Literal substring match (case-insensitive).
+    Literal(String),
+
+    /// Built-in PII category detection.
+    Pii(Vec<PiiKind>),
+}
+
 // -----------------------------------------------------------------------------
 // Guardrails Constants
 // -----------------------------------------------------------------------------
@@ -90,8 +132,8 @@ pub(super) struct RuleConfig {
     /// What to inspect: header or body.
     pub target: RuleTargetKind,
 
-    /// Literal substring match (case-sensitive).
-    pub contains: Option<String>,
+    /// Literal substring (case-insensitive) or PII category list.
+    pub contains: Option<ContainsValue>,
 
     /// Regex pattern match.
     pub pattern: Option<String>,

--- a/filter/src/builtins/http/security/guardrails/filter.rs
+++ b/filter/src/builtins/http/security/guardrails/filter.rs
@@ -21,20 +21,32 @@ use crate::{
 // GuardrailsFilter
 // -----------------------------------------------------------------------------
 
-/// Rejects requests matching string or regex rules against headers and/or body content.
+/// Rejects requests matching string, regex, or PII rules against headers
+/// and/or body content.
 ///
 /// # YAML configuration
 ///
 /// ```yaml
 /// filter: guardrails
+/// action: flag            # or "reject" (default)
 /// rules:
+///   # Detect PII in a header
+///   - target: header
+///     name: "Authorization"
+///     contains:
+///       pii: [ssn, credit_card, email]
+///   # Detect PII in body
+///   - target: body
+///     contains:
+///       pii: [ssn, credit_card, phone, email]
+///   # Block SQL injection in body
+///   - target: body
+///     contains:
+///       literal: "DROP TABLE"
 ///   # Block requests from bad bots
 ///   - target: header
 ///     name: "User-Agent"
 ///     pattern: "bad-bot.*"
-///   # Block SQL injection in body
-///   - target: body
-///     contains: "DROP TABLE"
 ///   # Require body to look like JSON (reject if NOT matching)
 ///   - target: body
 ///     pattern: "^\\{.*\\}$"
@@ -51,7 +63,8 @@ use crate::{
 /// rules:
 ///   - target: header
 ///     name: User-Agent
-///     contains: bad-bot
+///     contains:
+///       literal: bad-bot
 /// "#,
 /// )
 /// .unwrap();
@@ -143,21 +156,25 @@ impl GuardrailsFilter {
                 continue;
             };
 
-            let matched = ctx
+            // Retain the matching value for PII kind logging.
+            let matching_value = ctx
                 .request
                 .headers
                 .get_all(header_name.as_str())
                 .iter()
                 .filter_map(|val| val.to_str().ok())
-                .any(|s| rule.matches(s));
+                .find(|s| rule.matches(s));
 
+            let matched = matching_value.is_some();
             let triggered = if rule.negate { !matched } else { matched };
 
             if triggered {
+                let pii_kind = matching_value.and_then(|s| rule.matched_pii(s));
                 tracing::info!(
                     header = %header_name,
                     negate = rule.negate,
-                    "guardrails: header rule triggered, rejecting"
+                    pii_kind = ?pii_kind,
+                    "guardrails: header rule triggered"
                 );
                 return true;
             }
@@ -176,7 +193,12 @@ impl GuardrailsFilter {
             let triggered = if rule.negate { !matched } else { matched };
 
             if triggered {
-                tracing::info!(negate = rule.negate, "guardrails: body rule triggered, rejecting");
+                let pii_kind = if matched { rule.matched_pii(body) } else { None };
+                tracing::info!(
+                    negate = rule.negate,
+                    pii_kind = ?pii_kind,
+                    "guardrails: body rule triggered"
+                );
                 return true;
             }
         }

--- a/filter/src/builtins/http/security/guardrails/mod.rs
+++ b/filter/src/builtins/http/security/guardrails/mod.rs
@@ -5,6 +5,7 @@
 
 mod config;
 mod filter;
+mod pii;
 mod rule;
 
 #[cfg(test)]
@@ -19,6 +20,7 @@ mod rule;
 mod tests;
 
 pub use self::{
-    config::{GuardrailsAction, RuleTargetKind},
+    config::{ContainsValue, GuardrailsAction, RuleTargetKind},
     filter::GuardrailsFilter,
+    pii::PiiKind,
 };

--- a/filter/src/builtins/http/security/guardrails/pii.rs
+++ b/filter/src/builtins/http/security/guardrails/pii.rs
@@ -1,0 +1,123 @@
+//! Built-in PII detection patterns used by guardrail rules.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+use serde::Deserialize;
+
+// -----------------------------------------------------------------------------
+// PII Kind
+// -----------------------------------------------------------------------------
+
+/// Categories of personally identifiable information detectable via the
+/// `pii` matcher on a guardrail rule.
+///
+/// ```
+/// use praxis_filter::PiiKind;
+///
+/// let kinds: Vec<PiiKind> = serde_yaml::from_str("[ssn, credit_card, phone, email]").unwrap();
+/// assert_eq!(kinds.len(), 4);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PiiKind {
+    /// US Social Security Numbers (e.g. `123-45-6789`).
+    Ssn,
+
+    /// Credit / debit card numbers (major network prefixes, common delimiters).
+    CreditCard,
+
+    /// US phone numbers in formatted form (e.g. `(555) 867-5309`).
+    Phone,
+
+    /// Email addresses.
+    Email,
+}
+
+impl PiiKind {
+    /// All built-in PII categories.
+    pub const ALL: &[PiiKind] = &[
+        PiiKind::Ssn,
+        PiiKind::CreditCard,
+        PiiKind::Phone,
+        PiiKind::Email,
+    ];
+}
+
+// -----------------------------------------------------------------------------
+// Compiled Patterns (lazy, compiled once)
+// -----------------------------------------------------------------------------
+
+static SSN_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\b\d{3}-\d{2}-\d{4}\b").expect("SSN regex"));
+
+static CREDIT_CARD_RE: LazyLock<Regex> = LazyLock::new(|| {
+    // (?<!\d) / (?!\d) prevent matching a sub-sequence of a longer digit run
+    // (e.g. 17-digit string must not yield a 16-digit card detection).
+    Regex::new(
+        r"(?x)
+        (?<!\d)
+        (?:
+            # Visa 16-digit (4xxx xxxx xxxx xxxx)
+            4\d{3}[\ \-]?\d{4}[\ \-]?\d{4}[\ \-]?\d{4}
+            # Visa 13-digit (4xxx xxxx xxxx x)
+          | 4\d{3}[\ \-]?\d{4}[\ \-]?\d{4}[\ \-]?\d
+            # Mastercard 16-digit traditional range (51–55xx)
+          | 5[1-5]\d{2}[\ \-]?\d{4}[\ \-]?\d{4}[\ \-]?\d{4}
+            # Mastercard 16-digit 2021+ range (2221–2720)
+          | 2[2-7]\d{2}[\ \-]?\d{4}[\ \-]?\d{4}[\ \-]?\d{4}
+            # Amex 15-digit (34xx / 37xx)
+          | 3[47]\d{2}[\ \-]?\d{6}[\ \-]?\d{5}
+            # Discover 16-digit (6011 / 64x / 65xx)
+          | 6(?:011|[45]\d{2})[\ \-]?\d{4}[\ \-]?\d{4}[\ \-]?\d{4}
+        )
+        (?!\d)",
+    )
+    .expect("credit card regex")
+});
+
+static PHONE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    // Separators between each group are REQUIRED to avoid matching
+    // arbitrary digit subsequences (e.g. product codes, IDs).
+    // (?<!\d) / (?!\d) prevent embedding in a longer digit run.
+    Regex::new(
+        r"(?x)
+        (?<!\d)
+        (?:
+            (?:\+?1[ .\-])?            # optional US country code + separator
+            \(?[2-9]\d{2}\)?           # area code (optionally parenthesised)
+            [ .\-]                     # separator required (space, dot, or hyphen)
+            [2-9]\d{2}                 # exchange
+            \d{4}                      # subscriber
+        )
+        (?!\d)",
+    )
+    .expect("phone regex")
+});
+
+static EMAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b").expect("email regex")
+});
+
+// -----------------------------------------------------------------------------
+// Matching
+// -----------------------------------------------------------------------------
+
+fn regex_for(kind: PiiKind) -> &'static Regex {
+    match kind {
+        PiiKind::Ssn => &SSN_RE,
+        PiiKind::CreditCard => &CREDIT_CARD_RE,
+        PiiKind::Phone => &PHONE_RE,
+        PiiKind::Email => &EMAIL_RE,
+    }
+}
+
+/// Returns the first matching PII category if `haystack` matches any of the given PII categories.
+pub(super) fn matches_any(kinds: &[PiiKind], haystack: &str) -> Option<PiiKind> {
+    for kind in kinds {
+        if regex_for(*kind).is_match(haystack) {
+            return Some(*kind);
+        }
+    }
+    None
+}

--- a/filter/src/builtins/http/security/guardrails/rule.rs
+++ b/filter/src/builtins/http/security/guardrails/rule.rs
@@ -1,11 +1,11 @@
-// SPDX-License-Identifier: MIT
-// Copyright (c) 2024 Shane Utt
-
 //! Compiled rule types and config-to-rule parsing.
 
 use regex::{Regex, RegexBuilder};
 
-use super::config::{MAX_REGEX_PATTERN_LEN, MAX_REGEX_SIZE, RuleConfig, RuleTargetKind};
+use super::{
+    config::{ContainsValue, MAX_REGEX_PATTERN_LEN, MAX_REGEX_SIZE, RuleConfig, RuleTargetKind},
+    pii::{self, PiiKind},
+};
 use crate::FilterError;
 
 // -----------------------------------------------------------------------------
@@ -30,6 +30,9 @@ pub(super) enum RuleMatcher {
 
     /// Pre-compiled regex.
     Pattern(Regex),
+
+    /// Built-in PII category detection.
+    Pii(Vec<PiiKind>),
 }
 
 /// A compiled guardrail rule ready for per-request evaluation.
@@ -51,6 +54,16 @@ impl CompiledRule {
         match &self.matcher {
             RuleMatcher::Contains(needle) => haystack.to_lowercase().contains(needle.as_str()),
             RuleMatcher::Pattern(re) => re.is_match(haystack),
+            RuleMatcher::Pii(kinds) => pii::matches_any(kinds, haystack).is_some(),
+        }
+    }
+
+    /// For PII matchers, return the first category that matched `haystack`.
+    /// Returns `None` for non-PII matchers or when nothing matched.
+    pub(super) fn matched_pii(&self, haystack: &str) -> Option<PiiKind> {
+        match &self.matcher {
+            RuleMatcher::Pii(kinds) => pii::matches_any(kinds, haystack),
+            _ => None,
         }
     }
 }
@@ -82,11 +95,19 @@ pub(super) fn parse_target(rule: &RuleConfig) -> Result<RuleTarget, FilterError>
 /// to prevent configurations from consuming excessive memory.
 pub(super) fn parse_matcher(rule: &RuleConfig) -> Result<RuleMatcher, FilterError> {
     match (&rule.contains, &rule.pattern) {
-        (Some(s), None) => {
-            if s.is_empty() {
-                return Err("guardrails: 'contains' must not be empty".into());
-            }
-            Ok(RuleMatcher::Contains(s.to_lowercase()))
+        (Some(cv), None) => match cv {
+            ContainsValue::Literal(s) => {
+                if s.is_empty() {
+                    return Err("guardrails: 'contains' must not be empty".into());
+                }
+                Ok(RuleMatcher::Contains(s.to_lowercase()))
+            },
+            ContainsValue::Pii(kinds) => {
+                if kinds.is_empty() {
+                    return Err("guardrails: 'contains' PII list must not be empty".into());
+                }
+                Ok(RuleMatcher::Pii(kinds.clone()))
+            },
         },
         (None, Some(p)) => {
             if p.is_empty() {

--- a/filter/src/builtins/http/security/guardrails/tests.rs
+++ b/filter/src/builtins/http/security/guardrails/tests.rs
@@ -9,6 +9,7 @@ use regex::Regex;
 use super::{
     GuardrailsFilter,
     config::DEFAULT_MAX_BODY_BYTES,
+    pii::PiiKind,
     rule::{CompiledRule, RuleMatcher, RuleTarget},
 };
 use crate::{FilterAction, FilterResultSet, filter::HttpFilter};
@@ -403,6 +404,299 @@ async fn body_filter_defers_result_to_body_phase() {
 }
 
 // -----------------------------------------------------------------------------
+// PII Rule Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn pii_ssn_rejects_body() {
+    let f = make_filter(vec![body_pii(&[PiiKind::Ssn])]);
+    let req = crate::test_utils::make_request(http::Method::POST, "/api");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut body = Some(Bytes::from_static(b"my ssn is 123-45-6789 thanks"));
+    let action = f.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Reject(r) if r.status == 403),
+        "SSN in body should be rejected"
+    );
+    assert_result(&ctx.filter_results, "blocked");
+}
+
+#[tokio::test]
+async fn pii_ssn_allows_clean_body() {
+    let f = make_filter(vec![body_pii(&[PiiKind::Ssn])]);
+    let req = crate::test_utils::make_request(http::Method::POST, "/api");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut body = Some(Bytes::from_static(b"no sensitive data here"));
+    let action = f.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue), "clean body should pass");
+    assert_result(&ctx.filter_results, "passed");
+}
+
+#[tokio::test]
+async fn pii_credit_card_rejects_16_digit() {
+    let f = make_filter(vec![body_pii(&[PiiKind::CreditCard])]);
+    let req = crate::test_utils::make_request(http::Method::POST, "/api");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut body = Some(Bytes::from_static(b"card: 4111-1111-1111-1111"));
+    let action = f.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Reject(r) if r.status == 403),
+        "credit card number should be rejected"
+    );
+}
+
+#[tokio::test]
+async fn pii_credit_card_rejects_amex() {
+    let f = make_filter(vec![body_pii(&[PiiKind::CreditCard])]);
+    let req = crate::test_utils::make_request(http::Method::POST, "/api");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut body = Some(Bytes::from_static(b"amex: 3782-822463-10005"));
+    let action = f.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Reject(r) if r.status == 403),
+        "Amex card number should be rejected"
+    );
+}
+
+#[tokio::test]
+async fn pii_credit_card_rejects_mastercard() {
+    let f = make_filter(vec![body_pii(&[PiiKind::CreditCard])]);
+    let req = crate::test_utils::make_request(http::Method::POST, "/api");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut body = Some(Bytes::from_static(b"card: 5111-1111-1111-1118"));
+    let action = f.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Reject(r) if r.status == 403),
+        "Mastercard (traditional range) should be rejected"
+    );
+}
+
+#[tokio::test]
+async fn pii_credit_card_rejects_discover() {
+    let f = make_filter(vec![body_pii(&[PiiKind::CreditCard])]);
+    let req = crate::test_utils::make_request(http::Method::POST, "/api");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut body = Some(Bytes::from_static(b"card: 6011-1111-1111-1117"));
+    let action = f.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Reject(r) if r.status == 403),
+        "Discover card number should be rejected"
+    );
+}
+
+#[tokio::test]
+async fn pii_phone_rejects_us_format() {
+    let f = make_filter(vec![body_pii(&[PiiKind::Phone])]);
+    let req = crate::test_utils::make_request(http::Method::POST, "/api");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut body = Some(Bytes::from_static(b"call me at (555) 867-5309"));
+    let action = f.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Reject(r) if r.status == 403),
+        "US phone number should be rejected"
+    );
+}
+
+#[tokio::test]
+async fn pii_phone_rejects_with_country_code() {
+    let f = make_filter(vec![body_pii(&[PiiKind::Phone])]);
+    let req = crate::test_utils::make_request(http::Method::POST, "/api");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut body = Some(Bytes::from_static(b"call +1-555-867-5309"));
+    let action = f.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Reject(r) if r.status == 403),
+        "phone with country code should be rejected"
+    );
+}
+
+#[tokio::test]
+async fn pii_email_rejects_address() {
+    let f = make_filter(vec![body_pii(&[PiiKind::Email])]);
+    let req = crate::test_utils::make_request(http::Method::POST, "/api");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut body = Some(Bytes::from_static(b"send to user@example.com please"));
+    let action = f.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Reject(r) if r.status == 403),
+        "email address should be rejected"
+    );
+}
+
+#[tokio::test]
+async fn pii_email_allows_no_email() {
+    let f = make_filter(vec![body_pii(&[PiiKind::Email])]);
+    let req = crate::test_utils::make_request(http::Method::POST, "/api");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut body = Some(Bytes::from_static(b"just some text with an @ but no valid email"));
+    let action = f.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue), "non-email @ should pass");
+}
+
+
+#[tokio::test]
+async fn pii_combined_rejects_any_match() {
+    let f = make_filter(vec![body_pii(PiiKind::ALL)]);
+    let req = crate::test_utils::make_request(http::Method::POST, "/api");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut body = Some(Bytes::from_static(b"my email is foo@bar.com"));
+    let action = f.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Reject(r) if r.status == 403),
+        "any PII match in combined filter should reject"
+    );
+}
+
+#[tokio::test]
+async fn pii_combined_allows_clean() {
+    let f = make_filter(vec![body_pii(PiiKind::ALL)]);
+    let req = crate::test_utils::make_request(http::Method::POST, "/api");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut body = Some(Bytes::from_static(b"perfectly clean content"));
+    let action = f.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue), "clean body should pass all PII rules");
+}
+
+#[test]
+fn pii_from_config_yaml() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+rules:
+  - target: body
+    contains:
+      pii: [ssn, credit_card, email]
+"#,
+    )
+    .unwrap();
+    let filter = GuardrailsFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.name(), "guardrails");
+}
+
+#[test]
+fn pii_mixed_with_other_rules_from_config() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+rules:
+  - target: body
+    contains:
+      pii: [ssn, phone]
+  - target: body
+    contains:
+      literal: "DROP TABLE"
+"#,
+    )
+    .unwrap();
+    let filter = GuardrailsFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.name(), "guardrails");
+}
+
+#[test]
+fn pii_on_header_from_config_yaml() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+rules:
+  - target: header
+    name: Authorization
+    contains:
+      pii: [ssn, email]
+"#,
+    )
+    .unwrap();
+    let filter = GuardrailsFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.name(), "guardrails");
+}
+
+#[tokio::test]
+async fn pii_header_rejects_match() {
+    let f = make_filter(vec![header_pii("x-data", &[PiiKind::Ssn])]);
+    let mut req = crate::test_utils::make_request(http::Method::GET, "/");
+    req.headers
+        .insert("x-data", "ssn=123-45-6789".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = f.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Reject(r) if r.status == 403),
+        "SSN in header should be rejected"
+    );
+}
+
+#[tokio::test]
+async fn pii_header_allows_clean() {
+    let f = make_filter(vec![header_pii("x-data", &[PiiKind::Ssn])]);
+    let mut req = crate::test_utils::make_request(http::Method::GET, "/");
+    req.headers
+        .insert("x-data", "nothing sensitive".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = f.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "clean header should continue"
+    );
+}
+
+#[tokio::test]
+async fn pii_flag_action_continues_on_body_match() {
+    let f = make_flag_filter(vec![body_pii(PiiKind::ALL)]);
+    let req = crate::test_utils::make_request(http::Method::POST, "/api");
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let mut body = Some(Bytes::from_static(b"my ssn is 123-45-6789"));
+    let action = f.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "flag action should continue even on PII match"
+    );
+    assert_result(&ctx.filter_results, "blocked");
+}
+
+#[tokio::test]
+async fn pii_flag_action_continues_on_header_match() {
+    let f = make_flag_filter(vec![header_pii("x-data", &[PiiKind::Email])]);
+    let mut req = crate::test_utils::make_request(http::Method::GET, "/");
+    req.headers
+        .insert("x-data", "user@example.com".parse().unwrap());
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+
+    let action = f.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "flag action should continue even on header PII match"
+    );
+    assert_result(&ctx.filter_results, "blocked");
+}
+
+#[test]
+fn pii_empty_list_errors() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+rules:
+  - target: body
+    contains:
+      pii: []
+"#,
+    )
+    .unwrap();
+    assert!(
+        GuardrailsFilter::from_config(&yaml).is_err(),
+        "empty PII contains list should fail"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
 
@@ -479,7 +773,7 @@ fn body_not_pattern(re: &str) -> CompiledRule {
     }
 }
 
-/// Build a filter from compiled rules with default reject action.
+/// Build a guardrails filter from compiled rules with default reject action.
 fn make_filter(rules: Vec<CompiledRule>) -> GuardrailsFilter {
     let needs_body = rules.iter().any(|r| matches!(r.target, RuleTarget::Body));
     GuardrailsFilter {
@@ -489,12 +783,30 @@ fn make_filter(rules: Vec<CompiledRule>) -> GuardrailsFilter {
     }
 }
 
-/// Build a filter from compiled rules with flag action.
+/// Build a guardrails filter from compiled rules with flag action.
 fn make_flag_filter(rules: Vec<CompiledRule>) -> GuardrailsFilter {
     let needs_body = rules.iter().any(|r| matches!(r.target, RuleTarget::Body));
     GuardrailsFilter {
         action: super::config::GuardrailsAction::Flag,
         rules,
         needs_body,
+    }
+}
+
+/// Build a body PII rule for testing.
+fn body_pii(kinds: &[PiiKind]) -> CompiledRule {
+    CompiledRule {
+        target: RuleTarget::Body,
+        matcher: RuleMatcher::Pii(kinds.to_vec()),
+        negate: false,
+    }
+}
+
+/// Build a header PII rule for testing.
+fn header_pii(name: &str, kinds: &[PiiKind]) -> CompiledRule {
+    CompiledRule {
+        target: RuleTarget::Header(name.to_owned()),
+        matcher: RuleMatcher::Pii(kinds.to_vec()),
+        negate: false,
     }
 }

--- a/filter/src/builtins/http/security/mod.rs
+++ b/filter/src/builtins/http/security/mod.rs
@@ -16,5 +16,5 @@ pub use cors::{CorsFilter, DisallowedOriginMode};
 pub use credential_injection::CredentialInjectionFilter;
 pub use csrf::CsrfFilter;
 pub use forwarded_headers::ForwardedHeadersFilter;
-pub use guardrails::{GuardrailsAction, GuardrailsFilter, RuleTargetKind};
+pub use guardrails::{ContainsValue, GuardrailsAction, GuardrailsFilter, PiiKind, RuleTargetKind};
 pub use ip_acl::IpAclFilter;


### PR DESCRIPTION
This addresses part of praxis-proxy/ai#76 by adding built-in PII detection for content in HTTP headers and/or body. When one of the pre-defined PII categories is detected, it blocks the request and logs the PII category that triggered the action. Namely, it adds the following:

*  Built-in PII categories (Ssn, CreditCard, Phone, Email) 
*  Updates the config to include a `contains` field and `literal` and `pii` subfields to differentiate between regex and PII categories
* Rejects requests if PII is detected in the header and/or body and logs the category type that was detected

## Testing
* Updated guardrails unit tests for PII rules 


