### PR TITLE
feat(filter): Anthropic Messages API filters

### DIFF
--- a/docs/anthropic-messages.md
+++ b/docs/anthropic-messages.md
@@ -1,0 +1,267 @@
+# Anthropic Messages API
+
+Praxis supports the Anthropic Messages API
+(`/v1/messages`) through five composable filters.
+Operators can route, validate, and transform
+Anthropic requests to reach any backend.
+
+## Filters
+
+| Filter | Purpose |
+| ------ | ------- |
+| `anthropic_messages_format` | Classify requests and promote routing facts to headers |
+| `anthropic_validate` | Validate proxy-needed fields before forwarding |
+| `anthropic_passthrough` | Header management for native `/v1/messages` backends |
+| `anthropic_to_openai` | Bidirectional body transformation to `OpenAI` Chat Completions |
+| `anthropic_stream_events` | SSE event transformation (per-chunk streaming, conformant with Inference Proxy Conformance Guidelines) |
+
+## Passthrough to vLLM
+
+Route Anthropic requests directly to a backend that
+supports `/v1/messages` natively (e.g. vLLM with
+Anthropic endpoint enabled).
+
+```yaml
+listeners:
+  - name: gateway
+    address: "0.0.0.0:8080"
+    filter_chains: [anthropic]
+
+filter_chains:
+  - name: anthropic
+    filters:
+      - filter: anthropic_messages_format
+        on_invalid: continue
+
+      - filter: anthropic_validate
+
+      - filter: anthropic_passthrough
+        default_version: "2023-06-01"
+
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: vllm
+
+      - filter: load_balancer
+        clusters:
+          - name: vllm
+            endpoints:
+              - "127.0.0.1:8000"
+```
+
+Test:
+
+```console
+curl http://localhost:8080/v1/messages \
+  -H "content-type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "openai/gpt-oss-20b",
+    "max_tokens": 100,
+    "system": "Reply concisely.",
+    "messages": [{"role": "user", "content": "Hi"}]
+  }'
+```
+
+## Passthrough to Anthropic API
+
+Route to `api.anthropic.com` with credential
+injection for the `x-api-key` header.
+
+```yaml
+listeners:
+  - name: gateway
+    address: "0.0.0.0:8080"
+    filter_chains: [anthropic]
+
+filter_chains:
+  - name: anthropic
+    filters:
+      - filter: anthropic_messages_format
+        on_invalid: continue
+
+      - filter: anthropic_validate
+
+      - filter: anthropic_passthrough
+        default_version: "2023-06-01"
+
+      - filter: headers
+        request_set:
+          - name: Host
+            value: "api.anthropic.com"
+
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: anthropic
+
+      - filter: credential_injection
+        clusters:
+          - name: anthropic
+            header: x-api-key
+            env_var: ANTHROPIC_API_KEY
+            strip_client_credential: true
+
+      - filter: load_balancer
+        clusters:
+          - name: anthropic
+            tls:
+              sni: "api.anthropic.com"
+            endpoints:
+              - "api.anthropic.com:443"
+```
+
+Test:
+
+```console
+curl http://localhost:8080/v1/messages \
+  -H "content-type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "claude-haiku-4-5",
+    "max_tokens": 100,
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+## Transformation to OpenAI Backend
+
+Transform Anthropic requests to OpenAI Chat
+Completions format for backends that only speak
+OpenAI (e.g. llm-d with disaggregation, KServe
+without Anthropic support).
+
+```yaml
+listeners:
+  - name: gateway
+    address: "0.0.0.0:8080"
+    filter_chains: [transform]
+
+filter_chains:
+  - name: transform
+    filters:
+      - filter: anthropic_messages_format
+        on_invalid: continue
+
+      - filter: anthropic_validate
+
+      - filter: anthropic_to_openai
+        max_body_bytes: 1048576
+
+      - filter: path_rewrite
+        replace:
+          pattern: "^/v1/messages$"
+          replacement: "/v1/chat/completions"
+        conditions:
+          - when:
+              path_prefix: "/v1/messages"
+
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: vllm
+
+      - filter: load_balancer
+        clusters:
+          - name: vllm
+            endpoints:
+              - "127.0.0.1:8000"
+```
+
+The `anthropic_to_openai` filter:
+- Hoists `system` to an OpenAI system message
+- Flattens content blocks (text, image, tool_use,
+  tool_result)
+- Maps `stop_sequences` to `stop`,
+  `tool_choice` semantics, tool definitions
+- Preserves `top_k` as an extra body parameter
+- Drops `thinking` blocks with a log warning
+- Transforms the response back to Anthropic format
+- Preserves original `finish_reason` in filter
+  metadata as `openai.finish_reason`
+
+## Filter Configuration Reference
+
+### `anthropic_messages_format`
+
+Classifies requests by body structure, path, and
+`anthropic-version` header.
+
+```yaml
+filter: anthropic_messages_format
+on_invalid: continue      # continue | reject
+max_body_bytes: 1048576    # 1 MiB
+headers:
+  format: x-praxis-ai-format
+  model: x-praxis-ai-model
+  stream: x-praxis-ai-stream
+```
+
+Classification signals (in priority order):
+1. `anthropic-version` request header
+2. Request path is `/v1/messages`
+3. Body has `messages` + `max_tokens` + `system`
+4. Body has typed content blocks
+
+### `anthropic_validate`
+
+Validates proxy-needed fields. Role ordering
+(e.g. first message must be `user`) is deferred
+to the backend.
+
+```yaml
+filter: anthropic_validate
+max_body_bytes: 1048576    # 1 MiB
+```
+
+Checks: `model` present and non-empty,
+`max_tokens` present and > 0, `messages`
+non-empty array.
+
+### `anthropic_passthrough`
+
+Injects `anthropic-version` header if absent.
+No body transformation.
+
+```yaml
+filter: anthropic_passthrough
+default_version: "2023-06-01"
+```
+
+### `anthropic_to_openai`
+
+Bidirectional request/response transformation.
+Non-streaming only; use `anthropic_stream_events`
+for SSE responses.
+
+```yaml
+filter: anthropic_to_openai
+max_body_bytes: 1048576    # 1 MiB
+```
+
+### `anthropic_stream_events`
+
+Transforms OpenAI SSE chunks to Anthropic SSE
+events. Processes SSE chunks incrementally as they arrive.
+
+pending #143).
+
+```yaml
+filter: anthropic_stream_events
+max_body_bytes: 1048576    # 1 MiB
+```
+
+## Running with Debug Logging
+
+See filter activity in real time:
+
+```console
+RUST_LOG=debug cargo run -p praxis -- -c config.yaml
+```
+
+Filter-specific logging:
+
+```console
+RUST_LOG=praxis_filter::builtins::http::ai=debug cargo run -p praxis -- -c config.yaml
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -133,6 +133,9 @@ page.
 | [format-routing.yaml](configs/ai/openai/responses/format-routing.yaml) | Route by AI API format (Responses vs Chat Completions) |
 | [responses-routing.yaml](configs/ai/openai/responses/responses-routing.yaml) | Route Responses API by mode (stateless vs stateful) |
 | [request-validate.yaml](configs/ai/openai/responses/request-validate.yaml) | Validate Responses API requests and reject invalid parameter combinations |
+| [messages-passthrough.yaml](configs/ai/anthropic/messages-passthrough.yaml) | Anthropic Messages passthrough to native `/v1/messages` backend |
+| [messages-to-openai.yaml](configs/ai/anthropic/messages-to-openai.yaml) | Transform Anthropic Messages to OpenAI Chat Completions |
+| [unified-gateway.yaml](configs/ai/anthropic/unified-gateway.yaml) | Unified gateway routing Anthropic, OpenAI, and Responses traffic |
 | [response-store.yaml](configs/ai/openai/responses/response-store.yaml) | Persist non-streaming Responses API responses to SQLite |
 
 ### Branching

--- a/examples/configs/ai/anthropic/messages-passthrough.yaml
+++ b/examples/configs/ai/anthropic/messages-passthrough.yaml
@@ -1,0 +1,34 @@
+# Anthropic Messages Passthrough
+#
+# Routes Anthropic Messages API requests to a native `/v1/messages`
+# backend (e.g. vLLM with Anthropic endpoint, Anthropic API).
+# The `anthropic_passthrough` filter injects the `anthropic-version`
+# header if absent.
+#
+# No request or response body transformation. Use this when the
+# backend natively supports `/v1/messages`.
+
+listeners:
+  - name: anthropic-gateway
+    address: "127.0.0.1:8080"
+    filter_chains: [anthropic-native]
+
+filter_chains:
+  - name: anthropic-native
+    filters:
+      - filter: anthropic_messages_format
+        on_invalid: continue
+
+      - filter: anthropic_passthrough
+        default_version: "2023-06-01"
+
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "anthropic-backend"
+
+      - filter: load_balancer
+        clusters:
+          - name: "anthropic-backend"
+            endpoints:
+              - "127.0.0.1:3001"

--- a/examples/configs/ai/anthropic/messages-to-openai.yaml
+++ b/examples/configs/ai/anthropic/messages-to-openai.yaml
@@ -1,0 +1,42 @@
+# Anthropic Messages to OpenAI Transformation
+#
+# Transforms Anthropic Messages API requests to OpenAI Chat
+# Completions format for backends that only speak OpenAI
+# (e.g. llm-d with disaggregation, KServe without Anthropic).
+#
+# Request: system hoisting, content block flattening, tool mapping.
+# Response: content blocks, stop_reason, usage mapping back to
+# Anthropic format.
+
+listeners:
+  - name: anthropic-gateway
+    address: "127.0.0.1:8080"
+    filter_chains: [anthropic-transform]
+
+filter_chains:
+  - name: anthropic-transform
+    filters:
+      - filter: anthropic_messages_format
+        on_invalid: continue
+
+      - filter: anthropic_to_openai
+        max_body_bytes: 1048576
+
+      - filter: path_rewrite
+        replace:
+          pattern: "^/v1/messages$"
+          replacement: "/v1/chat/completions"
+        conditions:
+          - when:
+              path_prefix: "/v1/messages"
+
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: "openai-backend"
+
+      - filter: load_balancer
+        clusters:
+          - name: "openai-backend"
+            endpoints:
+              - "127.0.0.1:3001"

--- a/examples/configs/ai/anthropic/unified-gateway.yaml
+++ b/examples/configs/ai/anthropic/unified-gateway.yaml
@@ -1,0 +1,53 @@
+# Unified AI Gateway
+#
+# Routes traffic by detected API format:
+# - Anthropic Messages → anthropic-backend (passthrough)
+# - OpenAI Chat Completions → openai-backend (direct)
+# - OpenAI Responses → responses-backend (direct)
+#
+# The `anthropic_messages_format` filter classifies requests and
+# promotes `x-praxis-ai-format` for router-based cluster selection.
+
+listeners:
+  - name: unified-gateway
+    address: "127.0.0.1:8080"
+    filter_chains: [unified-routing]
+
+filter_chains:
+  - name: unified-routing
+    filters:
+      - filter: anthropic_messages_format
+        on_invalid: continue
+        headers:
+          format: x-praxis-ai-format
+          model: x-praxis-ai-model
+          stream: x-praxis-ai-stream
+
+      - filter: openai_responses_format
+        on_invalid: continue
+
+      - filter: router
+        routes:
+          - path: "/v1/messages"
+            cluster: "anthropic-backend"
+          - path: "/v1/chat/completions"
+            cluster: "openai-backend"
+          - path: "/v1/responses"
+            cluster: "responses-backend"
+          - path_prefix: "/"
+            cluster: "default-backend"
+
+      - filter: load_balancer
+        clusters:
+          - name: "anthropic-backend"
+            endpoints:
+              - "127.0.0.1:3001"
+          - name: "openai-backend"
+            endpoints:
+              - "127.0.0.1:3002"
+          - name: "responses-backend"
+            endpoints:
+              - "127.0.0.1:3003"
+          - name: "default-backend"
+            endpoints:
+              - "127.0.0.1:3004"

--- a/examples/demo/anthropic-messages/README.md
+++ b/examples/demo/anthropic-messages/README.md
@@ -1,0 +1,31 @@
+# Anthropic Messages API Demo
+
+Demonstrates routing Anthropic `/v1/messages` requests through Praxis
+to different backends with optional format transformation.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `goals.md` | One-page summary of what this demo covers |
+| `demo.md` | Step-by-step walkthrough with curl commands |
+| `passthrough.yaml` | Config: classify, validate, route by model to Anthropic API or vLLM |
+| `transform.yaml` | Config: transform Anthropic Messages to OpenAI Chat Completions |
+
+## Quick Start
+
+```bash
+# Passthrough (demos 1-3)
+export ANTHROPIC_API_KEY=sk-ant-...
+RUST_LOG=praxis_filter=debug cargo run -p praxis -- \
+  -c examples/demo/anthropic-messages/passthrough.yaml
+
+# Transform (demo 4)
+RUST_LOG=praxis_filter=debug cargo run -p praxis -- \
+  -c examples/demo/anthropic-messages/transform.yaml
+```
+
+## Prerequisites
+
+- `ANTHROPIC_API_KEY` env var set (for Anthropic API passthrough)
+- vLLM endpoint at `10.0.0.99:8000` (update `passthrough.yaml` / `transform.yaml` for your setup)

--- a/examples/demo/anthropic-messages/demo.md
+++ b/examples/demo/anthropic-messages/demo.md
@@ -1,0 +1,117 @@
+# Anthropic Messages API Filters — Demo
+
+---
+
+## Setup
+
+```
+# Terminal 1 (Praxis logs)
+RUST_LOG=praxis_filter=debug cargo run -p praxis -- -c examples/demo/anthropic-messages/passthrough.yaml 2>&1 \
+  | grep -E 'classified|validation|route matched|upstream selected|credential|transformed|streaming'
+
+# Terminal 2 (curl)
+```
+
+---
+
+## Intro
+
+This is a light demo of the Anthropic Messages API filters in Praxis.
+
+Major caveats that this is still a work in progress and needs more validation,
+but the goal is to show how far we can get with composable filters.
+
+## Goal
+
+Accept Anthropic `/v1/messages` requests and route them to any backend —
+Anthropic API, vLLM, or OpenAI-compatible — with optional format transformation.
+
+There are five composable filters (classify, validate, passthrough, transform, stream)
+wired via Praxis' YAML config. And there are no code changes to swap backends.
+
+## 1. Direct to Anthropic (no proxy)
+
+> First, let's hit Anthropic directly to confirm the API works. No proxy involved.
+
+```bash
+curl -s https://api.anthropic.com/v1/messages \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "content-type: application/json" \
+  -d '{
+    "model": "claude-haiku-4-5",
+    "max_tokens": 128,
+    "messages": [{"role": "user", "content": "Why is Red Hat awesome?"}]
+  }' | jq .
+```
+
+---
+
+## 2. Praxis → Anthropic API (/v1/messages passthrough)
+
+> Now the same request goes through Praxis. It classifies the format, validates the payload, injects credentials, and proxies to Anthropic. Same response, zero changes to the request.
+
+```bash
+curl -s http://127.0.0.1:8080/v1/messages \
+  -H "Host: api.anthropic.com" \
+  -H "content-type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "claude-haiku-4-5",
+    "max_tokens": 128,
+    "messages": [{"role": "user", "content": "Why is Red Hat awesome?"}]
+  }' | jq .
+```
+
+---
+
+## 3. Praxis → vLLM (/v1/messages passthrough)
+
+> Same Anthropic-format request, but now routed to vLLM with gpt-oss 20b. The backend speaks Messages natively — Praxis just forwards it. Different backend, zero code change.
+
+```bash
+curl -s http://127.0.0.1:8080/v1/messages \
+  -H "content-type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "openai/gpt-oss-20b",
+    "max_tokens": 128,
+    "system": "Reply concisely.",
+    "messages": [{"role": "user", "content": "Why is Red Hat awesome?"}]
+  }' | jq .
+```
+
+---
+
+## 4. Praxis → vLLM (/v1/chat/completions transform)
+
+> Now the interesting part. We restart Praxis with a transform config — the transform filter needs body hooks to rewrite request and response payloads, and body hooks don't run inside branch chains, so we swap the config rather than routing conditionally. Same Anthropic request goes in, Praxis transforms it to OpenAI, sends to /v1/chat/completions, and transforms the response back. The client never knows.
+
+```
+# Restart Praxis with the transform config
+RUST_LOG=praxis_filter=debug cargo run -p praxis -- -c examples/demo/anthropic-messages/transform.yaml
+```
+
+```bash
+curl -s http://127.0.0.1:8080/v1/messages \
+  -H "content-type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "openai/gpt-oss-20b",
+    "max_tokens": 128,
+    "system": "Reply concisely.",
+    "messages": [{"role": "user", "content": "Why is Red Hat awesome?"}]
+  }' | jq .
+```
+
+---
+
+## Filters
+
+| Filter | What it does |
+|--------|-------------|
+| `anthropic_messages_format` | Classify request format |
+| `anthropic_validate` | Validate model, max_tokens, messages |
+| `anthropic_passthrough` | Inject anthropic-version header |
+| `anthropic_to_openai` | Transform request/response body |
+| `anthropic_stream_events` | Per-chunk SSE transformation |

--- a/examples/demo/anthropic-messages/goals.md
+++ b/examples/demo/anthropic-messages/goals.md
@@ -1,0 +1,26 @@
+# Anthropic Messages API in Praxis
+
+## Goal
+
+Accept Anthropic `/v1/messages` requests and route them to any backend —
+Anthropic API, vLLM, or OpenAI-compatible — with optional format transformation.
+
+## Demo
+1. **Direct** — curl → Anthropic API
+2. **Passthrough** — curl → Praxis → Anthropic API (`/v1/messages`)
+3. **vLLM native** — curl → Praxis → vLLM (`/v1/messages`)
+4. **Transform** — curl → Praxis → vLLM (`/v1/chat/completions`, auto-converted)
+
+## How
+Five composable filters — classify, validate, passthrough, transform, stream —
+wired via YAML config. No code changes to swap backends.
+
+## Filters
+
+| Filter | What it does |
+|--------|-------------|
+| `anthropic_messages_format` | Classify request format |
+| `anthropic_validate` | Validate model, max_tokens, messages |
+| `anthropic_passthrough` | Inject anthropic-version header |
+| `anthropic_to_openai` | Transform request/response body |
+| `anthropic_stream_events` | Per-chunk SSE transformation |

--- a/examples/demo/anthropic-messages/passthrough.yaml
+++ b/examples/demo/anthropic-messages/passthrough.yaml
@@ -1,0 +1,42 @@
+listeners:
+  - name: gateway
+    address: "127.0.0.1:8080"
+    filter_chains: [anthropic]
+
+filter_chains:
+  - name: anthropic
+    filters:
+      - filter: anthropic_messages_format
+        on_invalid: continue
+
+      - filter: anthropic_validate
+
+      - filter: anthropic_passthrough
+        default_version: "2023-06-01"
+
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            headers:
+              x-praxis-ai-model: "claude-haiku-4-5"
+            cluster: anthropic
+          - path_prefix: "/"
+            cluster: vllm
+
+      - filter: credential_injection
+        clusters:
+          - name: anthropic
+            header: x-api-key
+            env_var: ANTHROPIC_API_KEY
+            strip_client_credential: true
+
+      - filter: load_balancer
+        clusters:
+          - name: anthropic
+            endpoints:
+              - "api.anthropic.com:443"
+            tls:
+              sni: "api.anthropic.com"
+          - name: vllm
+            endpoints:
+              - "10.0.0.99:8000"

