### PR TITLE
fix(ci): fix bash syntax error and regex bug in conventions workflow

### DIFF
--- a/.github/workflows/conventions.yaml
+++ b/.github/workflows/conventions.yaml
@@ -219,7 +219,7 @@ jobs:
           missing=$(gh api \
             "repos/${{ github.repository }}/pulls/${PR_NUMBER}/commits" \
             --paginate \
-            --jq '[.[] | select(.commit.message | test("^Signed-off-by: "; "m") | not) | .sha[:7]] | join(", ")')
+            --jq '[.[] | select(.commit.message | test("(?m)^Signed-off-by: ") | not) | .sha[:7]] | join(", ")')
 
           if [ -n "$missing" ]; then
             marker="<!-- praxis:signoff-check -->"

--- a/.github/workflows/conventions.yaml
+++ b/.github/workflows/conventions.yaml
@@ -316,7 +316,7 @@ jobs:
           ${violations}
 
           Sorry, this project does not accept commits authored by tools as valid.
-          Commits need to be authored by and signed-off by the human(s) responsible for the PR, with their name and contact.
+          Commits need to be authored by and signed-off by the human(s) responsible for the PR, with their name and contact."
             fi
             echo "::error::AI tool authorship found in PR commits"
             exit 1


### PR DESCRIPTION
## Summary

Fixes two bugs in the conventions CI workflow:

1. **ai-authorship-check**: The `gh pr comment --body` argument was missing its closing double quote, causing bash to consume the `fi` and subsequent statements as part of the string literal, failing with `unexpected EOF while looking for matching "` (exit code 2) on every PR.

2. **signoff-check**: The jq regex `test("^Signed-off-by: "; "m")` never matches multiline commit messages because jq uses Oniguruma, where the `"m"` flag makes `.` match newlines — it does **not** make `^` match at line boundaries (that's PCRE behavior). Changed to the inline `(?m)` flag so `^Signed-off-by:` correctly anchors to the start of any line.

**Note:** Both checks use `pull_request_target`, so the broken scripts on `main` run against this PR — the fixes cannot self-validate until merged.

Signed-off-by: Sébastien Han <seb@redhat.com>