### PR TITLE
fix(makefile): pin nightly toolchain version to match CI

### DIFF
--- a/.github/actions/install-nightly-rust/action.yml
+++ b/.github/actions/install-nightly-rust/action.yml
@@ -13,3 +13,13 @@ runs:
     - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly-2026-03-28 (rustc 1.96.0)
       with:
         components: ${{ inputs.components }}
+
+    - name: Register toolchain under date-pinned name
+      run: |
+        NIGHTLY=$(grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}' "${{ github.action_path }}/action.yml" | head -1)
+        if [ -n "${{ inputs.components }}" ]; then
+          rustup toolchain install "$NIGHTLY" --profile minimal --component "${{ inputs.components }}"
+        else
+          rustup toolchain install "$NIGHTLY" --profile minimal
+        fi
+      shell: bash

--- a/.github/actions/install-nightly-rust/action.yml
+++ b/.github/actions/install-nightly-rust/action.yml
@@ -1,0 +1,15 @@
+name: Install nightly Rust
+description: Install the pinned nightly Rust toolchain
+
+inputs:
+  components:
+    description: "Comma-separated list of components to install (e.g. rustfmt)"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly-2026-03-28 (rustc 1.96.0)
+      with:
+        components: ${{ inputs.components }}

--- a/.github/actions/install-nightly-rust/action.yml
+++ b/.github/actions/install-nightly-rust/action.yml
@@ -17,6 +17,10 @@ runs:
     - name: Register toolchain under date-pinned name
       run: |
         NIGHTLY=$(grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}' "${{ github.action_path }}/action.yml" | head -1)
+        if [ -z "$NIGHTLY" ]; then
+          echo "::error::Could not extract nightly version from action.yml"
+          exit 1
+        fi
         if [ -n "${{ inputs.components }}" ]; then
           rustup toolchain install "$NIGHTLY" --profile minimal --component "${{ inputs.components }}"
         else

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -18,3 +18,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: ".github/actions/install-nightly-rust"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -43,9 +43,6 @@ jobs:
       - name: Install nightly Rust
         uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly-2026-03-28 (rustc 1.96.0)
 
-      - name: Ensure nightly available under date-pinned name
-        run: rustup toolchain install "$(grep -m1 'rust-toolchain@' .github/workflows/tests.yaml | grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}')" --profile minimal
-
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
 

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -43,6 +43,9 @@ jobs:
       - name: Install nightly Rust
         uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly-2026-03-28 (rustc 1.96.0)
 
+      - name: Ensure nightly available under date-pinned name
+        run: rustup toolchain install "$(grep -m1 'rust-toolchain@' .github/workflows/tests.yaml | grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}')" --profile minimal
+
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
 

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install nightly Rust
-        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly-2026-03-28 (rustc 1.96.0)
+        uses: ./.github/actions/install-nightly-rust
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -35,6 +35,9 @@ jobs:
         with:
           components: rustfmt
 
+      - name: Ensure rustfmt for date-pinned nightly
+        run: rustup component add --toolchain "$(grep -m1 'rust-toolchain@' .github/workflows/tests.yaml | grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}')" rustfmt
+
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@10c3493d811a9096cee4fdf287e41e852f6a51ba # 1.94.0
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -36,7 +36,7 @@ jobs:
           components: rustfmt
 
       - name: Ensure rustfmt for date-pinned nightly
-        run: rustup component add --toolchain "$(grep -m1 'rust-toolchain@' .github/workflows/tests.yaml | grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}')" rustfmt
+        run: rustup component add --toolchain "$(grep -m1 'rust-toolchain@' .github/workflows/nightly.yaml | grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}')" rustfmt
 
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@10c3493d811a9096cee4fdf287e41e852f6a51ba # 1.94.0

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -35,9 +35,6 @@ jobs:
         with:
           components: rustfmt
 
-      - name: Ensure rustfmt for date-pinned nightly
-        run: rustup component add --toolchain "$(grep -m1 'rust-toolchain@' .github/workflows/nightly.yaml | grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}')" rustfmt
-
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@10c3493d811a9096cee4fdf287e41e852f6a51ba # 1.94.0
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install nightly Rust (for rustfmt)
-        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly-2026-03-28 (rustc 1.96.0)
+        uses: ./.github/actions/install-nightly-rust
         with:
           components: rustfmt
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install nightly Rust (for rustfmt)
-        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly-2026-03-28 (rustc 1.96.0)
+        uses: ./.github/actions/install-nightly-rust
         with:
           components: rustfmt
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,9 +44,6 @@ jobs:
         with:
           components: rustfmt
 
-      - name: Ensure rustfmt for date-pinned nightly
-        run: rustup component add --toolchain "$(grep -m1 'rust-toolchain@' .github/workflows/tests.yaml | grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}')" rustfmt
-
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@10c3493d811a9096cee4fdf287e41e852f6a51ba # 1.94.0
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,6 +44,9 @@ jobs:
         with:
           components: rustfmt
 
+      - name: Ensure rustfmt for date-pinned nightly
+        run: rustup component add --toolchain "$(grep -m1 'rust-toolchain@' .github/workflows/tests.yaml | grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}')" rustfmt
+
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@10c3493d811a9096cee4fdf287e41e852f6a51ba # 1.94.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 VERSION          ?= $(shell perl -ne 'print $$1 if /^version\s*=\s*"(.+)"/' Cargo.toml)
 IMAGE            ?= praxis
 CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
