### PR TITLE
chore: centralize unsafe_code lint in workspace configuration

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -90,7 +90,7 @@ server -> protocol -> filter -> core -> tls
 See `docs/conventions.md` for the full coding style
 guide. Key points:
 
-- `#![deny(unsafe_code)]` in all crates
+- `unsafe_code = "deny"` in workspace lints
 - All items (public and private) require `///` doc
   comments; enforced by `missing_docs` and
   `missing_docs_in_private_items` lints

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ opt-level = 2
 
 [workspace.lints.rust]
 dead_code = "deny"
+unsafe_code = "deny"
 missing_docs = "deny"
 unreachable_pub = "deny"
 unused_imports = "deny"

--- a/benchmarks/microbenchmarks/condition_eval.rs
+++ b/benchmarks/microbenchmarks/condition_eval.rs
@@ -3,7 +3,6 @@
 
 //! Criterion benchmarks for condition evaluation.
 
-#![deny(unsafe_code)]
 #![allow(
     clippy::unwrap_used,
     clippy::expect_used,

--- a/benchmarks/microbenchmarks/config_parsing.rs
+++ b/benchmarks/microbenchmarks/config_parsing.rs
@@ -3,7 +3,6 @@
 
 //! Criterion benchmarks for YAML config deserialization.
 
-#![deny(unsafe_code)]
 #![allow(clippy::unwrap_used, clippy::expect_used, reason = "benchmarks")]
 
 use std::hint::black_box;

--- a/benchmarks/microbenchmarks/filter_pipeline.rs
+++ b/benchmarks/microbenchmarks/filter_pipeline.rs
@@ -3,7 +3,6 @@
 
 //! Criterion benchmarks for filter pipeline construction and execution.
 
-#![deny(unsafe_code)]
 #![allow(
     clippy::unwrap_used,
     clippy::expect_used,

--- a/benchmarks/microbenchmarks/headers.rs
+++ b/benchmarks/microbenchmarks/headers.rs
@@ -3,7 +3,6 @@
 
 //! Criterion benchmarks for header manipulation filter.
 
-#![deny(unsafe_code)]
 #![allow(
     clippy::unwrap_used,
     clippy::expect_used,

--- a/benchmarks/microbenchmarks/load_balancer.rs
+++ b/benchmarks/microbenchmarks/load_balancer.rs
@@ -3,7 +3,6 @@
 
 //! Criterion benchmarks for load balancer endpoint selection.
 
-#![deny(unsafe_code)]
 #![allow(
     clippy::unwrap_used,
     clippy::expect_used,

--- a/benchmarks/microbenchmarks/router_lookup.rs
+++ b/benchmarks/microbenchmarks/router_lookup.rs
@@ -3,7 +3,6 @@
 
 //! Criterion benchmarks for router path-prefix matching.
 
-#![deny(unsafe_code)]
 #![allow(
     clippy::unwrap_used,
     clippy::expect_used,

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2024 Shane Utt
 
-#![deny(unsafe_code)]
 #![deny(unreachable_pub)]
 
 //! Benchmark tool and library for the Praxis proxy.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2024 Shane Utt
 
-#![deny(unsafe_code)]
 #![deny(unreachable_pub)]
 
 //! Core configuration, error types, and server factory for Praxis.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -110,7 +110,7 @@ and verify conformance against them.
 Security is enforced at the lint level. See lints in
 [Cargo.toml] for the full set.
 