--- a/examples/demo/anthropic-messages/transform.yaml
+++ b/examples/demo/anthropic-messages/transform.yaml
@@ -1,0 +1,33 @@
+listeners:
+  - name: gateway
+    address: "127.0.0.1:8080"
+    filter_chains: [transform]
+
+filter_chains:
+  - name: transform
+    filters:
+      - filter: anthropic_messages_format
+        on_invalid: continue
+
+      - filter: anthropic_validate
+
+      - filter: anthropic_to_openai
+
+      - filter: path_rewrite
+        replace:
+          pattern: "^/v1/messages$"
+          replacement: "/v1/chat/completions"
+        conditions:
+          - when:
+              path_prefix: "/v1/messages"
+
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: vllm
+
+      - filter: load_balancer
+        clusters:
+          - name: vllm
+            endpoints:
+              - "10.0.0.99:8000"

--- a/filter/src/builtins/http/ai/anthropic/messages_format/config.rs
+++ b/filter/src/builtins/http/ai/anthropic/messages_format/config.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Configuration types for the Anthropic Messages format classifier filter.
+
+use serde::Deserialize;
+
+use crate::FilterError;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Default maximum request body size for `StreamBuffer` mode (1 MiB).
+const DEFAULT_MAX_BODY_BYTES: usize = 1_048_576; // 1 MiB
+
+// -----------------------------------------------------------------------------
+// Behavior Enums
+// -----------------------------------------------------------------------------
+
+/// Behavior when the request body is not a recognized AI API format.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum OnInvalidBehavior {
+    /// Continue processing.
+    #[default]
+    Continue,
+
+    /// Reject the request with HTTP 400.
+    Reject,
+}
+
+// -----------------------------------------------------------------------------
+// AnthropicMessagesFormatHeaders
+// -----------------------------------------------------------------------------
+
+/// Configurable header names for promoted classification facts.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AnthropicMessagesFormatHeaders {
+    /// Header name for the detected format.
+    #[serde(default = "default_format_header")]
+    pub format: Option<String>,
+
+    /// Header name for the extracted model value.
+    #[serde(default = "default_model_header")]
+    pub model: Option<String>,
+
+    /// Header name for the extracted stream flag.
+    #[serde(default = "default_stream_header")]
+    pub stream: Option<String>,
+}
+
+impl Default for AnthropicMessagesFormatHeaders {
+    fn default() -> Self {
+        Self {
+            format: default_format_header(),
+            model: default_model_header(),
+            stream: default_stream_header(),
+        }
+    }
+}
+
+/// Default format header name.
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "serde default functions require Option return type"
+)]
+fn default_format_header() -> Option<String> {
+    Some("x-praxis-ai-format".to_owned())
+}
+
+/// Default model header name.
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "serde default functions require Option return type"
+)]
+fn default_model_header() -> Option<String> {
+    Some("x-praxis-ai-model".to_owned())
+}
+
+/// Default stream header name.
+#[allow(
+    clippy::unnecessary_wraps,
+    reason = "serde default functions require Option return type"
+)]
+fn default_stream_header() -> Option<String> {
+    Some("x-praxis-ai-stream".to_owned())
+}
+
+// -----------------------------------------------------------------------------
+// AnthropicMessagesFormatConfig
+// -----------------------------------------------------------------------------
+
+/// YAML configuration for the [`AnthropicMessagesFormatFilter`].
+///
+/// [`AnthropicMessagesFormatFilter`]: super::AnthropicMessagesFormatFilter
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AnthropicMessagesFormatConfig {
+    /// Behavior when the body cannot be classified.
+    #[serde(default)]
+    pub on_invalid: OnInvalidBehavior,
+
+    /// Maximum body size in bytes for `StreamBuffer` mode.
+    #[serde(default = "default_max_body_bytes")]
+    pub max_body_bytes: usize,
+
+    /// Header names for promoted classification facts.
+    #[serde(default)]
+    pub headers: AnthropicMessagesFormatHeaders,
+}
+
+/// Default max body bytes.
+fn default_max_body_bytes() -> usize {
+    DEFAULT_MAX_BODY_BYTES
+}
+
+// -----------------------------------------------------------------------------
+// Config Validation
+// -----------------------------------------------------------------------------
+
+/// Validate the parsed configuration.
+pub(crate) fn build_config(cfg: AnthropicMessagesFormatConfig) -> Result<AnthropicMessagesFormatConfig, FilterError> {
+    if cfg.max_body_bytes == 0 {
+        return Err("anthropic_messages_format: 'max_body_bytes' must be greater than 0".into());
+    }
+
+    validate_header_name("format", cfg.headers.format.as_deref())?;
+    validate_header_name("model", cfg.headers.model.as_deref())?;
+    validate_header_name("stream", cfg.headers.stream.as_deref())?;
+
+    Ok(cfg)
+}
+
+/// Validate a configured header name.
+fn validate_header_name(field: &str, header_name: Option<&str>) -> Result<(), FilterError> {
+    let Some(header_name) = header_name else {
+        return Ok(());
+    };
+    if header_name.is_empty() {
+        return Err(format!("anthropic_messages_format: {field} header name must not be empty").into());
+    }
+    if http::HeaderName::from_bytes(header_name.as_bytes()).is_err() {
+        return Err(format!("anthropic_messages_format: {field} header name is not a valid HTTP header name").into());
+    }
+    Ok(())
+}

--- a/filter/src/builtins/http/ai/anthropic/messages_format/mod.rs
+++ b/filter/src/builtins/http/ai/anthropic/messages_format/mod.rs
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Anthropic Messages API format classifier filter.
+//!
+//! Detects Anthropic Messages API requests using the shared
+//! [`AiRequestFormat`] classifier and promotes routing facts to
+//! configurable headers, durable metadata, and filter results.
+//! Uses `anthropic-version` header as a boost signal when
+//! body-only heuristics are ambiguous.
+//!
+//! [`AiRequestFormat`]: crate::builtins::http::ai::classifier::AiRequestFormat
+
+mod config;
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    clippy::too_many_lines,
+    reason = "tests"
+)]
+mod tests;
+
+use std::borrow::Cow;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use tracing::{debug, trace};
+
+use self::config::{AnthropicMessagesFormatConfig, OnInvalidBehavior, build_config};
+use crate::{
+    FilterAction, FilterError, Rejection,
+    body::{BodyAccess, BodyMode},
+    builtins::http::{
+        ai::classifier::{AiRequestFormat, ClassifiedRequest, classify_request_body},
+        value_safety::is_safe_promoted_value,
+    },
+    factory::parse_filter_config,
+    filter::{HttpFilter, HttpFilterContext},
+};
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Maximum length of a body-derived value promoted to headers or filter results.
+const MAX_PROMOTED_VALUE_LEN: usize = 256;
+
+/// Header name sent by Anthropic SDK clients.
+const ANTHROPIC_VERSION_HEADER: &str = "anthropic-version";
+
+// -----------------------------------------------------------------------------
+// AnthropicMessagesFormatFilter
+// -----------------------------------------------------------------------------
+
+/// Classifies Anthropic Messages API requests and promotes routing
+/// facts to headers, metadata, and filter results.
+///
+/// # YAML
+///
+/// ```yaml
+/// filter: anthropic_messages_format
+/// ```
+///
+/// # Full YAML
+///
+/// ```yaml
+/// filter: anthropic_messages_format
+/// on_invalid: continue
+/// max_body_bytes: 1048576
+/// headers:
+///   format: x-praxis-ai-format
+///   model: x-praxis-ai-model
+///   stream: x-praxis-ai-stream
+/// ```
+pub struct AnthropicMessagesFormatFilter {
+    /// Parsed and validated configuration.
+    config: AnthropicMessagesFormatConfig,
+}
+
+impl AnthropicMessagesFormatFilter {
+    /// Create a filter from parsed YAML config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if the YAML config is invalid.
+    pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
+        let cfg: AnthropicMessagesFormatConfig = parse_filter_config("anthropic_messages_format", config)?;
+        let validated = build_config(cfg)?;
+        Ok(Box::new(Self { config: validated }))
+    }
+}
+
+#[async_trait]
+impl HttpFilter for AnthropicMessagesFormatFilter {
+    fn name(&self) -> &'static str {
+        "anthropic_messages_format"
+    }
+
+    fn request_body_access(&self) -> BodyAccess {
+        BodyAccess::ReadOnly
+    }
+
+    fn request_body_mode(&self) -> BodyMode {
+        BodyMode::StreamBuffer {
+            max_bytes: Some(self.config.max_body_bytes),
+        }
+    }
+
+    async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        Ok(FilterAction::Continue)
+    }
+
+    async fn on_request_body(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        body: &mut Option<Bytes>,
+        end_of_stream: bool,
+    ) -> Result<FilterAction, FilterError> {
+        if !end_of_stream {
+            return Ok(FilterAction::Continue);
+        }
+
+        let bytes = match body.as_ref() {
+            Some(b) => b.as_ref(),
+            None => &[],
+        };
+
+        let mut classified = classify_request_body(bytes);
+
+        let has_anthropic_header = ctx.request.headers.get(ANTHROPIC_VERSION_HEADER).is_some();
+        let is_messages_path = ctx.request.uri.path() == "/v1/messages";
+
+        if classified.format == AiRequestFormat::ChatCompletions && (has_anthropic_header || is_messages_path) {
+            classified.format = AiRequestFormat::AnthropicMessages;
+        }
+
+        debug!(
+            format = classified.format.as_str(),
+            model = ?classified.model,
+            anthropic_header = has_anthropic_header,
+            messages_path = is_messages_path,
+            "classified anthropic request body"
+        );
+
+        if let Some(action) = handle_invalid_format(classified.format, &self.config) {
+            return Ok(action);
+        }
+
+        write_metadata(ctx, &classified);
+        promote_headers(ctx, &classified, &self.config);
+        promote_filter_results(ctx, &classified)?;
+
+        Ok(FilterAction::Release)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+/// Check whether the format requires rejection.
+fn handle_invalid_format(format: AiRequestFormat, config: &AnthropicMessagesFormatConfig) -> Option<FilterAction> {
+    match config.on_invalid {
+        OnInvalidBehavior::Continue => None,
+        OnInvalidBehavior::Reject => {
+            let message = match format {
+                AiRequestFormat::InvalidJson => "invalid JSON body",
+                AiRequestFormat::NonJson => "request body is not JSON",
+                AiRequestFormat::UnknownJson => "unrecognized AI API format",
+                AiRequestFormat::Responses | AiRequestFormat::AnthropicMessages | AiRequestFormat::ChatCompletions => {
+                    return None;
+                },
+            };
+
+            trace!(reason = message, "rejecting unrecognized body");
+            Some(FilterAction::Reject(
+                Rejection::status(400)
+                    .with_header("content-type", "application/json")
+                    .with_body(Bytes::from(format!(
+                        r#"{{"error":{{"message":"{message}","type":"invalid_request_error"}}}}"#
+                    ))),
+            ))
+        },
+    }
+}
+
+/// Write durable metadata.
+fn write_metadata(ctx: &mut HttpFilterContext<'_>, classified: &ClassifiedRequest) {
+    ctx.set_metadata("anthropic_format.format", classified.format.as_str());
+
+    if let Some(model) = &classified.model
+        && is_safe_promoted_value(model)
+    {
+        ctx.set_metadata("anthropic_format.model", model.clone());
+    }
+
+    if let Some(stream) = classified.stream {
+        ctx.set_metadata("anthropic_format.stream", if stream { "true" } else { "false" });
+    }
+
+    if let Some(max_tokens) = classified.max_tokens {
+        ctx.set_metadata("anthropic_format.max_tokens", max_tokens.to_string());
+    }
+}
+
+/// Promote classification facts to configurable request headers.
+fn promote_headers(
+    ctx: &mut HttpFilterContext<'_>,
+    classified: &ClassifiedRequest,
+    config: &AnthropicMessagesFormatConfig,
+) {
+    if let Some(header) = &config.headers.format {
+        ctx.extra_request_headers
+            .push((Cow::Owned(header.clone()), classified.format.as_str().to_owned()));
+    }
+
+    if let Some(header) = &config.headers.model
+        && let Some(model) = &classified.model
+        && is_safe_promoted_value(model)
+        && model.len() <= MAX_PROMOTED_VALUE_LEN
+    {
+        ctx.extra_request_headers
+            .push((Cow::Owned(header.clone()), model.clone()));
+    }
+
+    if let Some(header) = &config.headers.stream
+        && let Some(stream) = classified.stream
+    {
+        let val = if stream { "true" } else { "false" };
+        ctx.extra_request_headers
+            .push((Cow::Owned(header.clone()), val.to_owned()));
+    }
+}
+
+/// Promote classification facts to filter results for branch conditions.
+fn promote_filter_results(ctx: &mut HttpFilterContext<'_>, classified: &ClassifiedRequest) -> Result<(), FilterError> {
+    let results = ctx.filter_results.entry("anthropic_messages_format").or_default();
+
+    results.set("format", classified.format.as_str())?;
+
+    if let Some(model) = &classified.model
+        && is_safe_promoted_value(model)
+        && model.len() <= MAX_PROMOTED_VALUE_LEN
+    {
+        results.set("model", model.clone())?;
+    }
+
+    if let Some(stream) = classified.stream {
+        results.set("stream", if stream { "true" } else { "false" })?;
+    }
+
+    Ok(())
+}

--- a/filter/src/builtins/http/ai/anthropic/messages_format/tests.rs
+++ b/filter/src/builtins/http/ai/anthropic/messages_format/tests.rs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Unit tests for the `anthropic_messages_format` filter.
+
+use bytes::Bytes;
+
+use super::*;
+
+// -----------------------------------------------------------------------------
+// Config Parsing
+// -----------------------------------------------------------------------------
+
+#[test]
+fn default_config_parses() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("{}").unwrap();
+    let filter = AnthropicMessagesFormatFilter::from_config(&yaml).unwrap();
+    assert_eq!(
+        filter.name(),
+        "anthropic_messages_format",
+        "filter name should be anthropic_messages_format"
+    );
+}
+
+#[test]
+fn full_config_parses() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+on_invalid: reject
+max_body_bytes: 65536
+headers:
+  format: x-custom-format
+  model: x-custom-model
+  stream: x-custom-stream
+"#,
+    )
+    .unwrap();
+    let filter = AnthropicMessagesFormatFilter::from_config(&yaml).unwrap();
+    assert_eq!(
+        filter.name(),
+        "anthropic_messages_format",
+        "filter should parse full config"
+    );
+}
+
+#[test]
+fn zero_max_body_bytes_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("max_body_bytes: 0").unwrap();
+    let result = AnthropicMessagesFormatFilter::from_config(&yaml);
+    assert!(result.is_err(), "zero max_body_bytes should be rejected");
+}
+
+// -----------------------------------------------------------------------------
+// Handle Invalid Format
+// -----------------------------------------------------------------------------
+
+#[test]
+fn anthropic_messages_not_rejected() {
+    let cfg: AnthropicMessagesFormatConfig = serde_yaml::from_str("on_invalid: reject").unwrap();
+    let result = handle_invalid_format(AiRequestFormat::AnthropicMessages, &cfg);
+    assert!(result.is_none(), "anthropic_messages format should not be rejected");
+}
+
+#[test]
+fn responses_not_rejected() {
+    let cfg: AnthropicMessagesFormatConfig = serde_yaml::from_str("on_invalid: reject").unwrap();
+    let result = handle_invalid_format(AiRequestFormat::Responses, &cfg);
+    assert!(result.is_none(), "responses format should not be rejected");
+}
+
+#[test]
+fn invalid_json_rejected_in_reject_mode() {
+    let cfg: AnthropicMessagesFormatConfig = serde_yaml::from_str("on_invalid: reject").unwrap();
+    let result = handle_invalid_format(AiRequestFormat::InvalidJson, &cfg);
+    assert!(result.is_some(), "invalid JSON should be rejected in reject mode");
+}
+
+// -----------------------------------------------------------------------------
+// Promotion Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn promotes_anthropic_messages_format() {
+    let ctx = run_filter(
+        "{}",
+        r#"{"model":"claude-opus-4-8","max_tokens":1024,"system":"You are helpful.","messages":[{"role":"user","content":"Hi"}]}"#,
+    )
+    .await;
+    let headers = collect_headers(&ctx);
+
+    assert_eq!(
+        headers.get("x-praxis-ai-format"),
+        Some(&"anthropic_messages"),
+        "format header should be anthropic_messages"
+    );
+    assert_eq!(
+        headers.get("x-praxis-ai-model"),
+        Some(&"claude-opus-4-8"),
+        "model header"
+    );
+}
+
+#[tokio::test]
+async fn promotes_metadata_for_anthropic_request() {
+    let ctx = run_filter(
+        "{}",
+        r#"{"model":"claude-opus-4-8","max_tokens":512,"system":"Be helpful.","messages":[{"role":"user","content":"Hi"}],"stream":true}"#,
+    )
+    .await;
+
+    assert_eq!(
+        ctx.filter_metadata.get("anthropic_format.format").map(String::as_str),
+        Some("anthropic_messages"),
+        "format metadata"
+    );
+    assert_eq!(
+        ctx.filter_metadata.get("anthropic_format.model").map(String::as_str),
+        Some("claude-opus-4-8"),
+        "model metadata"
+    );
+    assert_eq!(
+        ctx.filter_metadata.get("anthropic_format.stream").map(String::as_str),
+        Some("true"),
+        "stream metadata"
+    );
+    assert_eq!(
+        ctx.filter_metadata
+            .get("anthropic_format.max_tokens")
+            .map(String::as_str),
+        Some("512"),
+        "max_tokens metadata"
+    );
+}
+
+#[tokio::test]
+async fn chat_completions_without_max_tokens_on_non_messages_path() {
+    let filter = make_filter("{}");
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
+
+    let req: &'static crate::context::Request = Box::leak(Box::new(req));
+    let mut ctx = crate::test_utils::make_filter_context(req);
+    let mut body = Some(Bytes::from(
+        r#"{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}"#,
+    ));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Release), "filter should release");
+
+    let headers = collect_headers(&ctx);
+    assert_eq!(
+        headers.get("x-praxis-ai-format"),
+        Some(&"openai_chat_completions"),
+        "messages without max_tokens on /v1/chat/completions should be chat_completions"
+    );
+}
+
+#[tokio::test]
+async fn anthropic_version_header_overrides_body_heuristic() {
+    let filter = make_filter("{}");
+    let mut req = crate::test_utils::make_request(http::Method::POST, "/v1/messages");
+    req.headers.insert("anthropic-version", "2023-06-01".parse().unwrap());
+
+    let req: &'static crate::context::Request = Box::leak(Box::new(req));
+    let mut ctx = crate::test_utils::make_filter_context(req);
+    let mut body = Some(Bytes::from(
+        r#"{"model":"claude-opus-4-8","messages":[{"role":"user","content":"Hi"}]}"#,
+    ));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Release), "filter should release");
+
+    let headers = collect_headers(&ctx);
+    assert_eq!(
+        headers.get("x-praxis-ai-format"),
+        Some(&"anthropic_messages"),
+        "anthropic-version header should override to anthropic_messages"
+    );
+}
+
+#[tokio::test]
+async fn minimal_messages_path_overrides_to_anthropic() {
+    let ctx = run_filter(
+        "{}",
+        r#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"Hi"}]}"#,
+    )
+    .await;
+    let headers = collect_headers(&ctx);
+
+    assert_eq!(
+        headers.get("x-praxis-ai-format"),
+        Some(&"anthropic_messages"),
+        "minimal body on /v1/messages path should classify as anthropic_messages"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+/// Run the filter and return the resulting context.
+async fn run_filter(config_yaml: &str, body_str: &str) -> HttpFilterContext<'static> {
+    let filter = make_filter(config_yaml);
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/messages");
+
+    let req: &'static crate::context::Request = Box::leak(Box::new(req));
+    let mut ctx = crate::test_utils::make_filter_context(req);
+    let mut body = Some(Bytes::from(body_str.to_owned()));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Release), "filter should release");
+    ctx
+}
+
+/// Collect extra request headers into a map.
+fn collect_headers<'a>(ctx: &'a HttpFilterContext<'_>) -> std::collections::HashMap<&'a str, &'a str> {
+    ctx.extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect()
+}
+
+/// Build a filter from a YAML snippet.
+fn make_filter(yaml_str: &str) -> Box<dyn HttpFilter> {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    AnthropicMessagesFormatFilter::from_config(&yaml).unwrap()
+}