-NIGHTLY_VERSION  := $(shell grep -m1 'rust-toolchain@' .github/workflows/tests.yaml | grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}')
+NIGHTLY_VERSION  := $(shell grep -m1 'rust-toolchain@' .github/actions/install-nightly-rust/action.yml | grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}')
 V                ?=
 
 UNAME_S := $(shell uname -s | tr A-Z a-z)

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,10 @@ check-prereqs-cmake: check-prereqs
 		exit 1; \
 	}
 check-prereqs-nightly: check-prereqs
+	@test -n "$(NIGHTLY_VERSION)" || { \
+		echo "Could not determine NIGHTLY_VERSION from .github/actions/install-nightly-rust/action.yml" >&2; \
+		exit 1; \
+	}
 	@cargo +$(NIGHTLY_VERSION) --version >/dev/null 2>&1 || { \
 		echo "Rust $(NIGHTLY_VERSION) is not installed — run \"rustup toolchain install $(NIGHTLY_VERSION)\" (see docs/development.md)" >&2; \
 		exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 VERSION          ?= $(shell perl -ne 'print $$1 if /^version\s*=\s*"(.+)"/' Cargo.toml)
 IMAGE            ?= praxis
 CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
+NIGHTLY_VERSION  := $(shell grep -m1 'rust-toolchain@' .github/workflows/tests.yaml | grep -oE 'nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}')
 V                ?=
 
 UNAME_S := $(shell uname -s | tr A-Z a-z)
@@ -70,8 +71,8 @@ check-prereqs-cmake: check-prereqs
 		exit 1; \
 	}
 check-prereqs-nightly: check-prereqs
-	@cargo +nightly --version >/dev/null 2>&1 || { \
-		echo "Rust nightly toolchain is not installed — run \"rustup toolchain install nightly\" (see docs/development.md)" >&2; \
+	@cargo +$(NIGHTLY_VERSION) --version >/dev/null 2>&1 || { \
+		echo "Rust $(NIGHTLY_VERSION) is not installed — run \"rustup toolchain install $(NIGHTLY_VERSION)\" (see docs/development.md)" >&2; \
 		exit 1; \
 	}
 
@@ -182,13 +183,13 @@ bench: $(VEGETA) $(FORTIO_DEP)
 FUZZ_DURATION ?= 120
 
 fuzz:
-	cargo +nightly fuzz run --fuzz-dir tests/fuzz fuzz_sni -- -max_total_time=$(FUZZ_DURATION)
-	cargo +nightly fuzz run --fuzz-dir tests/fuzz fuzz_path_sanitize -- -max_total_time=$(FUZZ_DURATION)
-	cargo +nightly fuzz run --fuzz-dir tests/fuzz fuzz_config_parse -- -max_total_time=$(FUZZ_DURATION)
-	cargo +nightly fuzz run --fuzz-dir tests/fuzz fuzz_filter_pipeline -- -max_total_time=$(FUZZ_DURATION)
+	cargo +$(NIGHTLY_VERSION) fuzz run --fuzz-dir tests/fuzz fuzz_sni -- -max_total_time=$(FUZZ_DURATION)
+	cargo +$(NIGHTLY_VERSION) fuzz run --fuzz-dir tests/fuzz fuzz_path_sanitize -- -max_total_time=$(FUZZ_DURATION)
+	cargo +$(NIGHTLY_VERSION) fuzz run --fuzz-dir tests/fuzz fuzz_config_parse -- -max_total_time=$(FUZZ_DURATION)
+	cargo +$(NIGHTLY_VERSION) fuzz run --fuzz-dir tests/fuzz fuzz_filter_pipeline -- -max_total_time=$(FUZZ_DURATION)
 
 fuzz-build:
-	cargo +nightly fuzz build --fuzz-dir tests/fuzz
+	cargo +$(NIGHTLY_VERSION) fuzz build --fuzz-dir tests/fuzz
 
 # -------------------------------------------------------------------
 # Quality
@@ -196,11 +197,11 @@ fuzz-build:
 
 lint:
 	cargo clippy --workspace --all-targets -- -D warnings
-	cargo +nightly fmt --all -- --check
+	cargo +$(NIGHTLY_VERSION) fmt --all -- --check
 	cargo xtask lint-deps
 
 fmt:
-	cargo +nightly fmt --all
+	cargo +$(NIGHTLY_VERSION) fmt --all
 
 doc:
 	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items


### PR DESCRIPTION
## Summary

- Introduces a reusable composite action (`.github/actions/install-nightly-rust/action.yml`) that centralizes the nightly Rust toolchain installation — single source of truth for the pinned version
- The dtolnay/rust-toolchain action registers the toolchain as generic `nightly`; a second step reads the date from the action's own comment and re-registers it under the date-pinned name (e.g. `nightly-2026-03-28`) so `cargo +nightly-YYYY-MM-DD` works
- All workflows (tests, nightly, fuzz) now reference the composite action instead of duplicating the pinned SHA
- The Makefile extracts `NIGHTLY_VERSION` from the composite action file and uses `cargo +$(NIGHTLY_VERSION)` for all nightly commands (fmt, lint, fuzz)
- When the required nightly is not installed locally, the prerequisite check fails with the specific version and the `rustup` command to install it
- Dependabot continues to bump the nightly SHA in the composite action; the Makefile and the registration step both read from the updated comment automatically

## Test plan

- [ ] CI lint job passes (`cargo +nightly-2026-03-28 fmt --all -- --check`)
- [ ] CI fuzz job passes (`cargo +nightly-2026-03-28 fuzz run ...`)
- [ ] Run `make fmt` and `make lint` locally with the pinned nightly installed
- [ ] Verify `make -p 2>/dev/null | grep NIGHTLY_VERSION` resolves correctly
- [ ] Uninstall the pinned nightly and confirm `make fmt` fails with a helpful message

🤖 Generated with [Claude Code](https://claude.com/claude-code)