-- `#![deny(unsafe_code)]` in all crate roots (no
+- `unsafe_code = "deny"` in workspace lints (no
   exceptions; unsafe belongs upstream)
 - Clippy runs with `-D warnings` (zero tolerance)
 - Errors via `thiserror`

--- a/docs/development.md
+++ b/docs/development.md
@@ -43,7 +43,7 @@ the `make audit` target. The `deny.toml` config bans
 wildcard version requirements, unknown registries, and
 unknown git sources. Multiple versions of the same crate
 produce a warning. All crates enforce
-`#![deny(unsafe_code)]` and Clippy runs with
+`unsafe_code = "deny"` in workspace lints and Clippy runs with
 `-D warnings` (zero tolerance).
 
 See [architecture.md](architecture.md) for workspace layout

--- a/docs/features.md
+++ b/docs/features.md
@@ -96,7 +96,7 @@ deployment guidance.
 
 **Build-level guarantees:**
 
-- `#![deny(unsafe_code)]` in every crate
+- `unsafe_code = "deny"` in workspace lints
 - Rustls (no OpenSSL, no C FFI in the TLS path)
 - Supply chain auditing via `cargo audit` and
   `cargo deny`

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -15,7 +15,7 @@ ambiguous configuration:
   for upstream connections.
 - Admin endpoints are restricted to localhost; public
   binding is a validation error.
-- `#![deny(unsafe_code)]` in every crate; no unsafe
+- `unsafe_code = "deny"` in workspace lints; no unsafe
   Rust in the Praxis codebase.
 - Rustls for TLS (no OpenSSL, no C FFI in the TLS
   path).

--- a/filter/ext-proc/src/lib.rs
+++ b/filter/ext-proc/src/lib.rs
@@ -33,7 +33,6 @@
 //! [`ext_proc`]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/ext_proc/v3/external_processor.proto
 //! [`ExternalProcessor`]: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_proc/v3/ext_proc.proto
 
-#![deny(unsafe_code)]
 #![deny(unreachable_pub)]
 
 #[cfg(test)]

--- a/filter/proto/src/lib.rs
+++ b/filter/proto/src/lib.rs
@@ -3,8 +3,6 @@
 //! This crate compiles vendored `.proto` files from the Envoy project into
 //! Rust types with [`tonic`] gRPC client and server stubs.
 
-#![deny(unsafe_code)]
-
 pub mod envoy {
     pub mod service {
         pub mod common {

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2024 Shane Utt
 
-#![deny(unsafe_code)]
 #![deny(unreachable_pub)]
 
 //! Filter pipeline engine for Praxis.

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2024 Shane Utt
 
-#![deny(unsafe_code)]
 #![deny(unreachable_pub)]
 
 //! Protocol adapters for Praxis.

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2024 Shane Utt
 
-#![deny(unsafe_code)]
-
 //! Server bootstrap for the Praxis proxy.
 
 pub(crate) mod pipelines;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2024 Shane Utt
 
-#![deny(unsafe_code)]
-
 //! Praxis server entry point.
 //!
 //! Loads configuration, initializes tracing (with optional JSON output and

--- a/tests/utils/src/lib.rs
+++ b/tests/utils/src/lib.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2024 Shane Utt
 
-#![deny(unsafe_code)]
 #![allow(
     clippy::unwrap_used,
     clippy::expect_used,

--- a/tls/src/lib.rs
+++ b/tls/src/lib.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2024 Shane Utt
 
-#![deny(unsafe_code)]
 #![deny(unreachable_pub)]
 
 //! TLS configuration types for the Praxis proxy.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,7 +3,6 @@
 
 //! Development tasks for the Praxis proxy.
 
-#![deny(unsafe_code)]
 #![allow(
     clippy::exit,
     clippy::print_stdout,


### PR DESCRIPTION
## Summary

- Add `unsafe_code = "deny"` to `[workspace.lints.rust]` in the root `Cargo.toml` so all crates (including new ones and test targets) inherit the lint automatically.
- Remove per-crate `#![deny(unsafe_code)]` attributes from 17 source files across the workspace.
- Keep the explicit `unsafe_code = "deny"` in `filter/proto/Cargo.toml` since that crate opts out of workspace lints for generated protobuf code.
- Update documentation (`conventions.md`, `security-hardening.md`, `development.md`, `features.md`, `CLAUDE.md`) to reference the workspace lint instead of per-crate attributes.

## Test plan

- [x] `cargo check --workspace` passes
- [ ] CI lint and build pipelines pass
- [ ] Verify no `#![deny(unsafe_code)]` attributes remain in `.rs` files

Signed-off-by: Sébastien Han <seb@redhat.com>