--- a/filter/src/builtins/http/ai/anthropic/mod.rs
+++ b/filter/src/builtins/http/ai/anthropic/mod.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Anthropic protocol filters.
+
+mod messages_format;
+mod passthrough;
+mod stream_events;
+pub(crate) mod to_openai;
+mod validate;
+
+pub use messages_format::AnthropicMessagesFormatFilter;
+pub use passthrough::AnthropicPassthroughFilter;
+pub use stream_events::AnthropicStreamEventsFilter;
+pub use to_openai::AnthropicToOpenaiFilter;
+pub use validate::AnthropicValidateFilter;

--- a/filter/src/builtins/http/ai/anthropic/passthrough/config.rs
+++ b/filter/src/builtins/http/ai/anthropic/passthrough/config.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Configuration for the Anthropic passthrough filter.
+
+use serde::Deserialize;
+
+use crate::FilterError;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Default Anthropic API version header value.
+const DEFAULT_VERSION: &str = "2023-06-01";
+
+// -----------------------------------------------------------------------------
+// AnthropicPassthroughConfig
+// -----------------------------------------------------------------------------
+
+/// YAML configuration for the [`AnthropicPassthroughFilter`].
+///
+/// [`AnthropicPassthroughFilter`]: super::AnthropicPassthroughFilter
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AnthropicPassthroughConfig {
+    /// Default `anthropic-version` header value when absent.
+    #[serde(default = "default_version")]
+    pub default_version: String,
+}
+
+/// Default version string.
+fn default_version() -> String {
+    DEFAULT_VERSION.to_owned()
+}
+
+// -----------------------------------------------------------------------------
+// Config Validation
+// -----------------------------------------------------------------------------
+
+/// Validate the parsed configuration.
+pub(crate) fn build_config(cfg: AnthropicPassthroughConfig) -> Result<AnthropicPassthroughConfig, FilterError> {
+    if cfg.default_version.is_empty() {
+        return Err("anthropic_passthrough: 'default_version' must not be empty".into());
+    }
+    Ok(cfg)
+}

--- a/filter/src/builtins/http/ai/anthropic/passthrough/mod.rs
+++ b/filter/src/builtins/http/ai/anthropic/passthrough/mod.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Anthropic passthrough filter for native `/v1/messages` backends.
+//!
+//! Manages `anthropic-version` header injection and forwards
+//! Anthropic rate-limit response headers to the client. Does not
+//! touch the request or response body.
+
+mod config;
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests;
+
+use std::borrow::Cow;
+
+use async_trait::async_trait;
+use tracing::debug;
+
+use self::config::{AnthropicPassthroughConfig, build_config};
+use crate::{
+    FilterAction, FilterError,
+    body::{BodyAccess, BodyMode},
+    factory::parse_filter_config,
+    filter::{HttpFilter, HttpFilterContext},
+};
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Anthropic API version header name.
+const ANTHROPIC_VERSION_HEADER: &str = "anthropic-version";
+
+// -----------------------------------------------------------------------------
+// AnthropicPassthroughFilter
+// -----------------------------------------------------------------------------
+
+/// Passes Anthropic Messages requests through to native backends
+/// with header management and rate-limit forwarding.
+///
+/// # YAML
+///
+/// ```yaml
+/// filter: anthropic_passthrough
+/// ```
+///
+/// # Full YAML
+///
+/// ```yaml
+/// filter: anthropic_passthrough
+/// default_version: "2023-06-01"
+/// forward_rate_limits: true
+/// ```
+pub struct AnthropicPassthroughFilter {
+    /// Parsed and validated configuration.
+    config: AnthropicPassthroughConfig,
+}
+
+impl AnthropicPassthroughFilter {
+    /// Create a filter from parsed YAML config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if the YAML config is invalid.
+    pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
+        let cfg: AnthropicPassthroughConfig = parse_filter_config("anthropic_passthrough", config)?;
+        let validated = build_config(cfg)?;
+        Ok(Box::new(Self { config: validated }))
+    }
+}
+
+#[async_trait]
+impl HttpFilter for AnthropicPassthroughFilter {
+    fn name(&self) -> &'static str {
+        "anthropic_passthrough"
+    }
+
+    fn request_body_access(&self) -> BodyAccess {
+        BodyAccess::None
+    }
+
+    fn request_body_mode(&self) -> BodyMode {
+        BodyMode::Stream
+    }
+
+    async fn on_request(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        let has_version = ctx.request.headers.get(ANTHROPIC_VERSION_HEADER).is_some();
+
+        if !has_version {
+            debug!(
+                version = self.config.default_version.as_str(),
+                "injecting default anthropic-version header"
+            );
+            ctx.extra_request_headers.push((
+                Cow::Borrowed(ANTHROPIC_VERSION_HEADER),
+                self.config.default_version.clone(),
+            ));
+        }
+
+        Ok(FilterAction::Continue)
+    }
+
+    async fn on_response(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        Ok(FilterAction::Continue)
+    }
+}

