### PR TITLE
fix(ci): skip merge commits in conventions workflow checks

### DIFF
--- a/.github/workflows/conventions.yaml
+++ b/.github/workflows/conventions.yaml
@@ -180,7 +180,7 @@ jobs:
           fi
 
           unsigned=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/commits" \
-            --paginate --jq '[.[] | select(.commit.verification.verified == false) | .sha[:7]] | join(", ")')
+            --paginate --jq '[.[] | select(.parents | length == 1) | select(.commit.verification.verified == false) | .sha[:7]] | join(", ")')
 
           if [ -n "$unsigned" ]; then
             marker="<!-- praxis:signed-commits-check -->"
@@ -219,7 +219,7 @@ jobs:
           missing=$(gh api \
             "repos/${{ github.repository }}/pulls/${PR_NUMBER}/commits" \
             --paginate \
-            --jq '[.[] | select(.commit.message | test("(?m)^Signed-off-by: ") | not) | .sha[:7]] | join(", ")')
+            --jq '[.[] | select(.parents | length == 1) | select(.commit.message | test("(?m)^Signed-off-by: ") | not) | .sha[:7]] | join(", ")')
 
           if [ -n "$missing" ]; then
             marker="<!-- praxis:signoff-check -->"
@@ -274,7 +274,8 @@ jobs:
             --arg credit "$CREDIT" \
             --arg any_trailer "$ANY_TRAILER" '
             [
-              (.[] | .sha[:7] as $sha |
+              (.[] | select(.parents | length == 1) |
+                .sha[:7] as $sha |
                 select(
                   (.commit.author.email |
                     test($ai_email; "i")) or
@@ -282,7 +283,8 @@ jobs:
                     test($ai_email; "i"))
                 ) |
                 "- `\($sha)`: AI tool email in author/committer"),
-              (.[] | .sha[:7] as $sha |
+              (.[] | select(.parents | length == 1) |
+                .sha[:7] as $sha |
                 select(
                   (.commit.author.name |
                     test($ai_author; "i")) or
@@ -290,7 +292,8 @@ jobs:
                     test($ai_author; "i"))
                 ) |
                 "- `\($sha)`: AI tool in author/committer name"),
-              (.[] | .sha[:7] as $sha |
+              (.[] | select(.parents | length == 1) |
+                .sha[:7] as $sha |
                 .commit.message | split("\n")[] |
                 select(
                   (test($any_trailer; "i") and


### PR DESCRIPTION
## Summary

- Skip merge commits in `signed-commits-check`, `signoff-check`, and `ai-authorship-check` jobs by filtering on `select(.parents | length == 1)`
- Merge commits are auto-generated by git and lack `Signed-off-by` trailers, may not be GPG-signed by the PR author, and have auto-generated commit metadata — checking them produces false positives

## Test plan

- [x] Verify the jq filter `select(.parents | length == 1)` correctly identifies non-merge commits via the GitHub API
- [ ] Confirm CI passes on a PR that contains merge commits