### PR TITLE
chore: add pre-commit hook for fmt and lint

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,6 +14,7 @@ repository.
 ## Quick Reference
 
 ```console
+make setup-hooks    # install git pre-commit hook (fmt + lint)
 make build          # workspace build (includes benches + fuzz)
 make test           # all tests (downloads h2spec if needed)
 make fmt            # format with nightly rustfmt

--- a/.gitignore
+++ b/.gitignore
@@ -23,11 +23,12 @@ coverage.json
 # IDEs
 .idea/
 
-# Dotdirs (allow .github/ and .cargo/)
+# Dotdirs (allow .github/, .cargo/, and .hooks/)
 .*/
 !.cargo/
 !.github/
 !.claude/
+!.hooks/
 .claude/*
 !.claude/CLAUDE.md
 

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$(git config --get commit.gpgsign 2>/dev/null)" != "true" ]; then
+    echo "pre-commit: commit signing is not enabled"
+    echo "pre-commit: run: git config --global commit.gpgsign true"
+    exit 1
+fi
+
+echo "pre-commit: formatting..."
+make fmt
+
+echo "pre-commit: linting..."
+make lint
+
+echo "pre-commit: all checks passed"

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ endif
 	check-prereqs \
 	check-prereqs-cmake \
 	check-prereqs-nightly \
+	setup-hooks \
 	help
 
 # Uses --version rather than command -v so we catch broken installs.
@@ -222,6 +223,14 @@ coverage-check:
 		--output-path coverage.json
 
 # -------------------------------------------------------------------
+# Dev Setup
+# -------------------------------------------------------------------
+
+setup-hooks:
+	ln -sf ../../.hooks/pre-commit .git/hooks/pre-commit
+	@echo "Git hooks installed."
+
+# -------------------------------------------------------------------
 # Dev tools
 # -------------------------------------------------------------------
 
@@ -375,6 +384,9 @@ help:
 	@echo "Binutils (target/praxis-binutils/):"
 	@echo "  tools                download all external CLI tools"
 	@echo "  clean-tools          remove downloaded tools"
+	@echo ""
+	@echo "Dev Setup:"
+	@echo "  setup-hooks          install git pre-commit hook (fmt + lint)"
 	@echo ""
 	@echo "Dev tools:"
 	@echo "  run-echo             start echo server (xtask)"

--- a/docs/development.md
+++ b/docs/development.md
@@ -17,6 +17,18 @@ that do not follow these conventions will be rejected.
 
 [conventions.md]:./conventions.md
 
+## Setup
+
+Install git hooks so formatting and lint errors are
+caught before they reach CI:
+
+```console
+make setup-hooks
+```
+
+The pre-commit hook verifies commit signing is
+enabled, then runs `make fmt` and `make lint`.
+
 ## Build
 
 ```console


### PR DESCRIPTION
## Summary

- Adds a tracked `.hooks/pre-commit` script that verifies commit signing is enabled, then runs `make fmt` and `make lint`
- Adds `make setup-hooks` Makefile target to install the hook via symlink
- Documents setup in `docs/development.md` and `.claude/CLAUDE.md`
- Adds `.hooks/` exception to `.gitignore`

## Test plan

- [x] Ran `make setup-hooks` — symlink created
- [x] Pre-commit hook: signing check, fmt, and lint all passed
- [x] All CI checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)