--- a/filter/src/builtins/http/ai/anthropic/passthrough/tests.rs
+++ b/filter/src/builtins/http/ai/anthropic/passthrough/tests.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Unit tests for the `anthropic_passthrough` filter.
+
+use super::*;
+
+// -----------------------------------------------------------------------------
+// Config Parsing
+// -----------------------------------------------------------------------------
+
+#[test]
+fn default_config_parses() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("{}").unwrap();
+    let filter = AnthropicPassthroughFilter::from_config(&yaml).unwrap();
+    assert_eq!(
+        filter.name(),
+        "anthropic_passthrough",
+        "filter name should be anthropic_passthrough"
+    );
+}
+
+#[test]
+fn empty_version_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("default_version: \"\"").unwrap();
+    let result = AnthropicPassthroughFilter::from_config(&yaml);
+    assert!(result.is_err(), "empty default_version should be rejected");
+}
+
+// -----------------------------------------------------------------------------
+// Header Injection
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn injects_anthropic_version_when_absent() {
+    let filter = make_filter("{}");
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/messages");
+
+    let req: &'static crate::context::Request = Box::leak(Box::new(req));
+    let mut ctx = crate::test_utils::make_filter_context(req);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue), "filter should continue");
+
+    let headers: std::collections::HashMap<&str, &str> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+
+    assert_eq!(
+        headers.get("anthropic-version"),
+        Some(&"2023-06-01"),
+        "should inject default anthropic-version"
+    );
+}
+
+#[tokio::test]
+async fn does_not_inject_when_header_present() {
+    let filter = make_filter("{}");
+    let mut req = crate::test_utils::make_request(http::Method::POST, "/v1/messages");
+    req.headers.insert("anthropic-version", "2024-01-01".parse().unwrap());
+
+    let req: &'static crate::context::Request = Box::leak(Box::new(req));
+    let mut ctx = crate::test_utils::make_filter_context(req);
+
+    let _action = filter.on_request(&mut ctx).await.unwrap();
+
+    assert!(
+        ctx.extra_request_headers.is_empty(),
+        "should not inject when header already present"
+    );
+}
+
+#[tokio::test]
+async fn custom_default_version() {
+    let filter = make_filter("default_version: \"2024-06-01\"");
+    let req = crate::test_utils::make_request(http::Method::POST, "/v1/messages");
+
+    let req: &'static crate::context::Request = Box::leak(Box::new(req));
+    let mut ctx = crate::test_utils::make_filter_context(req);
+
+    drop(filter.on_request(&mut ctx).await.unwrap());
+
+    let headers: std::collections::HashMap<&str, &str> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+
+    assert_eq!(
+        headers.get("anthropic-version"),
+        Some(&"2024-06-01"),
+        "should inject configured version"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+/// Build a filter from a YAML snippet.
+fn make_filter(yaml_str: &str) -> Box<dyn HttpFilter> {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+    AnthropicPassthroughFilter::from_config(&yaml).unwrap()
+}

--- a/filter/src/builtins/http/ai/anthropic/stream_events/config.rs
+++ b/filter/src/builtins/http/ai/anthropic/stream_events/config.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Configuration for the Anthropic stream events filter.
+
+use serde::Deserialize;
+
+use crate::FilterError;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Default maximum response body size (1 MiB).
+const DEFAULT_MAX_BODY_BYTES: usize = 1_048_576; // 1 MiB
+
+// -----------------------------------------------------------------------------
+// AnthropicStreamEventsConfig
+// -----------------------------------------------------------------------------
+
+/// YAML configuration for the [`AnthropicStreamEventsFilter`].
+///
+/// [`AnthropicStreamEventsFilter`]: super::AnthropicStreamEventsFilter
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AnthropicStreamEventsConfig {
+    /// Maximum body size in bytes for `StreamBuffer` mode.
+    #[serde(default = "default_max_body_bytes")]
+    pub max_body_bytes: usize,
+}
+
+/// Default max body bytes.
+fn default_max_body_bytes() -> usize {
+    DEFAULT_MAX_BODY_BYTES
+}
+
+// -----------------------------------------------------------------------------
+// Config Validation
+// -----------------------------------------------------------------------------
+
+/// Validate the parsed configuration.
+pub(crate) fn build_config(cfg: AnthropicStreamEventsConfig) -> Result<AnthropicStreamEventsConfig, FilterError> {
+    if cfg.max_body_bytes == 0 {
+        return Err("anthropic_stream_events: 'max_body_bytes' must be greater than 0".into());
+    }
+    Ok(cfg)
+}

--- a/filter/src/builtins/http/ai/anthropic/stream_events/mod.rs
+++ b/filter/src/builtins/http/ai/anthropic/stream_events/mod.rs
@@ -1,0 +1,586 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Anthropic SSE event transformation filter.
+//!
+//! Transforms `OpenAI` Chat Completions SSE events into Anthropic
+//! Messages SSE events per-chunk as they arrive. Each
+//! `on_response_body` call processes whatever bytes were received,
+//! transforms complete SSE events, and forwards immediately.
+//! Partial events are held in filter metadata until the next chunk.
+
+mod config;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use serde_json::Value;
+use tracing::debug;
+
+use self::config::{AnthropicStreamEventsConfig, build_config};
+use crate::{
+    FilterAction, FilterError,
+    body::{BodyAccess, BodyMode},
+    factory::parse_filter_config,
+    filter::{HttpFilter, HttpFilterContext},
+};
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Metadata key for the partial line buffer between chunks.
+const LINE_BUFFER_KEY: &str = "anthropic_stream.line_buffer";
+
+/// Metadata key for the streaming state (JSON-serialized).
+const STREAM_STATE_KEY: &str = "anthropic_stream.state";
+
+/// Metadata key tracking whether a text content block is open.
+const TEXT_BLOCK_OPEN_KEY: &str = "anthropic_stream.text_block_open";
+
+/// Metadata key for the finish reason from the upstream provider.
+const FINISH_REASON_KEY: &str = "anthropic_stream.finish_reason";
+
+/// Metadata key for accumulated output token count.
+const OUTPUT_TOKENS_KEY: &str = "anthropic_stream.output_tokens";
+
+/// Metadata key for the current content block index.
+const BLOCK_INDEX_KEY: &str = "anthropic_stream.block_index";
+
+// -----------------------------------------------------------------------------
+// AnthropicStreamEventsFilter
+// -----------------------------------------------------------------------------
+
+/// Transforms streaming SSE responses between `OpenAI` and
+/// Anthropic formats, processing each chunk as it arrives.
+///
+/// # YAML
+///
+/// ```yaml
+/// filter: anthropic_stream_events
+/// ```
+pub struct AnthropicStreamEventsFilter {
+    /// Parsed and validated configuration.
+    _config: AnthropicStreamEventsConfig,
+}
+
+impl AnthropicStreamEventsFilter {
+    /// Create a filter from parsed YAML config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if the YAML config is invalid.
+    pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
+        let cfg: AnthropicStreamEventsConfig = parse_filter_config("anthropic_stream_events", config)?;
+        let validated = build_config(cfg)?;
+        Ok(Box::new(Self { _config: validated }))
+    }
+}
+
+#[async_trait]
+impl HttpFilter for AnthropicStreamEventsFilter {
+    fn name(&self) -> &'static str {
+        "anthropic_stream_events"
+    }
+
+    fn request_body_access(&self) -> BodyAccess {
+        BodyAccess::None
+    }
+
+    fn request_body_mode(&self) -> BodyMode {
+        BodyMode::Stream
+    }
+
+    fn response_body_access(&self) -> BodyAccess {
+        BodyAccess::ReadWrite
+    }
+
+    fn response_body_mode(&self) -> BodyMode {
+        BodyMode::Stream
+    }
+
+    async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        Ok(FilterAction::Continue)
+    }
+
+    async fn on_response(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        if let Some(resp) = &mut ctx.response_header {
+            resp.headers.remove(http::header::CONTENT_LENGTH);
+            resp.headers.insert(
+                http::header::CONTENT_TYPE,
+                http::HeaderValue::from_static("text/event-stream"),
+            );
+            ctx.response_headers_modified = true;
+        }
+        Ok(FilterAction::Continue)
+    }
+
+    fn on_response_body(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        body: &mut Option<Bytes>,
+        _end_of_stream: bool,
+    ) -> Result<FilterAction, FilterError> {
+        let Some(bytes) = body.as_ref() else {
+            return Ok(FilterAction::Continue);
+        };
+
+        let Ok(chunk_str) = std::str::from_utf8(bytes) else {
+            return Ok(FilterAction::Continue);
+        };
+
+        let output = process_sse_chunk(ctx, chunk_str);
+        *body = Some(output);
+
+        Ok(FilterAction::Continue)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// SSE Chunk Processing
+// -----------------------------------------------------------------------------
+
+/// Parse SSE event boundaries from the combined buffer, transform
+/// each complete event, and store any leftover partial data.
+fn process_sse_chunk(ctx: &mut HttpFilterContext<'_>, chunk_str: &str) -> Bytes {
+    let leftover = ctx.filter_metadata.get(LINE_BUFFER_KEY).cloned().unwrap_or_default();
+    let combined = format!("{leftover}{chunk_str}");
+    let mut output = Vec::new();
+    let mut remaining = combined.as_str();
+
+    while let Some(boundary) = remaining.find("\n\n") {
+        let event_block = &remaining[..boundary];
+        remaining = &remaining[boundary + 2..];
+        process_event_block(ctx, event_block, &mut output);
+    }
+
+    ctx.set_metadata(LINE_BUFFER_KEY, remaining.to_owned());
+
+    if output.is_empty() {
+        Bytes::new()
+    } else {
+        Bytes::from(output)
+    }
+}
+
+/// Process a single SSE event block (lines between double-newlines).
+fn process_event_block(ctx: &mut HttpFilterContext<'_>, block: &str, output: &mut Vec<u8>) {
+    for line in block.lines() {
+        if let Some(data) = line.strip_prefix("data: ") {
+            if data == "[DONE]" {
+                emit_done(ctx, output);
+            } else if let Ok(chunk) = serde_json::from_str::<Value>(data) {
+                transform_chunk(ctx, &chunk, output);
+            }
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Per-Chunk Transformation
+// -----------------------------------------------------------------------------
+
+/// Transform a single `OpenAI` SSE chunk into Anthropic events.
+fn transform_chunk(ctx: &mut HttpFilterContext<'_>, chunk: &Value, output: &mut Vec<u8>) {
+    let started = ctx
+        .filter_metadata
+        .get(STREAM_STATE_KEY)
+        .is_some_and(|v| v == "started");
+
+    if !started {
+        emit_message_start(ctx, chunk, output);
+    }
+
+    if let Some(choice) = extract_first_choice(chunk) {
+        if let Some(delta) = choice.get("delta") {
+            transform_delta(ctx, delta, output);
+        }
+        if let Some(reason) = choice.get("finish_reason").and_then(Value::as_str) {
+            ctx.set_metadata(FINISH_REASON_KEY, reason.to_owned());
+        }
+    }
+
+    if let Some(ot) = chunk
+        .get("usage")
+        .and_then(|u| u.get("completion_tokens"))
+        .and_then(Value::as_u64)
+    {
+        ctx.set_metadata(OUTPUT_TOKENS_KEY, ot.to_string());
+    }
+}
+
+/// Emit the initial `message_start` event and mark the stream as started.
+fn emit_message_start(ctx: &mut HttpFilterContext<'_>, chunk: &Value, output: &mut Vec<u8>) {
+    let model = chunk.get("model").and_then(Value::as_str).unwrap_or("");
+
+    emit_event(
+        output,
+        "message_start",
+        &serde_json::json!({
+            "type": "message_start",
+            "message": {
+                "id": format!("msg_{:016x}", generate_timestamp_id()),
+                "type": "message",
+                "role": "assistant",
+                "model": model,
+                "content": [],
+                "stop_reason": null,
+                "stop_sequence": null,
+                "usage": {"input_tokens": 0, "output_tokens": 0}
+            }
+        }),
+    );
+    ctx.set_metadata(STREAM_STATE_KEY, "started".to_owned());
+}
+
+/// Extract the first choice from an `OpenAI` streaming chunk.
+fn extract_first_choice(chunk: &Value) -> Option<&Value> {
+    chunk.get("choices").and_then(Value::as_array).and_then(|c| c.first())
+}
+
+/// Generate a timestamp-based identifier for message IDs.
+fn generate_timestamp_id() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+        & 0xFFFF_FFFF_FFFF_FFFF_u128
+}
+
+// -----------------------------------------------------------------------------
+// Delta Transformation
+// -----------------------------------------------------------------------------
+
+/// Transform a delta object from a streaming chunk.
+fn transform_delta(ctx: &mut HttpFilterContext<'_>, delta: &Value, output: &mut Vec<u8>) {
+    if let Some(content) = delta.get("content").and_then(Value::as_str) {
+        emit_text_delta(ctx, content, output);
+    }
+
+    if let Some(Value::Array(tool_calls)) = delta.get("tool_calls") {
+        for tc in tool_calls {
+            transform_tool_delta(ctx, tc, output);
+        }
+    }
+}
+
+/// Emit a text content delta, opening a new block if needed.
+fn emit_text_delta(ctx: &mut HttpFilterContext<'_>, content: &str, output: &mut Vec<u8>) {
+    if !is_text_block_open(ctx) {
+        let idx = get_block_index(ctx);
+        emit_event(
+            output,
+            "content_block_start",
+            &serde_json::json!({
+                "type": "content_block_start",
+                "index": idx,
+                "content_block": {"type": "text", "text": ""}
+            }),
+        );
+        ctx.set_metadata(TEXT_BLOCK_OPEN_KEY, "true".to_owned());
+    }
+
+    let idx = get_block_index(ctx);
+    emit_event(
+        output,
+        "content_block_delta",
+        &serde_json::json!({
+            "type": "content_block_delta",
+            "index": idx,
+            "delta": {"type": "text_delta", "text": content}
+        }),
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Tool Delta Transformation
+// -----------------------------------------------------------------------------
+
+/// Transform a tool call delta into Anthropic content block events.
+fn transform_tool_delta(ctx: &mut HttpFilterContext<'_>, tc: &Value, output: &mut Vec<u8>) {
+    if let Some(id) = tc.get("id").and_then(Value::as_str) {
+        close_text_block_if_open(ctx, output);
+        emit_tool_block_start(ctx, tc, id, output);
+    }
+
+    emit_tool_arguments_delta(ctx, tc, output);
+}
+
+/// Close any open text content block and advance the block index.
+fn close_text_block_if_open(ctx: &mut HttpFilterContext<'_>, output: &mut Vec<u8>) {
+    if !is_text_block_open(ctx) {
+        return;
+    }
+
+    let idx = get_block_index(ctx);
+    emit_event(
+        output,
+        "content_block_stop",
+        &serde_json::json!({"type": "content_block_stop", "index": idx}),
+    );
+    increment_block_index(ctx);
+    ctx.set_metadata(TEXT_BLOCK_OPEN_KEY, "false".to_owned());
+}
+
+/// Emit a `content_block_start` for a tool-use block.
+fn emit_tool_block_start(ctx: &HttpFilterContext<'_>, tc: &Value, id: &str, output: &mut Vec<u8>) {
+    let idx = get_block_index(ctx);
+    let name = tc
+        .get("function")
+        .and_then(|f| f.get("name"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+
+    emit_event(
+        output,
+        "content_block_start",
+        &serde_json::json!({
+            "type": "content_block_start",
+            "index": idx,
+            "content_block": {"type": "tool_use", "id": id, "name": name, "input": {}}
+        }),
+    );
+}
+
+/// Emit an `input_json_delta` if the tool call has non-empty arguments.
+fn emit_tool_arguments_delta(ctx: &HttpFilterContext<'_>, tc: &Value, output: &mut Vec<u8>) {
+    let Some(args) = tc
+        .get("function")
+        .and_then(|f| f.get("arguments"))
+        .and_then(Value::as_str)
+    else {
+        return;
+    };
+
+    if args.is_empty() {
+        return;
+    }
+
+    let idx = get_block_index(ctx);
+    emit_event(
+        output,
+        "content_block_delta",
+        &serde_json::json!({
+            "type": "content_block_delta",
+            "index": idx,
+            "delta": {"type": "input_json_delta", "partial_json": args}
+        }),
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Stream Completion
+// -----------------------------------------------------------------------------
+
+/// Emit final events when `[DONE]` is received.
+fn emit_done(ctx: &HttpFilterContext<'_>, output: &mut Vec<u8>) {
+    emit_final_block_stop(ctx, output);
+    emit_message_delta(ctx, output);
+    emit_event(output, "message_stop", &serde_json::json!({"type": "message_stop"}));
+    debug!("streaming transformation complete");
+}
+
+/// Close any open content block at end of stream.
+fn emit_final_block_stop(ctx: &HttpFilterContext<'_>, output: &mut Vec<u8>) {
+    if !is_text_block_open(ctx) {
+        return;
+    }
+
+    let idx = get_block_index(ctx);
+    emit_event(
+        output,
+        "content_block_stop",
+        &serde_json::json!({"type": "content_block_stop", "index": idx}),
+    );
+}
+
+/// Emit the `message_delta` event with stop reason and usage.
+fn emit_message_delta(ctx: &HttpFilterContext<'_>, output: &mut Vec<u8>) {
+    let stop_reason = ctx
+        .filter_metadata
+        .get(FINISH_REASON_KEY)
+        .map_or("end_turn", |v| map_stop_reason(v));
+
+    let output_tokens: u64 = ctx
+        .filter_metadata
+        .get(OUTPUT_TOKENS_KEY)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    emit_event(
+        output,
+        "message_delta",
+        &serde_json::json!({
+            "type": "message_delta",
+            "delta": {"stop_reason": stop_reason, "stop_sequence": null},
+            "usage": {"output_tokens": output_tokens}
+        }),
+    );
+}
+
+/// Map `OpenAI` finish reasons to Anthropic stop reasons.
+fn map_stop_reason(reason: &str) -> &str {
+    match reason {
+        "tool_calls" => "tool_use",
+        "length" => "max_tokens",
+        _ => "end_turn",
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+/// Check whether a text content block is currently open.
+fn is_text_block_open(ctx: &HttpFilterContext<'_>) -> bool {
+    ctx.filter_metadata
+        .get(TEXT_BLOCK_OPEN_KEY)
+        .is_some_and(|v| v == "true")
+}
+
+/// Get the current block index from metadata.
+fn get_block_index(ctx: &HttpFilterContext<'_>) -> u32 {
+    ctx.filter_metadata
+        .get(BLOCK_INDEX_KEY)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0)
+}
+
+/// Increment the block index in metadata.
+fn increment_block_index(ctx: &mut HttpFilterContext<'_>) {
+    let current = get_block_index(ctx);
+    ctx.set_metadata(BLOCK_INDEX_KEY, (current + 1).to_string());
+}
+
+/// Write a single SSE event to the output buffer.
+fn emit_event(output: &mut Vec<u8>, event_type: &str, data: &Value) {
+    let data_str = serde_json::to_string(data).unwrap_or_default();
+    output.extend_from_slice(format!("event: {event_type}\ndata: {data_str}\n\n").as_bytes());
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    clippy::too_many_lines,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn incremental_text_chunks_transformed_immediately() {
+        let filter = make_filter();
+        let req = crate::test_utils::make_request(http::Method::POST, "/v1/messages");
+        let req: &'static crate::context::Request = Box::leak(Box::new(req));
+        let mut ctx = crate::test_utils::make_filter_context(req);
+
+        let chunk1 = "data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"delta\":{\"role\":\"assistant\"},\"index\":0}]}\n\n";
+        let mut body1 = Some(Bytes::from(chunk1));
+        drop(filter.on_response_body(&mut ctx, &mut body1, false).unwrap());
+
+        let out1 = String::from_utf8(body1.unwrap().to_vec()).unwrap();
+        assert!(
+            out1.contains("message_start"),
+            "first chunk should emit message_start immediately"
+        );
+
+        let chunk2 = "data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"delta\":{\"content\":\"Hello\"},\"index\":0}]}\n\n";
+        let mut body2 = Some(Bytes::from(chunk2));
+        drop(filter.on_response_body(&mut ctx, &mut body2, false).unwrap());
+
+        let out2 = String::from_utf8(body2.unwrap().to_vec()).unwrap();
+        assert!(
+            out2.contains("text_delta"),
+            "second chunk should emit text_delta immediately"
+        );
+        assert!(out2.contains("Hello"), "text content should be forwarded immediately");
+    }
+
+    #[test]
+    fn partial_chunk_buffered_until_complete() {
+        let filter = make_filter();
+        let req = crate::test_utils::make_request(http::Method::POST, "/v1/messages");
+        let req: &'static crate::context::Request = Box::leak(Box::new(req));
+        let mut ctx = crate::test_utils::make_filter_context(req);
+
+        let partial = "data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"delta\":{\"role\":\"assistant\"";
+        let mut body1 = Some(Bytes::from(partial));
+        drop(filter.on_response_body(&mut ctx, &mut body1, false).unwrap());
+
+        let out1 = body1.unwrap();
+        assert!(out1.is_empty(), "partial chunk should produce no output");
+
+        let rest = "},\"index\":0}]}\n\n";
+        let mut body2 = Some(Bytes::from(rest));
+        drop(filter.on_response_body(&mut ctx, &mut body2, false).unwrap());
+
+        let out2 = String::from_utf8(body2.unwrap().to_vec()).unwrap();
+        assert!(
+            out2.contains("message_start"),
+            "completed chunk should emit message_start"
+        );
+    }
+
+    #[test]
+    fn done_emits_final_events() {
+        let filter = make_filter();
+        let req = crate::test_utils::make_request(http::Method::POST, "/v1/messages");
+        let req: &'static crate::context::Request = Box::leak(Box::new(req));
+        let mut ctx = crate::test_utils::make_filter_context(req);
+
+        let chunk1 = "data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"delta\":{\"content\":\"Hi\"},\"index\":0,\"finish_reason\":\"stop\"}]}\n\n";
+        let mut body1 = Some(Bytes::from(chunk1));
+        drop(filter.on_response_body(&mut ctx, &mut body1, false).unwrap());
+
+        let done = "data: [DONE]\n\n";
+        let mut body2 = Some(Bytes::from(done));
+        drop(filter.on_response_body(&mut ctx, &mut body2, false).unwrap());
+
+        let out = String::from_utf8(body2.unwrap().to_vec()).unwrap();
+        assert!(out.contains("message_delta"), "DONE should emit message_delta");
+        assert!(out.contains("message_stop"), "DONE should emit message_stop");
+        assert!(out.contains("end_turn"), "stop reason should be end_turn");
+    }
+
+    #[test]
+    fn no_full_response_buffering() {
+        let filter = make_filter();
+        let req = crate::test_utils::make_request(http::Method::POST, "/v1/messages");
+        let req: &'static crate::context::Request = Box::leak(Box::new(req));
+        let mut ctx = crate::test_utils::make_filter_context(req);
+
+        let chunks = vec![
+            "data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"delta\":{\"role\":\"assistant\"},\"index\":0}]}\n\n",
+            "data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"delta\":{\"content\":\"A\"},\"index\":0}]}\n\n",
+            "data: {\"id\":\"c1\",\"model\":\"gpt-4\",\"choices\":[{\"delta\":{\"content\":\"B\"},\"index\":0}]}\n\n",
+        ];
+
+        let mut outputs_with_content = 0;
+        for chunk in chunks {
+            let mut body = Some(Bytes::from(chunk));
+            drop(filter.on_response_body(&mut ctx, &mut body, false).unwrap());
+            if !body.unwrap().is_empty() {
+                outputs_with_content += 1;
+            }
+        }
+
+        assert!(
+            outputs_with_content >= 3,
+            "each chunk should produce output immediately, got {outputs_with_content}/3"
+        );
+    }
+
+    /// Build a filter instance for testing.
+    fn make_filter() -> Box<dyn HttpFilter> {
+        let yaml: serde_yaml::Value = serde_yaml::from_str("{}").unwrap();
+        AnthropicStreamEventsFilter::from_config(&yaml).unwrap()
+    }
+}

--- a/filter/src/builtins/http/ai/anthropic/to_openai/config.rs
+++ b/filter/src/builtins/http/ai/anthropic/to_openai/config.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Configuration for the Anthropic-to-OpenAI transformation filter.
+
+use serde::Deserialize;
+
+use crate::FilterError;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Default maximum request body size (1 MiB).
+const DEFAULT_MAX_BODY_BYTES: usize = 1_048_576; // 1 MiB
+
+// -----------------------------------------------------------------------------
+// AnthropicToOpenaiConfig
+// -----------------------------------------------------------------------------
+
+/// YAML configuration for the [`AnthropicToOpenaiFilter`].
+///
+/// [`AnthropicToOpenaiFilter`]: super::AnthropicToOpenaiFilter
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AnthropicToOpenaiConfig {
+    /// Maximum body size in bytes for `StreamBuffer` mode.
+    #[serde(default = "default_max_body_bytes")]
+    pub max_body_bytes: usize,
+}
+
+/// Default max body bytes.
+fn default_max_body_bytes() -> usize {
+    DEFAULT_MAX_BODY_BYTES
+}
+
+
+// -----------------------------------------------------------------------------
+// Config Validation
+// -----------------------------------------------------------------------------
+
+/// Validate the parsed configuration.
+pub(crate) fn build_config(cfg: AnthropicToOpenaiConfig) -> Result<AnthropicToOpenaiConfig, FilterError> {
+    if cfg.max_body_bytes == 0 {
+        return Err("anthropic_to_openai: 'max_body_bytes' must be greater than 0".into());
+    }
+    Ok(cfg)
+}

--- a/filter/src/builtins/http/ai/anthropic/to_openai/mod.rs
+++ b/filter/src/builtins/http/ai/anthropic/to_openai/mod.rs
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Anthropic Messages to `OpenAI` Chat Completions transformation filter.
+//!
+//! Rewrites Anthropic Messages request bodies to `OpenAI` Chat
+//! Completions format and transforms non-streaming responses back.
+//! Streaming SSE transformation is handled by the separate
+//! `anthropic_stream_events` filter.
+
+mod config;
+pub(crate) mod request;
+pub(crate) mod response;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use tracing::{debug, warn};
+
+use self::config::{AnthropicToOpenaiConfig, build_config};
+use crate::{
+    FilterAction, FilterError, Rejection,
+    body::{BodyAccess, BodyMode},
+    factory::parse_filter_config,
+    filter::{HttpFilter, HttpFilterContext},
+};
+
+// -----------------------------------------------------------------------------
+// AnthropicToOpenaiFilter
+// -----------------------------------------------------------------------------
+
+/// Transforms Anthropic Messages API requests to `OpenAI` Chat
+/// Completions format and transforms responses back.
+///
+/// # YAML
+///
+/// ```yaml
+/// filter: anthropic_to_openai
+/// ```
+///
+/// # Full YAML
+///
+/// ```yaml
+/// filter: anthropic_to_openai
+/// max_body_bytes: 1048576
+/// strip_unsupported: true
+/// ```
+pub struct AnthropicToOpenaiFilter {
+    /// Parsed and validated configuration.
+    config: AnthropicToOpenaiConfig,
+}
+
+impl AnthropicToOpenaiFilter {
+    /// Create a filter from parsed YAML config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if the YAML config is invalid.
+    pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
+        let cfg: AnthropicToOpenaiConfig = parse_filter_config("anthropic_to_openai", config)?;
+        let validated = build_config(cfg)?;
+        Ok(Box::new(Self { config: validated }))
+    }
+}
+
+#[async_trait]
+impl HttpFilter for AnthropicToOpenaiFilter {
+    fn name(&self) -> &'static str {
+        "anthropic_to_openai"
+    }
+
+    fn request_body_access(&self) -> BodyAccess {
+        BodyAccess::ReadWrite
+    }
+
+    fn request_body_mode(&self) -> BodyMode {
+        BodyMode::StreamBuffer {
+            max_bytes: Some(self.config.max_body_bytes),
+        }
+    }
+
+    fn response_body_access(&self) -> BodyAccess {
+        BodyAccess::ReadWrite
+    }
+
+    fn response_body_mode(&self) -> BodyMode {
+        BodyMode::Stream
+    }
+
+    async fn on_response(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        let is_streaming = ctx
+            .filter_metadata
+            .get("anthropic_to_openai.streaming")
+            .is_some_and(|v| v == "true");
+
+        if !is_streaming {
+            ctx.set_response_body_mode(BodyMode::StreamBuffer {
+                max_bytes: Some(self.config.max_body_bytes),
+            });
+            if let Some(resp) = &mut ctx.response_header {
+                resp.headers.remove(http::header::CONTENT_LENGTH);
+                ctx.response_headers_modified = true;
+            }
+        }
+
+        Ok(FilterAction::Continue)
+    }
+
+    async fn on_request(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        ctx.request_headers_to_remove
+            .push(http::header::HeaderName::from_static("anthropic-version"));
+        ctx.request_headers_to_remove
+            .push(http::header::HeaderName::from_static("x-api-key"));
+
+        Ok(FilterAction::Continue)
+    }
+
+    async fn on_request_body(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        body: &mut Option<Bytes>,
+        end_of_stream: bool,
+    ) -> Result<FilterAction, FilterError> {
+        if !end_of_stream {
+            return Ok(FilterAction::Continue);
+        }
+
+        let bytes = match body.as_ref() {
+            Some(b) if !b.is_empty() => b.as_ref(),
+            _ => return Ok(FilterAction::Continue),
+        };
+
+        extract_request_metadata(ctx, bytes);
+        Ok(transform_request_body(body))
+    }
+
+    fn on_response_body(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        body: &mut Option<Bytes>,
+        end_of_stream: bool,
+    ) -> Result<FilterAction, FilterError> {
+        let is_streaming = ctx
+            .filter_metadata
+            .get("anthropic_to_openai.streaming")
+            .is_some_and(|v| v == "true");
+
+        if is_streaming {
+            return Ok(FilterAction::Continue);
+        }
+
+        if !end_of_stream {
+            return Ok(FilterAction::Continue);
+        }
+
+        let request_model = ctx
+            .filter_metadata
+            .get("anthropic_to_openai.model")
+            .cloned()
+            .unwrap_or_default();
+
+        transform_non_streaming_body(ctx, body, &request_model);
+
+        if let Some(b) = body.as_ref()
+            && let Some(resp) = &mut ctx.response_header
+        {
+            resp.headers
+                .insert(http::header::CONTENT_LENGTH, http::HeaderValue::from(b.len()));
+            resp.headers.insert(
+                http::header::CONTENT_TYPE,
+                http::HeaderValue::from_static("application/json"),
+            );
+            ctx.response_headers_modified = true;
+        }
+
+        Ok(FilterAction::Continue)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Request Body Helpers
+// -----------------------------------------------------------------------------
+
+/// Extract streaming and model metadata from the request body.
+fn extract_request_metadata(ctx: &mut HttpFilterContext<'_>, bytes: &[u8]) {
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(bytes) else {
+        ctx.set_metadata("anthropic_to_openai.streaming", "false");
+        return;
+    };
+
+    let is_streaming = value
+        .get("stream")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    ctx.set_metadata(
+        "anthropic_to_openai.streaming",
+        if is_streaming { "true" } else { "false" },
+    );
+
+    let model = value
+        .get("model")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+        .unwrap_or_default();
+    ctx.set_metadata("anthropic_to_openai.model", model);
+}
+
+/// Transform the request body and return the appropriate filter action.
+fn transform_request_body(body: &mut Option<Bytes>) -> FilterAction {
+    let Some(bytes) = body.as_ref() else {
+        return FilterAction::Continue;
+    };
+
+    match request::transform_request(bytes) {
+        Ok(transformed) => {
+            debug!(
+                original_len = bytes.len(),
+                transformed_len = transformed.len(),
+                "transformed Anthropic request to OpenAI"
+            );
+            *body = Some(Bytes::from(transformed));
+            FilterAction::Continue
+        },
+        Err(msg) => {
+            warn!(error = msg.as_str(), "failed to transform Anthropic request");
+            FilterAction::Reject(
+                Rejection::status(400)
+                    .with_header("content-type", "application/json")
+                    .with_body(Bytes::from(format!(
+                        r#"{{"error":{{"message":"{msg}","type":"invalid_request_error"}}}}"#
+                    ))),
+            )
+        },
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Response Body Helpers
+// -----------------------------------------------------------------------------
+
+/// Apply non-streaming JSON transformation to the response body.
+fn transform_non_streaming_body(ctx: &mut HttpFilterContext<'_>, body: &mut Option<Bytes>, request_model: &str) {
+    let bytes = match body.as_ref() {
+        Some(b) => b.as_ref(),
+        None => return,
+    };
+
+    if bytes.is_empty() {
+        return;
+    }
+
+    match response::transform_response(bytes, request_model) {
+        Ok(result) => {
+            debug!(
+                original_len = bytes.len(),
+                transformed_len = result.body.len(),
+                original_finish_reason = result.original_finish_reason.as_str(),
+                "transformed OpenAI response to Anthropic"
+            );
+            ctx.set_metadata("openai.finish_reason", result.original_finish_reason);
+            *body = Some(Bytes::from(result.body));
+        },
+        Err(msg) => {
+            warn!(error = msg.as_str(), "failed to transform OpenAI response");
+        },
+    }
+}

--- a/filter/src/builtins/http/ai/anthropic/to_openai/request.rs
+++ b/filter/src/builtins/http/ai/anthropic/to_openai/request.rs
@@ -1,0 +1,535 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Anthropic Messages to `OpenAI` Chat Completions request transformation.
+
+use serde_json::{Map, Value, json};
+use tracing::warn;
+
+// -----------------------------------------------------------------------------
+// Request Transformation
+// -----------------------------------------------------------------------------
+
+/// Transform an Anthropic Messages request body into `OpenAI` Chat
+/// Completions format.
+///
+/// Returns the transformed JSON bytes, or an error message.
+pub(crate) fn transform_request(body: &[u8]) -> Result<Vec<u8>, String> {
+    let value: Value = serde_json::from_slice(body).map_err(|e| format!("invalid JSON: {e}"))?;
+
+    let Some(obj) = value.as_object() else {
+        return Err("request body is not a JSON object".to_owned());
+    };
+
+    let mut openai = Map::new();
+
+    if let Some(model) = obj.get("model") {
+        openai.insert("model".to_owned(), model.clone());
+    }
+
+    let mut messages = Vec::new();
+    hoist_system(&mut messages, obj);
+    convert_messages(&mut messages, obj);
+    openai.insert("messages".to_owned(), Value::Array(messages));
+
+    if let Some(max_tokens) = obj.get("max_tokens") {
+        openai.insert("max_tokens".to_owned(), max_tokens.clone());
+    }
+
+    if let Some(stream) = obj.get("stream") {
+        openai.insert("stream".to_owned(), stream.clone());
+    }
+
+    map_parameters(&mut openai, obj);
+    convert_tools(&mut openai, obj);
+    convert_tool_choice(&mut openai, obj);
+
+    serde_json::to_vec(&Value::Object(openai)).map_err(|e| format!("serialization failed: {e}"))
+}
+
+// -----------------------------------------------------------------------------
+// System Message Hoisting
+// -----------------------------------------------------------------------------
+
+/// Hoist Anthropic top-level `system` to an `OpenAI` system message.
+fn hoist_system(messages: &mut Vec<Value>, obj: &Map<String, Value>) {
+    let Some(system) = obj.get("system") else {
+        return;
+    };
+
+    let content = match system {
+        Value::String(s) => s.clone(),
+        Value::Array(blocks) => {
+            let mut parts = Vec::new();
+            for block in blocks {
+                if let Some(text) = block.get("text").and_then(Value::as_str) {
+                    parts.push(text.to_owned());
+                }
+            }
+            parts.join("\n")
+        },
+        _ => return,
+    };
+
+    if !content.is_empty() {
+        messages.push(json!({"role": "system", "content": content}));
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Message Conversion
+// -----------------------------------------------------------------------------
+
+/// Convert Anthropic messages array to `OpenAI` messages.
+fn convert_messages(messages: &mut Vec<Value>, obj: &Map<String, Value>) {
+    let Some(Value::Array(anthropic_messages)) = obj.get("messages") else {
+        return;
+    };
+
+    for msg in anthropic_messages {
+        let Some(role) = msg.get("role").and_then(Value::as_str) else {
+            continue;
+        };
+
+        match msg.get("content") {
+            Some(Value::String(text)) => {
+                messages.push(json!({"role": role, "content": text}));
+            },
+            Some(Value::Array(blocks)) => {
+                convert_content_blocks(messages, role, blocks);
+            },
+            _ => {
+                messages.push(json!({"role": role, "content": ""}));
+            },
+        }
+    }
+}
+
+/// Convert typed content blocks to `OpenAI` format.
+fn convert_content_blocks(messages: &mut Vec<Value>, role: &str, blocks: &[Value]) {
+    let mut text_parts = Vec::new();
+    let mut content_parts: Vec<Value> = Vec::new();
+    let mut tool_calls: Vec<Value> = Vec::new();
+
+    for block in blocks {
+        let block_type = block.get("type").and_then(Value::as_str).unwrap_or("");
+        convert_single_block(
+            block,
+            block_type,
+            messages,
+            role,
+            &mut text_parts,
+            &mut content_parts,
+            &mut tool_calls,
+        );
+    }
+
+    finalize_content_blocks(messages, role, &mut text_parts, &mut content_parts, tool_calls);
+}
+
+/// Process a single content block within a message.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "accumulator pattern requires passing all state"
+)]
+fn convert_single_block(
+    block: &Value,
+    block_type: &str,
+    messages: &mut Vec<Value>,
+    role: &str,
+    text_parts: &mut Vec<String>,
+    content_parts: &mut Vec<Value>,
+    tool_calls: &mut Vec<Value>,
+) {
+    match block_type {
+        "text" => convert_text_block(block, text_parts, content_parts),
+        "image" => convert_image_block(block, content_parts),
+        "tool_use" => convert_tool_use_block(block, tool_calls),
+        "tool_result" => {
+            flush_text_parts(messages, text_parts, content_parts, role);
+            convert_tool_result_block(block, messages);
+        },
+        "thinking" | "redacted_thinking" => {
+            warn!(block_type, "dropping unsupported Anthropic content block");
+        },
+        _ => {
+            warn!(block_type, "dropping unknown Anthropic content block type");
+        },
+    }
+}
+
+/// Convert a text content block.
+fn convert_text_block(block: &Value, text_parts: &mut Vec<String>, content_parts: &mut Vec<Value>) {
+    if let Some(text) = block.get("text").and_then(Value::as_str) {
+        text_parts.push(text.to_owned());
+        content_parts.push(json!({"type": "text", "text": text}));
+    }
+}
+
+/// Convert an image content block.
+fn convert_image_block(block: &Value, content_parts: &mut Vec<Value>) {
+    if let Some(source) = block.get("source")
+        && let Some(url_val) = convert_image_source(source)
+    {
+        content_parts.push(json!({"type": "image_url", "image_url": {"url": url_val}}));
+    }
+}
+
+/// Convert a `tool_use` content block to an `OpenAI` tool call.
+fn convert_tool_use_block(block: &Value, tool_calls: &mut Vec<Value>) {
+    let id = block.get("id").and_then(Value::as_str).unwrap_or("");
+    let name = block.get("name").and_then(Value::as_str).unwrap_or("");
+    let input = block.get("input").cloned().unwrap_or_else(|| Value::Object(Map::new()));
+    let args = serde_json::to_string(&input).unwrap_or_default();
+
+    tool_calls.push(json!({
+        "id": id,
+        "type": "function",
+        "function": {"name": name, "arguments": args}
+    }));
+}
+
+/// Convert a `tool_result` content block to an `OpenAI` tool message.
+fn convert_tool_result_block(block: &Value, messages: &mut Vec<Value>) {
+    let tool_call_id = block.get("tool_use_id").and_then(Value::as_str).unwrap_or("");
+    let result_content = extract_tool_result_content(block);
+
+    messages.push(json!({
+        "role": "tool",
+        "tool_call_id": tool_call_id,
+        "content": result_content
+    }));
+}
+
+/// Emit the final message for accumulated content and tool calls.
+fn finalize_content_blocks(
+    messages: &mut Vec<Value>,
+    role: &str,
+    text_parts: &mut Vec<String>,
+    content_parts: &mut Vec<Value>,
+    tool_calls: Vec<Value>,
+) {
+    if role == "assistant" && !tool_calls.is_empty() {
+        let mut msg = json!({"role": "assistant"});
+        if let Some(obj) = msg.as_object_mut() {
+            if !text_parts.is_empty() {
+                obj.insert("content".to_owned(), Value::String(text_parts.join("")));
+            }
+            obj.insert("tool_calls".to_owned(), Value::Array(tool_calls));
+        }
+        messages.push(msg);
+    } else {
+        flush_text_parts(messages, text_parts, content_parts, role);
+    }
+}
+
+/// Flush accumulated text/content parts as a message.
+fn flush_text_parts(
+    messages: &mut Vec<Value>,
+    text_parts: &mut Vec<String>,
+    content_parts: &mut Vec<Value>,
+    role: &str,
+) {
+    if content_parts.is_empty() && text_parts.is_empty() {
+        return;
+    }
+
+    if content_parts.len() == 1
+        && content_parts
+            .first()
+            .and_then(|p| p.get("type"))
+            .and_then(Value::as_str)
+            == Some("text")
+    {
+        messages.push(json!({"role": role, "content": text_parts.join("")}));
+    } else if !content_parts.is_empty() {
+        messages.push(json!({"role": role, "content": content_parts.clone()}));
+    }
+
+    text_parts.clear();
+    content_parts.clear();
+}
+
+// -----------------------------------------------------------------------------
+// Image Source Conversion
+// -----------------------------------------------------------------------------
+
+/// Convert Anthropic image source to `OpenAI` `image_url` URL string.
+fn convert_image_source(source: &Value) -> Option<String> {
+    let source_type = source.get("type").and_then(Value::as_str)?;
+
+    match source_type {
+        "base64" => {
+            let media_type = source.get("media_type").and_then(Value::as_str)?;
+            let data = source.get("data").and_then(Value::as_str)?;
+            Some(format!("data:{media_type};base64,{data}"))
+        },
+        "url" => source.get("url").and_then(Value::as_str).map(str::to_owned),
+        _ => None,
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Tool Result Content Extraction
+// -----------------------------------------------------------------------------
+
+/// Extract text content from a `tool_result` block.
+fn extract_tool_result_content(block: &Value) -> String {
+    match block.get("content") {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Array(parts)) => {
+            let mut text_parts = Vec::new();
+            for part in parts {
+                if part.get("type").and_then(Value::as_str) == Some("text")
+                    && let Some(text) = part.get("text").and_then(Value::as_str)
+                {
+                    text_parts.push(text.to_owned());
+                }
+            }
+            text_parts.join("\n")
+        },
+        _ => String::new(),
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Parameter Mapping
+// -----------------------------------------------------------------------------
+
+/// Map Anthropic parameters to `OpenAI` equivalents.
+///
+/// `top_k` has no standard `OpenAI` equivalent but is preserved
+/// as an extra body parameter for backends that support it
+/// (e.g. vLLM).
+fn map_parameters(openai: &mut Map<String, Value>, obj: &Map<String, Value>) {
+    if let Some(stop) = obj.get("stop_sequences") {
+        openai.insert("stop".to_owned(), stop.clone());
+    }
+
+    if let Some(temp) = obj.get("temperature") {
+        openai.insert("temperature".to_owned(), temp.clone());
+    }
+
+    if let Some(top_p) = obj.get("top_p") {
+        openai.insert("top_p".to_owned(), top_p.clone());
+    }
+
+    if let Some(top_k) = obj.get("top_k") {
+        openai.insert("top_k".to_owned(), top_k.clone());
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Tool Conversion
+// -----------------------------------------------------------------------------
+
+/// Convert Anthropic tool definitions to `OpenAI` function tools.
+fn convert_tools(openai: &mut Map<String, Value>, obj: &Map<String, Value>) {
+    let Some(Value::Array(tools)) = obj.get("tools") else {
+        return;
+    };
+
+    let mut openai_tools = Vec::new();
+
+    for tool in tools {
+        let tool_type = tool.get("type").and_then(Value::as_str).unwrap_or("custom");
+
+        if tool_type.starts_with("web_search") || tool_type.starts_with("bash") || tool_type.starts_with("text_editor")
+        {
+            warn!(tool_type, "dropping server-side Anthropic tool");
+            continue;
+        }
+
+        let name = tool.get("name").and_then(Value::as_str).unwrap_or("");
+        let description = tool.get("description").and_then(Value::as_str).unwrap_or("");
+        let parameters = tool
+            .get("input_schema")
+            .cloned()
+            .unwrap_or_else(|| json!({"type": "object"}));
+
+        openai_tools.push(json!({
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": description,
+                "parameters": parameters
+            }
+        }));
+    }
+
+    if !openai_tools.is_empty() {
+        openai.insert("tools".to_owned(), Value::Array(openai_tools));
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Tool Choice Conversion
+// -----------------------------------------------------------------------------
+
+/// Convert Anthropic `tool_choice` to `OpenAI` format.
+fn convert_tool_choice(openai: &mut Map<String, Value>, obj: &Map<String, Value>) {
+    let Some(tool_choice) = obj.get("tool_choice") else {
+        return;
+    };
+
+    let openai_choice = match tool_choice {
+        Value::String(s) => match s.as_str() {
+            "any" => Value::String("required".to_owned()),
+            "none" => Value::String("none".to_owned()),
+            _ => Value::String("auto".to_owned()),
+        },
+        Value::Object(tc) => {
+            if tc.get("type").and_then(Value::as_str) == Some("tool") {
+                if let Some(name) = tc.get("name").and_then(Value::as_str) {
+                    json!({"type": "function", "function": {"name": name}})
+                } else {
+                    Value::String("auto".to_owned())
+                }
+            } else {
+                Value::String("auto".to_owned())
+            }
+        },
+        _ => return,
+    };
+
+    openai.insert("tool_choice".to_owned(), openai_choice);
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_text_request() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"Hello"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["model"], "claude-opus-4-8", "model preserved");
+        assert_eq!(parsed["max_tokens"], 1024, "max_tokens preserved");
+        assert_eq!(parsed["messages"][0]["role"], "user", "user message role");
+        assert_eq!(parsed["messages"][0]["content"], "Hello", "user message content");
+    }
+
+    #[test]
+    fn system_hoisted() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"system":"Be helpful.","messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(
+            parsed["messages"][0]["role"], "system",
+            "system message should be first"
+        );
+        assert_eq!(parsed["messages"][0]["content"], "Be helpful.", "system content");
+        assert_eq!(parsed["messages"][1]["role"], "user", "user message follows system");
+    }
+
+    #[test]
+    fn system_text_blocks_joined() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"system":[{"type":"text","text":"Part 1"},{"type":"text","text":"Part 2"}],"messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(
+            parsed["messages"][0]["content"], "Part 1\nPart 2",
+            "text blocks should be joined"
+        );
+    }
+
+    #[test]
+    fn tool_use_converted() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"call_1","name":"get_weather","input":{"city":"NYC"}}]}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        let msg = &parsed["messages"][0];
+        assert_eq!(msg["role"], "assistant", "assistant role");
+        assert_eq!(msg["tool_calls"][0]["function"]["name"], "get_weather", "tool name");
+        assert!(
+            msg["tool_calls"][0]["function"]["arguments"]
+                .as_str()
+                .unwrap()
+                .contains("NYC"),
+            "tool arguments contain city"
+        );
+    }
+
+    #[test]
+    fn tool_result_converted() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":"72F sunny"}]}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["messages"][0]["role"], "tool", "tool role");
+        assert_eq!(parsed["messages"][0]["tool_call_id"], "call_1", "tool_call_id");
+        assert_eq!(parsed["messages"][0]["content"], "72F sunny", "tool result content");
+    }
+
+    #[test]
+    fn stop_sequences_mapped() {
+        let body =
+            br#"{"model":"claude-opus-4-8","max_tokens":1024,"stop_sequences":["END"],"messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["stop"][0], "END", "stop_sequences mapped to stop");
+    }
+
+    #[test]
+    fn tool_choice_any_mapped() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tool_choice":"any","messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["tool_choice"], "required", "any maps to required");
+    }
+
+    #[test]
+    fn tool_definitions_converted() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"tools":[{"name":"get_weather","description":"Get weather","input_schema":{"type":"object","properties":{"city":{"type":"string"}}}}],"messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["tools"][0]["type"], "function", "tool type should be function");
+        assert_eq!(parsed["tools"][0]["function"]["name"], "get_weather", "tool name");
+    }
+
+    #[test]
+    fn image_base64_converted() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":[{"type":"image","source":{"type":"base64","media_type":"image/jpeg","data":"abc123"}},{"type":"text","text":"What is this?"}]}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        let content = &parsed["messages"][0]["content"];
+        assert_eq!(content[0]["type"], "image_url", "image type");
+        assert_eq!(
+            content[0]["image_url"]["url"], "data:image/jpeg;base64,abc123",
+            "data URL"
+        );
+        assert_eq!(content[1]["type"], "text", "text part follows");
+    }
+
+    #[test]
+    fn top_k_preserved_as_extra_param() {
+        let body =
+            br#"{"model":"claude-opus-4-8","max_tokens":1024,"top_k":40,"messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = transform_request(body).unwrap();
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["top_k"], 40, "top_k should be preserved as extra body parameter");
+    }
+}

--- a/filter/src/builtins/http/ai/anthropic/to_openai/response.rs
+++ b/filter/src/builtins/http/ai/anthropic/to_openai/response.rs
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! `OpenAI` Chat Completions to Anthropic Messages response transformation
+//! (non-streaming).
+
+use serde_json::{Map, Value, json};
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Default response type.
+const RESPONSE_TYPE: &str = "message";
+
+/// Default response role.
+const RESPONSE_ROLE: &str = "assistant";
+
+// -----------------------------------------------------------------------------
+// Response Transformation
+// -----------------------------------------------------------------------------
+
+/// Result of a response transformation.
+pub(crate) struct TransformResult {
+    /// Transformed response body bytes.
+    pub body: Vec<u8>,
+    /// Original `OpenAI` `finish_reason` (preserved for metadata).
+    pub original_finish_reason: String,
+}
+
+/// Transform an `OpenAI` Chat Completions response body into Anthropic
+/// Messages format.
+pub(crate) fn transform_response(body: &[u8], request_model: &str) -> Result<TransformResult, String> {
+    let value: Value = serde_json::from_slice(body).map_err(|e| format!("invalid JSON: {e}"))?;
+
+    let Some(obj) = value.as_object() else {
+        return Err("response body is not a JSON object".to_owned());
+    };
+
+    let mut anthropic = Map::new();
+
+    let id = match obj.get("id").and_then(Value::as_str) {
+        Some(id) => format!("msg_{id}"),
+        None => format!("msg_{}", timestamp_hex_id()),
+    };
+
+    anthropic.insert("id".to_owned(), Value::String(id));
+    anthropic.insert("type".to_owned(), Value::String(RESPONSE_TYPE.to_owned()));
+    anthropic.insert("role".to_owned(), Value::String(RESPONSE_ROLE.to_owned()));
+
+    let model = obj.get("model").and_then(Value::as_str).unwrap_or(request_model);
+    anthropic.insert("model".to_owned(), Value::String(model.to_owned()));
+
+    let content = build_content_blocks(obj);
+    anthropic.insert("content".to_owned(), Value::Array(content));
+
+    let (stop_reason, original_finish_reason) = map_finish_reason(obj);
+    anthropic.insert("stop_reason".to_owned(), Value::String(stop_reason));
+    anthropic.insert("stop_sequence".to_owned(), Value::Null);
+
+    let usage = build_usage(obj);
+    anthropic.insert("usage".to_owned(), usage);
+
+    let body = serde_json::to_vec(&Value::Object(anthropic)).map_err(|e| format!("serialization failed: {e}"))?;
+    Ok(TransformResult {
+        body,
+        original_finish_reason,
+    })
+}
+
+// -----------------------------------------------------------------------------
+// Content Block Building
+// -----------------------------------------------------------------------------
+
+/// Extract content blocks from the first choice.
+fn build_content_blocks(obj: &Map<String, Value>) -> Vec<Value> {
+    let mut blocks = Vec::new();
+
+    let choice = obj.get("choices").and_then(Value::as_array).and_then(|c| c.first());
+
+    let Some(choice) = choice else {
+        return blocks;
+    };
+
+    let message = choice.get("message");
+    extract_text_block(message, &mut blocks);
+    extract_tool_call_blocks(message, &mut blocks);
+
+    blocks
+}
+
+/// Extract a text content block from the message if present.
+fn extract_text_block(message: Option<&Value>, blocks: &mut Vec<Value>) {
+    if let Some(content) = message.and_then(|m| m.get("content")).and_then(Value::as_str)
+        && !content.is_empty()
+    {
+        blocks.push(json!({"type": "text", "text": content}));
+    }
+}
+
+/// Extract tool call blocks from the message.
+fn extract_tool_call_blocks(message: Option<&Value>, blocks: &mut Vec<Value>) {
+    let Some(Value::Array(tool_calls)) = message.and_then(|m| m.get("tool_calls")) else {
+        return;
+    };
+
+    for tc in tool_calls {
+        let id = tc.get("id").and_then(Value::as_str).unwrap_or("");
+        let name = tc
+            .get("function")
+            .and_then(|f| f.get("name"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let args_str = tc
+            .get("function")
+            .and_then(|f| f.get("arguments"))
+            .and_then(Value::as_str)
+            .unwrap_or("{}");
+        let input: Value = serde_json::from_str(args_str).unwrap_or_else(|_| Value::Object(Map::new()));
+
+        blocks.push(json!({
+            "type": "tool_use",
+            "id": id,
+            "name": name,
+            "input": input
+        }));
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Finish Reason Mapping
+// -----------------------------------------------------------------------------
+
+/// Map `OpenAI` `finish_reason` to Anthropic `stop_reason`.
+///
+/// Returns `(anthropic_stop_reason, original_finish_reason)`.
+/// The `content_filter` to `end_turn` mapping is lossy; the
+/// original is preserved so callers can store it in metadata.
+fn map_finish_reason(obj: &Map<String, Value>) -> (String, String) {
+    let finish_reason = obj
+        .get("choices")
+        .and_then(Value::as_array)
+        .and_then(|c| c.first())
+        .and_then(|c| c.get("finish_reason"))
+        .and_then(Value::as_str)
+        .unwrap_or("stop");
+
+    let mapped = match finish_reason {
+        "tool_calls" => "tool_use",
+        "length" => "max_tokens",
+        _ => "end_turn",
+    };
+
+    (mapped.to_owned(), finish_reason.to_owned())
+}
+
+// -----------------------------------------------------------------------------
+// Usage Mapping
+// -----------------------------------------------------------------------------
+
+/// Build Anthropic usage object from `OpenAI` usage.
+fn build_usage(obj: &Map<String, Value>) -> Value {
+    let usage = obj.get("usage");
+
+    let input_tokens = usage
+        .and_then(|u| u.get("prompt_tokens"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+
+    let output_tokens = usage
+        .and_then(|u| u.get("completion_tokens"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+
+    let cache_read = usage
+        .and_then(|u| u.get("prompt_tokens_details"))
+        .and_then(|d| d.get("cached_tokens"))
+        .and_then(Value::as_u64);
+
+    let mut usage_obj = json!({
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens
+    });
+
+    if let Some(cached) = cache_read
+        && let Some(obj) = usage_obj.as_object_mut()
+    {
+        obj.insert("cache_read_input_tokens".to_owned(), Value::Number(cached.into()));
+    }
+
+    usage_obj
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+/// Generate a timestamp-based hex identifier for response IDs.
+fn timestamp_hex_id() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+
+    format!("{nanos:024x}")
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_text_response() {
+        let body = br#"{"id":"chatcmpl-1","model":"gpt-4","choices":[{"message":{"role":"assistant","content":"Hello!"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}"#;
+        let tr = transform_response(body, "gpt-4").unwrap();
+        let result = tr.body;
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["type"], "message", "type should be message");
+        assert_eq!(parsed["role"], "assistant", "role should be assistant");
+        assert_eq!(parsed["content"][0]["type"], "text", "content block type");
+        assert_eq!(parsed["content"][0]["text"], "Hello!", "content text");
+        assert_eq!(parsed["stop_reason"], "end_turn", "stop → end_turn");
+        assert_eq!(parsed["usage"]["input_tokens"], 10, "input tokens");
+        assert_eq!(parsed["usage"]["output_tokens"], 5, "output tokens");
+    }
+
+    #[test]
+    fn tool_calls_response() {
+        let body = br#"{"id":"chatcmpl-2","model":"gpt-4","choices":[{"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"NYC\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":20,"completion_tokens":15}}"#;
+        let tr = transform_response(body, "gpt-4").unwrap();
+        let result = tr.body;
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["stop_reason"], "tool_use", "tool_calls → tool_use");
+        assert_eq!(parsed["content"][0]["type"], "tool_use", "tool_use block");
+        assert_eq!(parsed["content"][0]["name"], "get_weather", "tool name");
+        assert_eq!(parsed["content"][0]["input"]["city"], "NYC", "parsed input");
+    }
+
+    #[test]
+    fn length_finish_reason() {
+        let body = br#"{"id":"chatcmpl-3","model":"gpt-4","choices":[{"message":{"role":"assistant","content":"truncated..."},"finish_reason":"length"}],"usage":{"prompt_tokens":10,"completion_tokens":100}}"#;
+        let tr = transform_response(body, "gpt-4").unwrap();
+        let result = tr.body;
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["stop_reason"], "max_tokens", "length → max_tokens");
+    }
+
+    #[test]
+    fn cached_tokens_in_usage() {
+        let body = br#"{"id":"chatcmpl-4","model":"gpt-4","choices":[{"message":{"role":"assistant","content":"Hi"},"finish_reason":"stop"}],"usage":{"prompt_tokens":100,"completion_tokens":5,"prompt_tokens_details":{"cached_tokens":80}}}"#;
+        let tr = transform_response(body, "gpt-4").unwrap();
+        let result = tr.body;
+        let parsed: Value = serde_json::from_slice(&result).unwrap();
+
+        assert_eq!(parsed["usage"]["cache_read_input_tokens"], 80, "cached tokens mapped");
+    }
+}

--- a/filter/src/builtins/http/ai/anthropic/validate/config.rs
+++ b/filter/src/builtins/http/ai/anthropic/validate/config.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Configuration for the Anthropic request validation filter.
+
+use serde::Deserialize;
+
+use crate::FilterError;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Default maximum request body size (1 MiB).
+const DEFAULT_MAX_BODY_BYTES: usize = 1_048_576; // 1 MiB
+
+// -----------------------------------------------------------------------------
+// AnthropicValidateConfig
+// -----------------------------------------------------------------------------
+
+/// YAML configuration for the [`AnthropicValidateFilter`].
+///
+/// [`AnthropicValidateFilter`]: super::AnthropicValidateFilter
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AnthropicValidateConfig {
+    /// Maximum body size in bytes for `StreamBuffer` mode.
+    #[serde(default = "default_max_body_bytes")]
+    pub max_body_bytes: usize,
+}
+
+/// Default max body bytes.
+fn default_max_body_bytes() -> usize {
+    DEFAULT_MAX_BODY_BYTES
+}
+
+// -----------------------------------------------------------------------------
+// Config Validation
+// -----------------------------------------------------------------------------
+
+/// Validate the parsed configuration.
+pub(crate) fn build_config(cfg: AnthropicValidateConfig) -> Result<AnthropicValidateConfig, FilterError> {
+    if cfg.max_body_bytes == 0 {
+        return Err("anthropic_validate: 'max_body_bytes' must be greater than 0".into());
+    }
+    Ok(cfg)
+}

--- a/filter/src/builtins/http/ai/anthropic/validate/mod.rs
+++ b/filter/src/builtins/http/ai/anthropic/validate/mod.rs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Anthropic Messages request validation filter.
+//!
+//! Validates proxy-needed fields before forwarding. Rejects
+//! malformed requests with consistent 400 error responses.
+//! Does not create shared state or initialize persistence —
+//! Anthropic Messages has no stateful orchestration.
+
+mod config;
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    reason = "tests"
+)]
+mod tests;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use tracing::debug;
+
+use self::config::{AnthropicValidateConfig, build_config};
+use crate::{
+    FilterAction, FilterError, Rejection,
+    body::{BodyAccess, BodyMode},
+    factory::parse_filter_config,
+    filter::{HttpFilter, HttpFilterContext},
+};
+
+// -----------------------------------------------------------------------------
+// AnthropicValidateFilter
+// -----------------------------------------------------------------------------
+
+/// Validates Anthropic Messages request bodies for proxy-needed
+/// fields. Rejects malformed requests before they reach the backend.
+///
+/// # YAML
+///
+/// ```yaml
+/// filter: anthropic_validate
+/// ```
+pub struct AnthropicValidateFilter {
+    /// Parsed and validated configuration.
+    config: AnthropicValidateConfig,
+}
+
+impl AnthropicValidateFilter {
+    /// Create a filter from parsed YAML config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] if the YAML config is invalid.
+    pub fn from_config(config: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
+        let cfg: AnthropicValidateConfig = parse_filter_config("anthropic_validate", config)?;
+        let validated = build_config(cfg)?;
+        Ok(Box::new(Self { config: validated }))
+    }
+}
+
+#[async_trait]
+impl HttpFilter for AnthropicValidateFilter {
+    fn name(&self) -> &'static str {
+        "anthropic_validate"
+    }
+
+    fn request_body_access(&self) -> BodyAccess {
+        BodyAccess::ReadOnly
+    }
+
+    fn request_body_mode(&self) -> BodyMode {
+        BodyMode::StreamBuffer {
+            max_bytes: Some(self.config.max_body_bytes),
+        }
+    }
+
+    async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        Ok(FilterAction::Continue)
+    }
+
+    async fn on_request_body(
+        &self,
+        _ctx: &mut HttpFilterContext<'_>,
+        body: &mut Option<Bytes>,
+        end_of_stream: bool,
+    ) -> Result<FilterAction, FilterError> {
+        if !end_of_stream {
+            return Ok(FilterAction::Continue);
+        }
+
+        let bytes = match body.as_ref() {
+            Some(b) if !b.is_empty() => b.as_ref(),
+            _ => return Ok(FilterAction::Continue),
+        };
+
+        if let Some(rejection) = validate_request(bytes) {
+            return Ok(FilterAction::Reject(rejection));
+        }
+
+        debug!("anthropic request validation passed");
+        Ok(FilterAction::Continue)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Validation
+// -----------------------------------------------------------------------------
+
+/// Validate proxy-needed fields in the request body.
+fn validate_request(body: &[u8]) -> Option<Rejection> {
+    let value: serde_json::Value = match serde_json::from_slice(body) {
+        Ok(v) => v,
+        Err(_) => return Some(reject("request body is not valid JSON")),
+    };
+
+    let Some(obj) = value.as_object() else {
+        return Some(reject("request body is not a JSON object"));
+    };
+
+    if let Err(msg) = check_model(obj) {
+        return Some(reject(&msg));
+    }
+
+    if let Err(msg) = check_max_tokens(obj) {
+        return Some(reject(&msg));
+    }
+
+    if let Err(msg) = check_messages(obj) {
+        return Some(reject(&msg));
+    }
+
+    None
+}
+
+/// Check that `model` is present and non-empty.
+fn check_model(obj: &serde_json::Map<String, serde_json::Value>) -> Result<(), String> {
+    match obj.get("model") {
+        Some(serde_json::Value::String(s)) if !s.is_empty() => Ok(()),
+        Some(serde_json::Value::String(_)) => Err("'model' must not be empty".to_owned()),
+        Some(_) => Err("'model' must be a string".to_owned()),
+        None => Err("'model' is required".to_owned()),
+    }
+}
+
+/// Check that `max_tokens` is present and > 0.
+fn check_max_tokens(obj: &serde_json::Map<String, serde_json::Value>) -> Result<(), String> {
+    match obj.get("max_tokens") {
+        Some(serde_json::Value::Number(n)) => {
+            if n.as_u64().is_some_and(|v| v > 0) {
+                Ok(())
+            } else {
+                Err("'max_tokens' must be a positive integer".to_owned())
+            }
+        },
+        Some(_) => Err("'max_tokens' must be a number".to_owned()),
+        None => Err("'max_tokens' is required".to_owned()),
+    }
+}
+
+/// Check that `messages` is a non-empty array.
+///
+/// Role ordering (e.g. first message must be `role: user`) is
+/// deferred to the backend, consistent with validating only what
+/// the proxy needs for its own operation.
+fn check_messages(obj: &serde_json::Map<String, serde_json::Value>) -> Result<(), String> {
+    let Some(serde_json::Value::Array(messages)) = obj.get("messages") else {
+        return Err("'messages' must be a non-empty array".to_owned());
+    };
+
+    if messages.is_empty() {
+        return Err("'messages' must not be empty".to_owned());
+    }
+
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+/// Build a 400 rejection with a JSON error body.
+fn reject(message: &str) -> Rejection {
+    Rejection::status(400)
+        .with_header("content-type", "application/json")
+        .with_body(Bytes::from(format!(
+            r#"{{"error":{{"message":"{message}","type":"invalid_request_error"}}}}"#
+        )))
+}

--- a/filter/src/builtins/http/ai/anthropic/validate/tests.rs
+++ b/filter/src/builtins/http/ai/anthropic/validate/tests.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Unit tests for the `anthropic_validate` filter.
+
+use super::*;
+
+// -----------------------------------------------------------------------------
+// Validation Logic
+// -----------------------------------------------------------------------------
+
+#[test]
+fn valid_request_passes() {
+    let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"Hi"}]}"#;
+    assert!(validate_request(body).is_none(), "valid request should pass");
+}
+
+#[test]
+fn missing_model_rejected() {
+    let body = br#"{"max_tokens":1024,"messages":[{"role":"user","content":"Hi"}]}"#;
+    let rejection = validate_request(body);
+    assert!(rejection.is_some(), "missing model should be rejected");
+}
+
+#[test]
+fn empty_model_rejected() {
+    let body = br#"{"model":"","max_tokens":1024,"messages":[{"role":"user","content":"Hi"}]}"#;
+    let rejection = validate_request(body);
+    assert!(rejection.is_some(), "empty model should be rejected");
+}
+
+#[test]
+fn missing_max_tokens_rejected() {
+    let body = br#"{"model":"claude-opus-4-8","messages":[{"role":"user","content":"Hi"}]}"#;
+    let rejection = validate_request(body);
+    assert!(rejection.is_some(), "missing max_tokens should be rejected");
+}
+
+#[test]
+fn zero_max_tokens_rejected() {
+    let body = br#"{"model":"claude-opus-4-8","max_tokens":0,"messages":[{"role":"user","content":"Hi"}]}"#;
+    let rejection = validate_request(body);
+    assert!(rejection.is_some(), "zero max_tokens should be rejected");
+}
+
+#[test]
+fn missing_messages_rejected() {
+    let body = br#"{"model":"claude-opus-4-8","max_tokens":1024}"#;
+    let rejection = validate_request(body);
+    assert!(rejection.is_some(), "missing messages should be rejected");
+}
+
+#[test]
+fn empty_messages_rejected() {
+    let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[]}"#;
+    let rejection = validate_request(body);
+    assert!(rejection.is_some(), "empty messages should be rejected");
+}
+
+#[test]
+fn first_message_not_user_passes() {
+    let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"assistant","content":"Hi"}]}"#;
+    assert!(validate_request(body).is_none(), "role ordering deferred to backend");
+}
+
+#[test]
+fn invalid_json_rejected() {
+    let body = b"not json {{{";
+    let rejection = validate_request(body);
+    assert!(rejection.is_some(), "invalid JSON should be rejected");
+}
+
+// -----------------------------------------------------------------------------
+// Config
+// -----------------------------------------------------------------------------
+
+#[test]
+fn default_config_parses() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("{}").unwrap();
+    let filter = AnthropicValidateFilter::from_config(&yaml).unwrap();
+    assert_eq!(
+        filter.name(),
+        "anthropic_validate",
+        "filter name should be anthropic_validate"
+    );
+}
+
+#[test]
+fn zero_max_body_bytes_rejected() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str("max_body_bytes: 0").unwrap();
+    let result = AnthropicValidateFilter::from_config(&yaml);
+    assert!(result.is_err(), "zero max_body_bytes should be rejected");
+}

