### PR TITLE
fix(filter): merge StreamBuffer limits with largest-wins

### DIFF
--- a/filter/src/context.rs
+++ b/filter/src/context.rs
@@ -417,8 +417,8 @@ mod tests {
         ctx.set_request_body_mode(BodyMode::StreamBuffer { max_bytes: Some(1024) });
         assert_eq!(
             ctx.request_body_mode,
-            BodyMode::StreamBuffer { max_bytes: Some(1024) },
-            "smaller StreamBuffer limit should win when merging"
+            BodyMode::StreamBuffer { max_bytes: Some(2048) },
+            "larger StreamBuffer limit should win when merging"
         );
     }
 

--- a/filter/src/pipeline/body.rs
+++ b/filter/src/pipeline/body.rs
@@ -15,21 +15,30 @@ use crate::{
 // Body Mode Merging
 // -----------------------------------------------------------------------------
 
-/// Merge two optional size limits, keeping the smallest `Some` value.
+/// Merge two optional size limits, keeping the largest value.
+///
+/// `None` represents unbounded buffering and is treated as larger
+/// than any finite limit. When both sides are `Some`, the larger
+/// value wins so that every filter in the pipeline gets enough
+/// buffer to do its job. The pipeline-level body ceiling (applied
+/// separately via [`apply_body_limits`]) remains the hard safety cap.
+///
+/// [`apply_body_limits`]: super::FilterPipeline::apply_body_limits
 pub(super) fn merge_optional_limits(a: Option<usize>, b: Option<usize>) -> Option<usize> {
     match (a, b) {
-        (Some(x), Some(y)) => Some(x.min(y)),
-        (Some(x), None) | (None, Some(x)) => Some(x),
-        (None, None) => None,
+        (Some(x), Some(y)) => Some(x.max(y)),
+        (None, _) | (_, None) => None,
+        // unreachable, but spelled out for clarity — both None is still None
     }
 }
 
 /// Merge a filter's body mode into the current accumulated mode.
 ///
 /// Precedence: `StreamBuffer` > `SizeLimit` > `Stream`.
-/// When two modes of the same variant merge, the stricter (smaller)
-/// limit wins. `SizeLimit` is treated as equivalent to `Stream`
-/// from a filter perspective (filters never request it directly).
+/// When two `StreamBuffer` modes merge, the **largest** limit wins
+/// so that every filter gets enough buffer to do its job. The
+/// pipeline-level body ceiling is applied separately and acts as the
+/// hard safety cap.
 pub(crate) fn merge_body_mode(current: &mut BodyMode, filter_mode: BodyMode) {
     match filter_mode {
         BodyMode::StreamBuffer { max_bytes } => {
@@ -172,8 +181,8 @@ mod tests {
         merge_body_mode(&mut mode, BodyMode::StreamBuffer { max_bytes: Some(1024) });
         assert_eq!(
             mode,
-            BodyMode::StreamBuffer { max_bytes: Some(1024) },
-            "smaller StreamBuffer limit should win"
+            BodyMode::StreamBuffer { max_bytes: Some(2048) },
+            "larger StreamBuffer limit should win"
         );
     }
 
@@ -183,8 +192,8 @@ mod tests {
         merge_body_mode(&mut mode, BodyMode::StreamBuffer { max_bytes: Some(1024) });
         assert_eq!(
             mode,
-            BodyMode::StreamBuffer { max_bytes: Some(1024) },
-            "Some limit should win over None"
+            BodyMode::StreamBuffer { max_bytes: None },
+            "None (unbounded) should win over Some"
         );
     }
 
@@ -200,11 +209,11 @@ mod tests {
     }
 
     #[test]
-    fn merge_optional_limits_both_some_picks_smaller() {
+    fn merge_optional_limits_both_some_picks_larger() {
         assert_eq!(
             merge_optional_limits(Some(100), Some(50)),
-            Some(50),
-            "should pick smaller of two Some values"
+            Some(100),
+            "should pick larger of two Some values"
         );
     }
 
@@ -212,13 +221,13 @@ mod tests {
     fn merge_optional_limits_one_none() {
         assert_eq!(
             merge_optional_limits(Some(100), None),
-            Some(100),
-            "Some should win over None (left)"
+            None,
+            "None (unbounded) should win over Some (left)"
         );
         assert_eq!(
             merge_optional_limits(None, Some(200)),
-            Some(200),
-            "Some should win over None (right)"
+            None,
+            "None (unbounded) should win over Some (right)"
         );
     }
 

--- a/filter/src/pipeline/tests.rs
+++ b/filter/src/pipeline/tests.rs
@@ -538,7 +538,7 @@ fn body_capabilities_buffer_overrides_stream_buffer() {
 }
 
 #[test]
-fn body_capabilities_multiple_stream_buffer_takes_min() {
+fn body_capabilities_multiple_stream_buffer_merges() {
     let pipeline = make_pipeline(vec![
         Box::new(StreamBufferReleaseFilter { marker: b"A" }),
         Box::new(StreamBufferReleaseFilter { marker: b"B" }),

--- a/filter/src/pipeline/tests.rs
+++ b/filter/src/pipeline/tests.rs
@@ -552,6 +552,23 @@ fn body_capabilities_multiple_stream_buffer_merges() {
     );
 }
 
+#[test]
+fn body_capabilities_multiple_stream_buffer_largest_wins() {
+    let pipeline = make_pipeline(vec![
+        Box::new(BoundedStreamBufferFilter { max_bytes: 1024 }),
+        Box::new(BoundedStreamBufferFilter { max_bytes: 65_536 }),
+    ]);
+    let caps = pipeline.body_capabilities();
+
+    assert_eq!(
+        caps.request_body_mode,
+        BodyMode::StreamBuffer {
+            max_bytes: Some(65_536)
+        },
+        "largest StreamBuffer limit should win when merging finite limits"
+    );
+}
+
 #[tokio::test]
 async fn execute_request_body_release_propagates() {
     let pipeline = make_pipeline(vec![Box::new(StreamBufferReleaseFilter { marker: b"GO" })]);
@@ -2479,6 +2496,41 @@ impl HttpFilter for StreamBufferReleaseFilter {
         {
             return Ok(FilterAction::Release);
         }
+        Ok(FilterAction::Continue)
+    }
+}
+
+/// A filter that declares StreamBuffer mode with a finite byte limit.
+struct BoundedStreamBufferFilter {
+    max_bytes: usize,
+}
+
+#[async_trait]
+impl HttpFilter for BoundedStreamBufferFilter {
+    fn name(&self) -> &'static str {
+        "bounded_stream_buffer"
+    }
+
+    async fn on_request(&self, _ctx: &mut crate::HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        Ok(FilterAction::Continue)
+    }
+
+    fn request_body_access(&self) -> BodyAccess {
+        BodyAccess::ReadOnly
+    }
+
+    fn request_body_mode(&self) -> BodyMode {
+        BodyMode::StreamBuffer {
+            max_bytes: Some(self.max_bytes),
+        }
+    }
+
+    async fn on_request_body(
+        &self,
+        _ctx: &mut crate::HttpFilterContext<'_>,
+        _body: &mut Option<Bytes>,
+        _end_of_stream: bool,
+    ) -> Result<FilterAction, FilterError> {
         Ok(FilterAction::Continue)
     }
 }

--- a/protocol/src/http/pingora/handler/mod.rs
+++ b/protocol/src/http/pingora/handler/mod.rs
@@ -157,7 +157,6 @@ where
 fn clamp_body_mode_to_ceiling(mode: BodyMode, baseline: BodyMode) -> BodyMode {
     let ceiling = match baseline {
         BodyMode::StreamBuffer { max_bytes: Some(v) } | BodyMode::SizeLimit { max_bytes: v } => Some(v),
-        BodyMode::StreamBuffer { max_bytes: None } | BodyMode::Stream => None,
         _ => None,
     };
 
@@ -168,7 +167,7 @@ fn clamp_body_mode_to_ceiling(mode: BodyMode, baseline: BodyMode) -> BodyMode {
         (BodyMode::SizeLimit { max_bytes }, Some(limit)) => BodyMode::SizeLimit {
             max_bytes: max_bytes.min(limit),
         },
-        (m, None) | (m, Some(_)) => m,
+        (m, None | Some(_)) => m,
     }
 }
 

--- a/protocol/src/http/pingora/handler/mod.rs
+++ b/protocol/src/http/pingora/handler/mod.rs
@@ -8,7 +8,7 @@ use std::{sync::Arc, time::Duration};
 use arc_swap::ArcSwap;
 use pingora_core::{Result, apps::HttpServerOptions, server::Server, services::listening::Service};
 use pingora_proxy::{Session, http_proxy};
-use praxis_filter::{CompressionConfig, FilterPipeline};
+use praxis_filter::{BodyMode, CompressionConfig, FilterPipeline};
 use tokio::sync::Semaphore;
 use tracing::{debug, warn};
 
@@ -147,6 +147,30 @@ where
 // -----------------------------------------------------------------------------
 // Shared Utilities
 // -----------------------------------------------------------------------------
+
+/// Clamp a runtime-selected body mode to the byte ceiling implied by `baseline`.
+///
+/// `baseline` is the mode established before request/response-phase filter hooks
+/// run (typically from pipeline capabilities + global body limits). Runtime
+/// `set_*_body_mode` calls may widen limits; this helper preserves the original
+/// ceiling while still allowing upgrades between body mode variants.
+fn clamp_body_mode_to_ceiling(mode: BodyMode, baseline: BodyMode) -> BodyMode {
+    let ceiling = match baseline {
+        BodyMode::StreamBuffer { max_bytes: Some(v) } | BodyMode::SizeLimit { max_bytes: v } => Some(v),
+        BodyMode::StreamBuffer { max_bytes: None } | BodyMode::Stream => None,
+        _ => None,
+    };
+
+    match (mode, ceiling) {
+        (BodyMode::StreamBuffer { max_bytes }, Some(limit)) => BodyMode::StreamBuffer {
+            max_bytes: Some(max_bytes.map_or(limit, |v| v.min(limit))),
+        },
+        (BodyMode::SizeLimit { max_bytes }, Some(limit)) => BodyMode::SizeLimit {
+            max_bytes: max_bytes.min(limit),
+        },
+        (m, None) | (m, Some(_)) => m,
+    }
+}
 
 /// Apply compression settings from the pipeline config to the Pingora response.
 fn adjust_compression(

--- a/protocol/src/http/pingora/handler/mod.rs
+++ b/protocol/src/http/pingora/handler/mod.rs
@@ -154,6 +154,13 @@ where
 /// run (typically from pipeline capabilities + global body limits). Runtime
 /// `set_*_body_mode` calls may widen limits; this helper preserves the original
 /// ceiling while still allowing upgrades between body mode variants.
+///
+/// `Stream` mode passes through unconditionally because it delivers chunks
+/// as they arrive without accumulating them — there is no buffer to cap.
+/// A filter that downgrades from `StreamBuffer` to `Stream` at runtime is
+/// opting out of buffering entirely, which is always safe from a memory
+/// perspective. The pipeline-level body size limit (enforced separately
+/// via `SizeLimit`) remains the backstop for oversized payloads.
 fn clamp_body_mode_to_ceiling(mode: BodyMode, baseline: BodyMode) -> BodyMode {
     let ceiling = match baseline {
         BodyMode::StreamBuffer { max_bytes: Some(v) } | BodyMode::SizeLimit { max_bytes: v } => Some(v),
@@ -167,6 +174,8 @@ fn clamp_body_mode_to_ceiling(mode: BodyMode, baseline: BodyMode) -> BodyMode {
         (BodyMode::SizeLimit { max_bytes }, Some(limit)) => BodyMode::SizeLimit {
             max_bytes: max_bytes.min(limit),
         },
+        // Stream has no buffer to clamp; other modes pass through when the
+        // baseline imposes no ceiling (e.g. unbounded StreamBuffer).
         (m, None | Some(_)) => m,
     }
 }

--- a/protocol/src/http/pingora/handler/request_filter/mod.rs
+++ b/protocol/src/http/pingora/handler/request_filter/mod.rs
@@ -174,6 +174,7 @@ async fn run_pipeline(
     request: Request,
     ctx: &mut PingoraRequestCtx,
 ) -> std::result::Result<PipelineResult, FilterError> {
+    let baseline_request_body_mode = ctx.request_body_mode;
     let (
         action,
         extra_headers,
@@ -213,7 +214,7 @@ async fn run_pipeline(
             ctx.cluster = cluster;
             ctx.upstream = upstream;
             ctx.rewritten_path = rewritten_path;
-            ctx.request_body_mode = request_body_mode;
+            ctx.request_body_mode = super::clamp_body_mode_to_ceiling(request_body_mode, baseline_request_body_mode);
             ctx.selected_endpoint_index = selected_endpoint_index;
             Ok(PipelineResult {
                 action: FilterAction::Continue,
@@ -270,7 +271,7 @@ mod tests {
 
     use http::{HeaderMap, Method, Uri};
     use praxis_core::config::FailureMode;
-    use praxis_filter::{FilterAction, FilterPipeline, FilterRegistry, Request};
+    use praxis_filter::{BodyMode, FilterAction, FilterPipeline, FilterRegistry, Request};
 
     use super::*;
     use crate::http::pingora::context::PingoraRequestCtx;
@@ -411,6 +412,32 @@ mod tests {
             normalize_mapped_ipv4(mapped),
             expected,
             "::ffff:127.0.0.1 should normalize to 127.0.0.1"
+        );
+    }
+
+    #[test]
+    fn clamp_body_mode_to_ceiling_caps_stream_buffer_limit() {
+        let clamped = super::super::clamp_body_mode_to_ceiling(
+            BodyMode::StreamBuffer { max_bytes: Some(4096) },
+            BodyMode::StreamBuffer { max_bytes: Some(1024) },
+        );
+        assert_eq!(
+            clamped,
+            BodyMode::StreamBuffer { max_bytes: Some(1024) },
+            "runtime StreamBuffer widening should be clamped to baseline ceiling"
+        );
+    }
+
+    #[test]
+    fn clamp_body_mode_to_ceiling_caps_unbounded_stream_buffer() {
+        let clamped = super::super::clamp_body_mode_to_ceiling(
+            BodyMode::StreamBuffer { max_bytes: None },
+            BodyMode::SizeLimit { max_bytes: 512 },
+        );
+        assert_eq!(
+            clamped,
+            BodyMode::StreamBuffer { max_bytes: Some(512) },
+            "runtime unbounded StreamBuffer should be clamped to baseline ceiling"
         );
     }
 

--- a/protocol/src/http/pingora/handler/request_filter/mod.rs
+++ b/protocol/src/http/pingora/handler/request_filter/mod.rs
@@ -441,6 +441,68 @@ mod tests {
         );
     }
 
+    #[test]
+    fn clamp_body_mode_to_ceiling_stream_passes_through_with_ceiling() {
+        let clamped = super::super::clamp_body_mode_to_ceiling(
+            BodyMode::Stream,
+            BodyMode::StreamBuffer { max_bytes: Some(1024) },
+        );
+        assert_eq!(
+            clamped,
+            BodyMode::Stream,
+            "Stream has no buffer to clamp and should pass through unchanged"
+        );
+    }
+
+    #[test]
+    fn clamp_body_mode_to_ceiling_stream_passes_through_without_ceiling() {
+        let clamped = super::super::clamp_body_mode_to_ceiling(BodyMode::Stream, BodyMode::Stream);
+        assert_eq!(
+            clamped,
+            BodyMode::Stream,
+            "Stream baseline imposes no ceiling; Stream mode passes through"
+        );
+    }
+
+    #[test]
+    fn clamp_body_mode_to_ceiling_size_limit_clamped_to_baseline() {
+        let clamped = super::super::clamp_body_mode_to_ceiling(
+            BodyMode::SizeLimit { max_bytes: 8192 },
+            BodyMode::SizeLimit { max_bytes: 2048 },
+        );
+        assert_eq!(
+            clamped,
+            BodyMode::SizeLimit { max_bytes: 2048 },
+            "runtime SizeLimit should be clamped to baseline ceiling"
+        );
+    }
+
+    #[test]
+    fn clamp_body_mode_to_ceiling_no_ceiling_passes_through() {
+        let clamped = super::super::clamp_body_mode_to_ceiling(
+            BodyMode::StreamBuffer { max_bytes: Some(4096) },
+            BodyMode::StreamBuffer { max_bytes: None },
+        );
+        assert_eq!(
+            clamped,
+            BodyMode::StreamBuffer { max_bytes: Some(4096) },
+            "unbounded baseline imposes no ceiling; runtime mode passes through"
+        );
+    }
+
+    #[test]
+    fn clamp_body_mode_to_ceiling_within_limit_unchanged() {
+        let clamped = super::super::clamp_body_mode_to_ceiling(
+            BodyMode::StreamBuffer { max_bytes: Some(512) },
+            BodyMode::StreamBuffer { max_bytes: Some(1024) },
+        );
+        assert_eq!(
+            clamped,
+            BodyMode::StreamBuffer { max_bytes: Some(512) },
+            "runtime limit within baseline ceiling should be unchanged"
+        );
+    }
+
     // -------------------------------------------------------------------------
     // Test Utilities
     // -------------------------------------------------------------------------

--- a/protocol/src/http/pingora/handler/response_filter.rs
+++ b/protocol/src/http/pingora/handler/response_filter.rs
@@ -47,6 +47,7 @@ async fn run_response_pipeline(
     ctx: &mut PingoraRequestCtx,
     resp: &mut praxis_filter::Response,
 ) -> Result<(std::result::Result<FilterAction, praxis_filter::FilterError>, bool)> {
+    let baseline_response_body_mode = ctx.response_body_mode;
     let (r, headers_modified, response_body_mode, cluster, filter_metadata) = {
         let mut fctx = ctx.filter_context_for(pipeline, Some(resp)).ok_or_else(|| {
             pingora_core::Error::explain(
@@ -64,7 +65,7 @@ async fn run_response_pipeline(
         )
     };
     ctx.cluster = cluster;
-    ctx.response_body_mode = response_body_mode;
+    ctx.response_body_mode = super::clamp_body_mode_to_ceiling(response_body_mode, baseline_response_body_mode);
     ctx.filter_metadata = filter_metadata;
     Ok((r, headers_modified))
 }


### PR DESCRIPTION
## Summary

- **Largest-wins merge**: When multiple filters declare `StreamBuffer`, the pipeline now takes the largest `max_bytes` value instead of the smallest, so every filter gets enough buffer to do its job. `None` (unbounded) is treated as larger than any finite limit.
- **Runtime body mode clamping**: A new `clamp_body_mode_to_ceiling` helper ensures that runtime `set_*_body_mode` calls from filter hooks cannot widen limits beyond the baseline established at pipeline build time + global body limits. This preserves the safety ceiling even with the largest-wins merge.
- **Test updates**: All unit tests updated to reflect the new semantics; no integration test changes needed (496 integration tests pass).

The pipeline-level body ceiling (`apply_body_limits`) remains the hard safety cap for memory protection — individual filters express need, the pipeline enforces the bound.

## Test plan

- [x] All 1332 filter unit tests pass
- [x] All 496 integration tests pass
- [x] Full workspace build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)