--- a/filter/src/builtins/http/ai/classifier/mod.rs
+++ b/filter/src/builtins/http/ai/classifier/mod.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Praxis Contributors
 
-//! Pure request body classifier for Responses API versus Chat Completions.
+//! Pure request body classifier for AI API format detection.
+//!
+//! Disambiguates Responses API, Anthropic Messages, and Chat
+//! Completions from a single JSON body parse.
 
 // -----------------------------------------------------------------------------
 // AiRequestFormat
@@ -12,7 +15,9 @@
 pub(crate) enum AiRequestFormat {
     /// `OpenAI` Responses API (has `input` field).
     Responses,
-    /// Chat Completions API (has `messages` field).
+    /// Anthropic Messages API (`messages` + required `max_tokens`).
+    AnthropicMessages,
+    /// Chat Completions API (has `messages` without required `max_tokens`).
     ChatCompletions,
     /// Valid JSON but neither recognized format.
     UnknownJson,
@@ -27,6 +32,7 @@ impl AiRequestFormat {
     pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::Responses => "openai_responses",
+            Self::AnthropicMessages => "anthropic_messages",
             Self::ChatCompletions => "openai_chat_completions",
             Self::UnknownJson => "unknown",
             Self::InvalidJson => "invalid_json",
@@ -55,6 +61,8 @@ pub(crate) struct ClassifiedRequest {
     pub has_prompt_id: bool,
     /// Whether `tools` is a non-empty array.
     pub has_tools: bool,
+    /// Extracted `max_tokens` field value, if present.
+    pub max_tokens: Option<u64>,
     /// Extracted `model` field value, if present.
     pub model: Option<String>,
     /// Extracted `store` field value, if present.
@@ -134,24 +142,62 @@ pub(crate) fn classify_request_body(body: &[u8]) -> ClassifiedRequest {
         has_tools: obj
             .get("tools")
             .is_some_and(|v| v.as_array().is_some_and(|a| !a.is_empty())),
+        max_tokens: obj.get("max_tokens").and_then(serde_json::Value::as_u64),
         model: extract_string(obj, "model"),
         store: obj.get("store").and_then(serde_json::Value::as_bool),
         stream: obj.get("stream").and_then(serde_json::Value::as_bool),
     }
 }
 
-/// Determine format from top-level keys. When both `input` and
-/// `messages` are present, `input` takes precedence (Responses API).
-/// A `prompt` object also indicates a Responses API request (prompt
-/// template usage per `OpenAI` Prompts guide).
+/// Determine format from top-level keys.
+///
+/// Precedence: `input` or `prompt` object → Responses, then
+/// `messages` with Anthropic signals → Anthropic Messages, then
+/// `messages` alone → Chat Completions.
+///
+/// Anthropic signals: `max_tokens` is required AND at least one of
+/// top-level `system` field or typed content blocks (arrays of
+/// objects with a `type` key in `messages`). This prevents false
+/// positives when `OpenAI` Chat Completions requests include the
+/// optional `max_tokens` field.
 fn classify_format(obj: &serde_json::Map<String, serde_json::Value>) -> AiRequestFormat {
     if obj.contains_key("input") || obj.get("prompt").is_some_and(serde_json::Value::is_object) {
-        AiRequestFormat::Responses
-    } else if obj.contains_key("messages") {
-        AiRequestFormat::ChatCompletions
-    } else {
-        AiRequestFormat::UnknownJson
+        return AiRequestFormat::Responses;
     }
+
+    if obj.contains_key("messages") {
+        if obj.contains_key("max_tokens") && has_anthropic_signals(obj) {
+            return AiRequestFormat::AnthropicMessages;
+        }
+        return AiRequestFormat::ChatCompletions;
+    }
+
+    AiRequestFormat::UnknownJson
+}
+
+/// Check for Anthropic-specific structural signals beyond `max_tokens`.
+///
+/// Returns true if any of:
+/// - Top-level `system` field is present (Anthropic separates system from messages; `OpenAI` puts it in the messages
+///   array)
+/// - Any message in `messages` has typed content blocks (array of objects with a `type` key, e.g. `[{"type": "text",
+///   ...}]`)
+fn has_anthropic_signals(obj: &serde_json::Map<String, serde_json::Value>) -> bool {
+    if obj.contains_key("system") {
+        return true;
+    }
+
+    if let Some(serde_json::Value::Array(messages)) = obj.get("messages") {
+        for msg in messages {
+            if let Some(serde_json::Value::Array(blocks)) = msg.get("content")
+                && blocks.iter().any(|b| b.get("type").is_some())
+            {
+                return true;
+            }
+        }
+    }
+
+    false
 }
 
 // -----------------------------------------------------------------------------
@@ -167,6 +213,7 @@ pub(crate) fn empty_result(format: AiRequestFormat) -> ClassifiedRequest {
         has_previous_response_id: false,
         has_prompt_id: false,
         has_tools: false,
+        max_tokens: None,
         model: None,
         store: None,
         stream: None,
@@ -271,14 +318,14 @@ mod tests {
     }
 
     #[test]
-    fn chat_completions_messages() {
+    fn chat_completions_messages_without_max_tokens() {
         let body = br#"{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}"#;
         let result = classify_request_body(body);
 
         assert_eq!(
             result.format,
             AiRequestFormat::ChatCompletions,
-            "messages array should classify as openai_chat_completions"
+            "messages without max_tokens should classify as chat_completions"
         );
         assert_eq!(result.model.as_deref(), Some("gpt-4"), "model should be extracted");
     }
@@ -291,9 +338,64 @@ mod tests {
         assert_eq!(
             result.format,
             AiRequestFormat::ChatCompletions,
-            "should be openai_chat_completions"
+            "should be chat_completions"
         );
         assert_eq!(result.stream, Some(true), "stream should be extracted");
+    }
+
+    #[test]
+    fn anthropic_messages_with_system() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"system":"Be helpful.","messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::AnthropicMessages,
+            "messages + max_tokens + system should classify as anthropic_messages"
+        );
+        assert_eq!(
+            result.model.as_deref(),
+            Some("claude-opus-4-8"),
+            "model should be extracted"
+        );
+        assert_eq!(result.max_tokens, Some(1024), "max_tokens should be extracted");
+    }
+
+    #[test]
+    fn anthropic_messages_with_typed_content_blocks() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":512,"messages":[{"role":"user","content":[{"type":"text","text":"Hi"}]}],"stream":true}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::AnthropicMessages,
+            "typed content blocks should classify as anthropic_messages"
+        );
+        assert_eq!(result.stream, Some(true), "stream should be extracted");
+    }
+
+    #[test]
+    fn chat_completions_with_max_tokens_not_misclassified() {
+        let body = br#"{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}],"max_tokens":100}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::ChatCompletions,
+            "messages + max_tokens without Anthropic signals should be chat_completions"
+        );
+    }
+
+    #[test]
+    fn anthropic_messages_max_tokens_without_signals_is_chat() {
+        let body = br#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::ChatCompletions,
+            "max_tokens + string content + no system should be chat_completions — header override disambiguates in the filter layer"
+        );
     }
 
     #[test]

--- a/filter/src/builtins/http/ai/mod.rs
+++ b/filter/src/builtins/http/ai/mod.rs
@@ -6,6 +6,10 @@
 
 pub(crate) mod agentic;
 #[cfg(feature = "ai-inference")]
+mod anthropic;
+#[cfg(feature = "ai-inference")]
+pub(crate) mod classifier;
+#[cfg(feature = "ai-inference")]
 mod inference;
 #[cfg(feature = "ai-inference")]
 pub(crate) mod openai;
@@ -21,6 +25,16 @@ pub(crate) mod store;
 pub mod token_usage;
 
 pub use agentic::{A2aFilter, JsonRpcFilter, McpFilter};
+#[cfg(feature = "ai-inference")]
+pub use anthropic::AnthropicMessagesFormatFilter;
+#[cfg(feature = "ai-inference")]
+pub use anthropic::AnthropicPassthroughFilter;
+#[cfg(feature = "ai-inference")]
+pub use anthropic::AnthropicStreamEventsFilter;
+#[cfg(feature = "ai-inference")]
+pub use anthropic::AnthropicToOpenaiFilter;
+#[cfg(feature = "ai-inference")]
+pub use anthropic::AnthropicValidateFilter;
 #[cfg(feature = "ai-inference")]
 pub use inference::ModelToHeaderFilter;
 #[cfg(feature = "ai-inference")]

--- a/filter/src/builtins/http/ai/openai/responses/mod.rs
+++ b/filter/src/builtins/http/ai/openai/responses/mod.rs
@@ -17,7 +17,6 @@
 //! The `openai_responses_validate` filter runs after the classifier
 //! to validate parameter combinations and extract additional fields.
 
-pub(crate) mod classifier;
 mod config;
 #[allow(
     dead_code,
@@ -46,9 +45,9 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use tracing::{debug, trace};
 
-use self::{
-    classifier::{AiRequestFormat, classify_request_body, is_responses_path},
-    config::{OnInvalidBehavior, ResponsesFormatConfig, build_config},
+use self::config::{OnInvalidBehavior, ResponsesFormatConfig, build_config};
+use crate::builtins::http::ai::classifier::{
+    AiRequestFormat, ClassifiedRequest, classify_request_body, empty_result, is_responses_path,
 };
 
 // -----------------------------------------------------------------------------
@@ -151,7 +150,7 @@ impl HttpFilter for ResponsesFormatFilter {
                 path = ctx.request.uri.path(),
                 "classified request by method and path"
             );
-            classifier::empty_result(AiRequestFormat::Responses)
+            empty_result(AiRequestFormat::Responses)
         } else {
             classify_request_body(bytes)
         };
@@ -189,7 +188,9 @@ fn handle_invalid_format(format: AiRequestFormat, config: &ResponsesFormatConfig
                 AiRequestFormat::InvalidJson => "invalid JSON body",
                 AiRequestFormat::NonJson => "request body is not JSON",
                 AiRequestFormat::UnknownJson => "unrecognized AI API format",
-                AiRequestFormat::Responses | AiRequestFormat::ChatCompletions => return None,
+                AiRequestFormat::Responses | AiRequestFormat::AnthropicMessages | AiRequestFormat::ChatCompletions => {
+                    return None;
+                },
             };
 
             trace!(reason = message, "rejecting unrecognized body");
@@ -210,7 +211,7 @@ fn handle_invalid_format(format: AiRequestFormat, config: &ResponsesFormatConfig
 /// (conversation history, tools, persistence, or background processing)
 /// and `Some("stateless")` when it can be forwarded directly to a
 /// native Responses backend. Returns `None` for non-Responses formats.
-fn compute_mode(classified: &classifier::ClassifiedRequest) -> Option<&'static str> {
+fn compute_mode(classified: &ClassifiedRequest) -> Option<&'static str> {
     if classified.format != AiRequestFormat::Responses {
         return None;
     }
@@ -225,7 +226,7 @@ fn compute_mode(classified: &classifier::ClassifiedRequest) -> Option<&'static s
 }
 
 /// Write durable metadata that persists across all Pingora lifecycle phases.
-fn write_metadata(ctx: &mut HttpFilterContext<'_>, classified: &classifier::ClassifiedRequest, mode: Option<&str>) {
+fn write_metadata(ctx: &mut HttpFilterContext<'_>, classified: &ClassifiedRequest, mode: Option<&str>) {
     ctx.set_metadata("openai_responses_format.format", classified.format.as_str());
     write_optional_metadata(ctx, classified);
     write_boolean_metadata(ctx, classified);
@@ -236,7 +237,7 @@ fn write_metadata(ctx: &mut HttpFilterContext<'_>, classified: &classifier::Clas
 }
 
 /// Write optional string and boolean-option metadata fields.
-fn write_optional_metadata(ctx: &mut HttpFilterContext<'_>, classified: &classifier::ClassifiedRequest) {
+fn write_optional_metadata(ctx: &mut HttpFilterContext<'_>, classified: &ClassifiedRequest) {
     if let Some(model) = &classified.model
         && is_safe_promoted_value(model)
     {
@@ -260,7 +261,7 @@ fn write_optional_metadata(ctx: &mut HttpFilterContext<'_>, classified: &classif
 }
 
 /// Write boolean presence flags to metadata.
-fn write_boolean_metadata(ctx: &mut HttpFilterContext<'_>, classified: &classifier::ClassifiedRequest) {
+fn write_boolean_metadata(ctx: &mut HttpFilterContext<'_>, classified: &ClassifiedRequest) {
     if classified.has_previous_response_id {
         ctx.set_metadata("openai_responses_format.has_previous_response_id", "true");
     }
@@ -278,7 +279,7 @@ fn write_boolean_metadata(ctx: &mut HttpFilterContext<'_>, classified: &classifi
 /// Promote classification facts to configurable request headers.
 fn promote_headers(
     ctx: &mut HttpFilterContext<'_>,
-    classified: &classifier::ClassifiedRequest,
+    classified: &ClassifiedRequest,
     config: &ResponsesFormatConfig,
     mode: Option<&str>,
 ) {
@@ -316,7 +317,7 @@ fn promote_headers(
 /// Promote classification facts to filter results for branch conditions.
 fn promote_filter_results(
     ctx: &mut HttpFilterContext<'_>,
-    classified: &classifier::ClassifiedRequest,
+    classified: &ClassifiedRequest,
     mode: Option<&'static str>,
 ) -> Result<(), FilterError> {
     let results = ctx.filter_results.entry("openai_responses_format").or_default();
@@ -335,7 +336,7 @@ fn promote_filter_results(
 /// Promote optional string and boolean-option fields to filter results.
 fn promote_optional_results(
     results: &mut crate::results::FilterResultSet,
-    classified: &classifier::ClassifiedRequest,
+    classified: &ClassifiedRequest,
 ) -> Result<(), FilterError> {
     if let Some(model) = &classified.model
         && is_safe_promoted_value(model)
@@ -362,7 +363,7 @@ fn promote_optional_results(
 /// Promote boolean presence flags to filter results.
 fn promote_boolean_results(
     results: &mut crate::results::FilterResultSet,
-    classified: &classifier::ClassifiedRequest,
+    classified: &ClassifiedRequest,
 ) -> Result<(), FilterError> {
     if classified.has_previous_response_id {
         results.set("has_previous_response_id", "true")?;

--- a/filter/src/builtins/http/mod.rs
+++ b/filter/src/builtins/http/mod.rs
@@ -12,6 +12,16 @@ mod transformation;
 pub(crate) mod value_safety;
 
 #[cfg(feature = "ai-inference")]
+pub use ai::AnthropicMessagesFormatFilter;
+#[cfg(feature = "ai-inference")]
+pub use ai::AnthropicPassthroughFilter;
+#[cfg(feature = "ai-inference")]
+pub use ai::AnthropicStreamEventsFilter;
+#[cfg(feature = "ai-inference")]
+pub use ai::AnthropicToOpenaiFilter;
+#[cfg(feature = "ai-inference")]
+pub use ai::AnthropicValidateFilter;
+#[cfg(feature = "ai-inference")]
 pub use ai::ModelToHeaderFilter;
 #[cfg(feature = "ai-inference")]
 pub use ai::OpenaiResponsesValidateFilter;

--- a/filter/src/builtins/mod.rs
+++ b/filter/src/builtins/mod.rs
@@ -7,6 +7,16 @@ pub(crate) mod http;
 mod tcp;
 
 #[cfg(feature = "ai-inference")]
+pub use http::AnthropicMessagesFormatFilter;
+#[cfg(feature = "ai-inference")]
+pub use http::AnthropicPassthroughFilter;
+#[cfg(feature = "ai-inference")]
+pub use http::AnthropicStreamEventsFilter;
+#[cfg(feature = "ai-inference")]
+pub use http::AnthropicToOpenaiFilter;
+#[cfg(feature = "ai-inference")]
+pub use http::AnthropicValidateFilter;
+#[cfg(feature = "ai-inference")]
 pub use http::ModelToHeaderFilter;
 #[cfg(feature = "ai-inference")]
 pub use http::OpenaiResponsesValidateFilter;

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -25,6 +25,16 @@ pub use actions::{FilterAction, Rejection};
 pub use any_filter::AnyFilter;
 pub use body::{BodyAccess, BodyBuffer, BodyBufferOverflow, BodyCapabilities, BodyMode};
 #[cfg(feature = "ai-inference")]
+pub use builtins::AnthropicMessagesFormatFilter;
+#[cfg(feature = "ai-inference")]
+pub use builtins::AnthropicPassthroughFilter;
+#[cfg(feature = "ai-inference")]
+pub use builtins::AnthropicStreamEventsFilter;
+#[cfg(feature = "ai-inference")]
+pub use builtins::AnthropicToOpenaiFilter;
+#[cfg(feature = "ai-inference")]
+pub use builtins::AnthropicValidateFilter;
+#[cfg(feature = "ai-inference")]
 pub use builtins::OpenaiResponsesValidateFilter;
 #[cfg(feature = "ai-inference")]
 pub use builtins::PromptEnrichFilter;

--- a/filter/src/registry.rs
+++ b/filter/src/registry.rs
@@ -146,6 +146,36 @@ fn register_http_builtins(factories: &mut HashMap<String, FilterFactory>) {
     #[cfg(feature = "ai-inference")]
     register_http(
         factories,
+        "anthropic_messages_format",
+        crate::builtins::AnthropicMessagesFormatFilter::from_config,
+    );
+    #[cfg(feature = "ai-inference")]
+    register_http(
+        factories,
+        "anthropic_passthrough",
+        crate::builtins::AnthropicPassthroughFilter::from_config,
+    );
+    #[cfg(feature = "ai-inference")]
+    register_http(
+        factories,
+        "anthropic_validate",
+        crate::builtins::AnthropicValidateFilter::from_config,
+    );
+    #[cfg(feature = "ai-inference")]
+    register_http(
+        factories,
+        "anthropic_stream_events",
+        crate::builtins::AnthropicStreamEventsFilter::from_config,
+    );
+    #[cfg(feature = "ai-inference")]
+    register_http(
+        factories,
+        "anthropic_to_openai",
+        crate::builtins::AnthropicToOpenaiFilter::from_config,
+    );
+    #[cfg(feature = "ai-inference")]
+    register_http(
+        factories,
         "model_to_header",
         crate::builtins::ModelToHeaderFilter::from_config,
     );
@@ -288,6 +318,31 @@ mod tests {
         );
         #[cfg(feature = "ai-inference")]
         assert!(names.contains(&"prompt_enrich"), "prompt_enrich should be registered");
+        #[cfg(feature = "ai-inference")]
+        assert!(
+            names.contains(&"anthropic_messages_format"),
+            "anthropic_messages_format should be registered"
+        );
+        #[cfg(feature = "ai-inference")]
+        assert!(
+            names.contains(&"anthropic_passthrough"),
+            "anthropic_passthrough should be registered"
+        );
+        #[cfg(feature = "ai-inference")]
+        assert!(
+            names.contains(&"anthropic_validate"),
+            "anthropic_validate should be registered"
+        );
+        #[cfg(feature = "ai-inference")]
+        assert!(
+            names.contains(&"anthropic_stream_events"),
+            "anthropic_stream_events should be registered"
+        );
+        #[cfg(feature = "ai-inference")]
+        assert!(
+            names.contains(&"anthropic_to_openai"),
+            "anthropic_to_openai should be registered"
+        );
         #[cfg(feature = "ai-inference")]
         assert!(
             names.contains(&"openai_responses_format"),

--- a/tests/integration/tests/suite/anthropic_messages.rs
+++ b/tests/integration/tests/suite/anthropic_messages.rs
@@ -1,0 +1,539 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Integration tests for Anthropic Messages API filters.
+//!
+//! Ported from OGX's `test_messages.py` — each Rust test maps 1:1
+//! to its Python counterpart. Tests validate the full request/response
+//! cycle through Praxis with passthrough and transform filter chains.
+
+use praxis_core::config::Config;
+use praxis_test_utils::{
+    Backend, free_port, http_send, parse_body, parse_status, start_backend_with_shutdown, start_proxy,
+};
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+const BASIC_RESPONSE: &str = r#"{"id":"msg_test123","type":"message","role":"assistant","model":"mock-model","content":[{"type":"text","text":"The answer is 4."}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":15,"output_tokens":8}}"#;
+
+const SYSTEM_RESPONSE: &str = r#"{"id":"msg_test456","type":"message","role":"assistant","model":"mock-model","content":[{"type":"text","text":"Arrr, I be a helpful pirate assistant!"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":25,"output_tokens":12}}"#;
+
+const MULTI_TURN_RESPONSE: &str = r#"{"id":"msg_test789","type":"message","role":"assistant","model":"mock-model","content":[{"type":"text","text":"Your name is Alice."}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":30,"output_tokens":6}}"#;
+
+const TEMPERATURE_RESPONSE: &str = r#"{"id":"msg_temp01","type":"message","role":"assistant","model":"mock-model","content":[{"type":"text","text":"Hello!"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":3}}"#;
+
+const STOP_SEQUENCES_RESPONSE: &str = r#"{"id":"msg_stop01","type":"message","role":"assistant","model":"mock-model","content":[{"type":"text","text":"Count: 1"}],"stop_reason":"stop_sequence","stop_sequence":",","usage":{"input_tokens":20,"output_tokens":4}}"#;
+
+const TOOL_DEFS_RESPONSE: &str = r#"{"id":"msg_tool01","type":"message","role":"assistant","model":"mock-model","content":[{"type":"tool_use","id":"toolu_test01","name":"get_weather","input":{"location":"San Francisco, CA"}}],"stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":40,"output_tokens":20}}"#;
+
+const TOOL_RESULT_RESPONSE: &str = r#"{"id":"msg_tool02","type":"message","role":"assistant","model":"mock-model","content":[{"type":"text","text":"15 times 7 equals 105."}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":50,"output_tokens":10}}"#;
+
+const CONTENT_BLOCK_RESPONSE: &str = r#"{"id":"msg_block01","type":"message","role":"assistant","model":"mock-model","content":[{"type":"text","text":"2"}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":12,"output_tokens":2}}"#;
+
+const SSE_RESPONSE: &str = "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_stream01\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"mock-model\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":10,\"output_tokens\":0}}}\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" there\"}}\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n";
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+/// OGX: test_messages_non_streaming_basic
+#[test]
+fn non_streaming_basic() {
+    let backend = Backend::fixed(BASIC_RESPONSE)
+        .header("content-type", "application/json")
+        .header("anthropic-version", "2023-06-01")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = Config::from_yaml(&passthrough_yaml(proxy_port, backend.port())).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &anthropic_post(
+            "/v1/messages",
+            r#"{"model":"mock-model","messages":[{"role":"user","content":"What is 2+2? Reply with just the number."}],"max_tokens":64}"#,
+        ),
+    );
+    let status = parse_status(&raw);
+    let body = parse_body(&raw);
+    let data: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(status, 200, "expected 200");
+    assert_eq!(data["type"], "message", "type should be message");
+    assert_eq!(data["role"], "assistant", "role should be assistant");
+    assert!(
+        data["id"].as_str().unwrap().starts_with("msg_"),
+        "id should start with msg_"
+    );
+    let content = data["content"].as_array().unwrap();
+    assert!(!content.is_empty(), "content should not be empty");
+    let text_blocks: Vec<_> = content.iter().filter(|b| b["type"] == "text").collect();
+    assert!(!text_blocks.is_empty(), "should have at least one text block");
+    assert!(
+        !text_blocks[0]["text"].as_str().unwrap().is_empty(),
+        "text should not be empty"
+    );
+    assert!(
+        ["end_turn", "max_tokens"].contains(&data["stop_reason"].as_str().unwrap()),
+        "stop_reason should be end_turn or max_tokens"
+    );
+    assert!(
+        data["usage"]["input_tokens"].as_u64().unwrap() > 0,
+        "input_tokens should be > 0"
+    );
+    assert!(
+        data["usage"]["output_tokens"].as_u64().unwrap() > 0,
+        "output_tokens should be > 0"
+    );
+    for block in content {
+        assert!(
+            ["text", "thinking", "tool_use"].contains(&block["type"].as_str().unwrap()),
+            "block type should be text, thinking, or tool_use"
+        );
+    }
+}
+
+/// OGX: test_messages_non_streaming_with_system
+#[test]
+fn non_streaming_with_system() {
+    let backend = Backend::fixed(SYSTEM_RESPONSE)
+        .header("content-type", "application/json")
+        .header("anthropic-version", "2023-06-01")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = Config::from_yaml(&passthrough_yaml(proxy_port, backend.port())).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &anthropic_post(
+            "/v1/messages",
+            r#"{"model":"mock-model","messages":[{"role":"user","content":"What are you?"}],"system":"You are a helpful pirate. Always respond in pirate speak.","max_tokens":128}"#,
+        ),
+    );
+    let status = parse_status(&raw);
+    let body = parse_body(&raw);
+    let data: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(status, 200, "expected 200");
+    assert_eq!(data["type"], "message", "type should be message");
+    let content = data["content"].as_array().unwrap();
+    assert!(!content.is_empty(), "content should not be empty");
+    let text_blocks: Vec<_> = content.iter().filter(|b| b["type"] == "text").collect();
+    assert!(!text_blocks.is_empty(), "should have at least one text block");
+    assert!(
+        !text_blocks[0]["text"].as_str().unwrap().is_empty(),
+        "text should not be empty"
+    );
+}
+
+/// OGX: test_messages_non_streaming_multi_turn
+#[test]
+fn non_streaming_multi_turn() {
+    let backend = Backend::fixed(MULTI_TURN_RESPONSE)
+        .header("content-type", "application/json")
+        .header("anthropic-version", "2023-06-01")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = Config::from_yaml(&passthrough_yaml(proxy_port, backend.port())).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &anthropic_post(
+            "/v1/messages",
+            r#"{"model":"mock-model","messages":[{"role":"user","content":"My name is Alice."},{"role":"assistant","content":"Hello Alice! Nice to meet you."},{"role":"user","content":"What is my name?"}],"max_tokens":64}"#,
+        ),
+    );
+    let status = parse_status(&raw);
+    let body = parse_body(&raw);
+    let data: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(status, 200, "expected 200");
+    assert_eq!(data["type"], "message", "type should be message");
+    let content = data["content"].as_array().unwrap();
+    assert!(!content.is_empty(), "content should not be empty");
+    let text_blocks: Vec<_> = content.iter().filter(|b| b["type"] == "text").collect();
+    assert!(!text_blocks.is_empty(), "should have at least one text block");
+    let text = text_blocks[0]["text"].as_str().unwrap().to_lowercase();
+    assert!(text.contains("alice"), "response should mention Alice");
+}
+
+/// OGX: test_messages_streaming_basic
+#[test]
+fn streaming_basic() {
+    let backend = Backend::fixed(SSE_RESPONSE)
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-cache")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = Config::from_yaml(&passthrough_yaml(proxy_port, backend.port())).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &anthropic_post(
+            "/v1/messages",
+            r#"{"model":"mock-model","messages":[{"role":"user","content":"Say hello in one sentence."}],"max_tokens":64,"stream":true}"#,
+        ),
+    );
+    let body = parse_body(&raw);
+
+    let events = parse_sse_events(&body);
+    let event_types: Vec<&str> = events.iter().filter_map(|e| e["_event_type"].as_str()).collect();
+
+    assert!(event_types.contains(&"message_start"), "should have message_start");
+    assert!(event_types.contains(&"message_stop"), "should have message_stop");
+
+    let msg_start = events.iter().find(|e| e["_event_type"] == "message_start").unwrap();
+    assert_eq!(
+        msg_start["message"]["role"], "assistant",
+        "message_start role should be assistant"
+    );
+
+    let content_deltas: Vec<_> = events
+        .iter()
+        .filter(|e| e["_event_type"] == "content_block_delta")
+        .collect();
+    assert!(
+        !content_deltas.is_empty(),
+        "should have at least one content_block_delta"
+    );
+
+    for delta in &content_deltas {
+        assert!(
+            ["text_delta", "thinking_delta"].contains(&delta["delta"]["type"].as_str().unwrap()),
+            "delta type should be text_delta or thinking_delta"
+        );
+    }
+}
+
+/// OGX: test_messages_streaming_collects_full_text
+#[test]
+fn streaming_collects_full_text() {
+    let backend = Backend::fixed(SSE_RESPONSE)
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-cache")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = Config::from_yaml(&passthrough_yaml(proxy_port, backend.port())).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &anthropic_post(
+            "/v1/messages",
+            r#"{"model":"mock-model","messages":[{"role":"user","content":"Count from 1 to 5, separated by commas."}],"max_tokens":64,"stream":true}"#,
+        ),
+    );
+    let body = parse_body(&raw);
+    let events = parse_sse_events(&body);
+
+    let full_text: String = events
+        .iter()
+        .filter(|e| e["_event_type"] == "content_block_delta")
+        .filter(|e| e["delta"]["type"] == "text_delta")
+        .filter_map(|e| e["delta"]["text"].as_str())
+        .collect();
+
+    assert!(!full_text.is_empty(), "collected text should not be empty");
+}
+
+/// OGX: test_messages_non_streaming_with_temperature
+#[test]
+fn non_streaming_with_temperature() {
+    let backend = Backend::fixed(TEMPERATURE_RESPONSE)
+        .header("content-type", "application/json")
+        .header("anthropic-version", "2023-06-01")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = Config::from_yaml(&passthrough_yaml(proxy_port, backend.port())).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &anthropic_post(
+            "/v1/messages",
+            r#"{"model":"mock-model","messages":[{"role":"user","content":"Say hello."}],"max_tokens":32,"temperature":0.0}"#,
+        ),
+    );
+    let status = parse_status(&raw);
+    let body = parse_body(&raw);
+    let data: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(status, 200, "expected 200");
+    assert_eq!(data["type"], "message", "type should be message");
+    assert!(
+        !data["content"].as_array().unwrap().is_empty(),
+        "content should not be empty"
+    );
+}
+
+/// OGX: test_messages_non_streaming_with_stop_sequences
+#[test]
+fn non_streaming_with_stop_sequences() {
+    let backend = Backend::fixed(STOP_SEQUENCES_RESPONSE)
+        .header("content-type", "application/json")
+        .header("anthropic-version", "2023-06-01")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = Config::from_yaml(&passthrough_yaml(proxy_port, backend.port())).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &anthropic_post(
+            "/v1/messages",
+            r#"{"model":"mock-model","messages":[{"role":"user","content":"Count: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10"}],"max_tokens":128,"stop_sequences":[","]}"#,
+        ),
+    );
+    let status = parse_status(&raw);
+    let body = parse_body(&raw);
+    let data: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(status, 200, "expected 200");
+    assert_eq!(data["type"], "message", "type should be message");
+}
+
+/// OGX: test_messages_with_tool_definitions
+#[test]
+fn with_tool_definitions() {
+    let backend = Backend::fixed(TOOL_DEFS_RESPONSE)
+        .header("content-type", "application/json")
+        .header("anthropic-version", "2023-06-01")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = Config::from_yaml(&passthrough_yaml(proxy_port, backend.port())).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &anthropic_post(
+            "/v1/messages",
+            r#"{"model":"mock-model","messages":[{"role":"user","content":"What's the weather in San Francisco?"}],"tools":[{"name":"get_weather","description":"Get the current weather in a given location","input_schema":{"type":"object","properties":{"location":{"type":"string","description":"The city and state"}},"required":["location"]}}],"max_tokens":256}"#,
+        ),
+    );
+    let status = parse_status(&raw);
+    let body = parse_body(&raw);
+    let data: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(status, 200, "expected 200");
+    assert_eq!(data["type"], "message", "type should be message");
+    let content = data["content"].as_array().unwrap();
+    assert!(!content.is_empty(), "content should not be empty");
+
+    for block in content {
+        assert!(
+            ["text", "tool_use", "thinking"].contains(&block["type"].as_str().unwrap()),
+            "block type should be text, tool_use, or thinking"
+        );
+        if block["type"] == "tool_use" {
+            assert!(block["id"].is_string(), "tool_use should have id");
+            assert_eq!(block["name"], "get_weather", "tool name should be get_weather");
+            assert!(block["input"].is_object(), "tool_use should have input");
+        }
+    }
+}
+
+/// OGX: test_messages_tool_use_round_trip
+#[test]
+fn tool_use_round_trip() {
+    let backend = Backend::fixed(TOOL_RESULT_RESPONSE)
+        .header("content-type", "application/json")
+        .header("anthropic-version", "2023-06-01")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = Config::from_yaml(&passthrough_yaml(proxy_port, backend.port())).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &anthropic_post(
+            "/v1/messages",
+            r#"{"model":"mock-model","messages":[{"role":"user","content":"Use the calculator tool to compute 15 * 7."},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_test01","name":"calculator","input":{"expression":"15 * 7"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_test01","content":"105"}]}],"tools":[{"name":"calculator","description":"Perform basic arithmetic.","input_schema":{"type":"object","properties":{"expression":{"type":"string"}},"required":["expression"]}}],"max_tokens":256}"#,
+        ),
+    );
+    let status = parse_status(&raw);
+    let body = parse_body(&raw);
+    let data: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(status, 200, "expected 200");
+    assert_eq!(data["type"], "message", "type should be message");
+    assert!(
+        !data["content"].as_array().unwrap().is_empty(),
+        "content should not be empty"
+    );
+}
+
+/// OGX: test_messages_error_missing_model
+#[test]
+fn error_missing_model() {
+    let backend = start_backend_with_shutdown("should not reach backend");
+    let proxy_port = free_port();
+    let config = Config::from_yaml(&passthrough_yaml(proxy_port, backend.port())).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &anthropic_post(
+            "/v1/messages",
+            r#"{"messages":[{"role":"user","content":"Hello"}],"max_tokens":64}"#,
+        ),
+    );
+    let status = parse_status(&raw);
+
+    assert!(
+        [400, 422].contains(&status),
+        "missing model should return 400 or 422, got {status}"
+    );
+}
+
+/// OGX: test_messages_error_empty_messages
+#[test]
+fn error_empty_messages() {
+    let backend = start_backend_with_shutdown("should not reach backend");
+    let proxy_port = free_port();
+    let config = Config::from_yaml(&passthrough_yaml(proxy_port, backend.port())).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &anthropic_post(
+            "/v1/messages",
+            r#"{"model":"mock-model","messages":[],"max_tokens":64}"#,
+        ),
+    );
+    let status = parse_status(&raw);
+
+    assert!(
+        [400, 422, 500].contains(&status),
+        "empty messages should return 400, 422, or 500, got {status}"
+    );
+}
+
+/// OGX: test_messages_response_headers
+#[test]
+fn response_headers() {
+    let backend = Backend::fixed(BASIC_RESPONSE)
+        .header("content-type", "application/json")
+        .header("anthropic-version", "2023-06-01")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = Config::from_yaml(&passthrough_yaml(proxy_port, backend.port())).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &anthropic_post(
+            "/v1/messages",
+            r#"{"model":"mock-model","messages":[{"role":"user","content":"Hi"}],"max_tokens":16}"#,
+        ),
+    );
+    let status = parse_status(&raw);
+
+    assert_eq!(status, 200, "expected 200");
+    let raw_lower = raw.to_lowercase();
+    assert!(
+        raw_lower.contains("anthropic-version: 2023-06-01"),
+        "response should include anthropic-version header"
+    );
+}
+
+/// OGX: test_messages_content_block_array
+#[test]
+fn content_block_array() {
+    let backend = Backend::fixed(CONTENT_BLOCK_RESPONSE)
+        .header("content-type", "application/json")
+        .header("anthropic-version", "2023-06-01")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let config = Config::from_yaml(&passthrough_yaml(proxy_port, backend.port())).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &anthropic_post(
+            "/v1/messages",
+            r#"{"model":"mock-model","messages":[{"role":"user","content":[{"type":"text","text":"What is 1+1? Reply with just the number."}]}],"max_tokens":32}"#,
+        ),
+    );
+    let status = parse_status(&raw);
+    let body = parse_body(&raw);
+    let data: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(status, 200, "expected 200");
+    assert_eq!(data["type"], "message", "type should be message");
+    assert!(
+        !data["content"].as_array().unwrap().is_empty(),
+        "content should not be empty"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+fn passthrough_yaml(proxy_port: u16, backend_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: test
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [passthrough]
+
+filter_chains:
+  - name: passthrough
+    filters:
+      - filter: anthropic_messages_format
+        on_invalid: continue
+      - filter: anthropic_validate
+      - filter: anthropic_passthrough
+        default_version: "2023-06-01"
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: mock
+      - filter: load_balancer
+        clusters:
+          - name: mock
+            endpoints:
+              - "127.0.0.1:{backend_port}"
+"#
+    )
+}
+
+fn anthropic_post(path: &str, body: &str) -> String {
+    format!(
+        "POST {path} HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         anthropic-version: 2023-06-01\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\r\n\
+         {body}",
+        body.len()
+    )
+}
+
+fn parse_sse_events(body: &str) -> Vec<serde_json::Value> {
+    let mut events = Vec::new();
+    let mut current_event_type = None;
+
+    for line in body.lines() {
+        if let Some(event_type) = line.strip_prefix("event: ") {
+            current_event_type = Some(event_type.to_owned());
+        } else if let Some(data) = line.strip_prefix("data: ")
+            && let Ok(mut value) = serde_json::from_str::<serde_json::Value>(data)
+        {
+            if let Some(ref et) = current_event_type {
+                value["_event_type"] = serde_json::Value::String(et.clone());
+            }
+            events.push(value);
+            current_event_type = None;
+        }
+    }
+
+    events
+}

--- a/tests/integration/tests/suite/examples/anthropic_messages.rs
+++ b/tests/integration/tests/suite/examples/anthropic_messages.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Functional tests for Anthropic Messages example configs.
+
+use std::collections::HashMap;
+
+use praxis_test_utils::{
+    free_port, http_send, json_post, load_example_config, parse_body, parse_status, start_backend_with_shutdown,
+    start_proxy,
+};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn anthropic_passthrough_routes_to_backend() {
+    let backend_guard = start_backend_with_shutdown("anthropic-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "ai/anthropic/messages-passthrough.yaml",
+        proxy_port,
+        HashMap::from([("127.0.0.1:3001", backend_guard.port())]),
+    );
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"Hello"}]}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/messages", body));
+
+    assert_eq!(parse_status(&raw), 200, "passthrough should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "anthropic-backend",
+        "should route to anthropic-backend"
+    );
+}
+
+#[test]
+fn anthropic_to_openai_routes_to_backend() {
+    let backend_guard = start_backend_with_shutdown("openai-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "ai/anthropic/messages-to-openai.yaml",
+        proxy_port,
+        HashMap::from([("127.0.0.1:3001", backend_guard.port())]),
+    );
+    let proxy = start_proxy(&config);
+
+    let body = r#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"Hello"}]}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/messages", body));
+
+    assert_eq!(parse_status(&raw), 200, "transformation should return 200");
+    assert_eq!(parse_body(&raw), "openai-backend", "should route to openai-backend");
+}
+
+#[test]
+fn unified_gateway_routes_anthropic_to_correct_backend() {
+    let anthropic_guard = start_backend_with_shutdown("anthropic-backend");
+    let openai_guard = start_backend_with_shutdown("openai-backend");
+    let responses_guard = start_backend_with_shutdown("responses-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "ai/anthropic/unified-gateway.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", anthropic_guard.port()),
+            ("127.0.0.1:3002", openai_guard.port()),
+            ("127.0.0.1:3003", responses_guard.port()),
+            ("127.0.0.1:3004", default_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let anthropic_body = r#"{"model":"claude-opus-4-8","max_tokens":1024,"messages":[{"role":"user","content":"Hi"}]}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/messages", anthropic_body));
+    assert_eq!(parse_status(&raw), 200, "anthropic request should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "anthropic-backend",
+        "anthropic should route to anthropic-backend"
+    );
+}
+
+#[test]
+fn unified_gateway_routes_openai_to_correct_backend() {
+    let anthropic_guard = start_backend_with_shutdown("anthropic-backend");
+    let openai_guard = start_backend_with_shutdown("openai-backend");
+    let responses_guard = start_backend_with_shutdown("responses-backend");
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "ai/anthropic/unified-gateway.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:3001", anthropic_guard.port()),
+            ("127.0.0.1:3002", openai_guard.port()),
+            ("127.0.0.1:3003", responses_guard.port()),
+            ("127.0.0.1:3004", default_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let openai_body = r#"{"model":"gpt-4","messages":[{"role":"user","content":"Hi"}]}"#;
+    let raw = http_send(proxy.addr(), &json_post("/v1/chat/completions", openai_body));
+    assert_eq!(parse_status(&raw), 200, "openai request should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        "openai-backend",
+        "openai should route to openai-backend"
+    );
+}

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -10,6 +10,8 @@ pub use test_utils::load_example_config;
 mod access_logging;
 mod admin_interface;
 mod agentic_routing;
+#[cfg(feature = "ai-inference")]
+mod anthropic_messages;
 mod api_key_filter;
 mod basic_reverse_proxy;
 mod canary_routing;

--- a/tests/integration/tests/suite/main.rs
+++ b/tests/integration/tests/suite/main.rs
@@ -37,6 +37,8 @@
 mod a2a;
 mod adversarial;
 mod agentic_mocks;
+#[cfg(feature = "ai-inference")]
+mod anthropic_messages;
 mod body;
 mod body_pipeline;
 mod compression;


### PR DESCRIPTION
## Summary

Adds five composable `HttpFilter` implementations for Anthropic Messages API support:

- **`anthropic_messages_format`** — classifies requests via shared `AiRequestFormat` enum with header, path, and body-based detection
- **`anthropic_request_validate`** — validates proxy-needed fields (messages, max_tokens, model); role ordering deferred to backend
- **`anthropic_passthrough`** — injects `anthropic-version` header for native `/v1/messages` backends
- **`anthropic_to_openai`** — request/response body transformation; declares `Stream` statically for response body mode, upgrades to `StreamBuffer` per-request via `set_response_body_mode()` only for non-streaming requests (enabling coexistence with `anthropic_stream_events`)
- **`anthropic_stream_events`** — per-chunk SSE event transformation conformant with [Inference Proxy Conformance Guidelines](https://docs.google.com/document/d/1yDzs9ehHFxqYbufOmY-sEXiEtn9nhXUKHx4uKjasC5Q/edit?tab=t.0) §4.2/§4.3

Moves the shared `AiRequestFormat` classifier from `openai/responses/classifier/` to `ai/classifier/` with an `AnthropicMessages` variant. Path rewriting delegated to the `path_rewrite` filter per CLAUDE.md Key Patterns.

## Related

- praxis-proxy/ai#103 — epic
- praxis-proxy/praxis#420 — proposal What+Why (merged)
- praxis-proxy/praxis#425 — proposal How

## Tested against

- vLLM `/v1/messages` passthrough
- Anthropic API with credential injection + TLS
- vLLM `/v1/chat/completions` via Anthropic→OpenAI transformation

## Test coverage

- 1,496 Rust unit tests pass (50+ anthropic-specific, 4 streaming-specific)
- 13 Rust integration tests ported 1:1 from [OGX](https://github.com/ogx-ai/ogx/) `test_messages.py`
- 4 example config integration tests
- `make lint` clean, no Python dependencies