### PR TITLE
feat(mcp): add protocol profile and version plumbing

### DIFF
--- a/docs/operating/filter-reference.md
+++ b/docs/operating/filter-reference.md
@@ -394,6 +394,46 @@ a JSON-RPC error if the selector is missing and
 and `json_rpc.*` entries to the filter result set for
 branch chain conditions.
 
+### MCP Broker Mode
+
+When the `mcp` filter config includes a `servers`
+block, broker mode activates. The broker aggregates
+tool catalogs from configured backends and handles
+`initialize`, `tools/list`, `ping`, and notifications
+directly as synthetic responses.
+
+```yaml
+- filter: mcp
+  path: /mcp
+  max_body_bytes: 65536
+  protocol_profile: current
+  default_version: "2025-03-26"
+  supported_versions: ["2025-03-26"]
+  servers:
+    - name: weather
+      cluster: weather-mcp
+      path: /mcp
+      tool_prefix: "weather_"
+      tools:
+        - name: get_weather
+          description: Get current weather
+```
+
+| Field | Type | Default | Description |
+| ----- | ---- | ------- | ----------- |
+| `path` | string | `"/mcp"` | Public endpoint path |
+| `max_body_bytes` | integer | 65536 | Maximum body size to buffer (64 KiB) |
+| `protocol_profile` | string | `"current"` | Protocol profile governing session semantics |
+| `default_version` | string | `"2025-03-26"` | Protocol version used in `initialize` responses when the client's requested version is not supported |
+| `supported_versions` | list | `["2025-03-26"]` | Protocol versions accepted during `initialize` negotiation; every entry must be implemented by this build |
+| `invalid_tool_policy` | string | `"reject_server"` | `"reject_server"` or `"filter_out"` for tools with invalid schemas |
+| `servers` | list | `[]` | Backend MCP server definitions |
+
+Each server entry supports `name`, `cluster`, `path`
+(default `"/mcp"`), `tool_prefix`, and `tools`. Tool
+definitions include `name`, optional `description`,
+optional `inputSchema`, and optional `annotations`.
+
 ## Static Response
 
 Returns a fixed response without contacting any upstream.

--- a/examples/configs/payload-processing/mcp-static-catalog.yaml
+++ b/examples/configs/payload-processing/mcp-static-catalog.yaml
@@ -19,6 +19,9 @@ filter_chains:
       - filter: mcp
         path: /mcp
         max_body_bytes: 65536
+        protocol_profile: current
+        default_version: "2025-03-26"
+        supported_versions: ["2025-03-26"]
         servers:
           - name: weather
             cluster: weather-mcp

--- a/filter/src/builtins/http/ai/agentic/mcp/broker/config.rs
+++ b/filter/src/builtins/http/ai/agentic/mcp/broker/config.rs
@@ -5,6 +5,7 @@
 
 use serde::Deserialize;
 
+use super::super::protocol::{self, ProtocolProfile};
 use crate::{FilterError, builtins::http::transformation::has_dot_dot_traversal};
 
 // -----------------------------------------------------------------------------
@@ -79,6 +80,12 @@ pub(super) struct McpServerConfig {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct McpBrokerConfig {
+    /// Fallback MCP protocol version returned in broker `initialize`
+    /// responses when the client's requested version is not supported.
+    /// Must be present in `supported_versions` and implemented by this
+    /// build. Defaults to [`protocol::DEFAULT_VERSION`].
+    #[serde(default = "default_version")]
+    pub default_version: String,
     /// Behavior when a tool has an invalid schema.
     #[serde(default)]
     pub invalid_tool_policy: InvalidToolPolicy,
@@ -88,9 +95,19 @@ pub(super) struct McpBrokerConfig {
     /// Public MCP path handled by Praxis.
     #[serde(default = "default_path")]
     pub path: String,
+    /// Protocol profile governing session semantics and header
+    /// requirements for this broker instance.
+    #[serde(default)]
+    pub protocol_profile: ProtocolProfile,
     /// Backend server definitions.
     #[serde(default)]
     pub servers: Vec<McpServerConfig>,
+    /// Protocol versions accepted during `initialize` negotiation.
+    /// Every entry must be implemented by this build (present in
+    /// [`protocol::SUPPORTED_VERSIONS`]). Defaults to the versions
+    /// this build implements.
+    #[serde(default = "default_supported_versions")]
+    pub supported_versions: Vec<String>,
 }
 
 // -----------------------------------------------------------------------------
@@ -133,6 +150,16 @@ fn default_max_body_bytes() -> usize {
     DEFAULT_MAX_BODY_BYTES
 }
 
+/// Default protocol version from the centralized constant.
+fn default_version() -> String {
+    protocol::DEFAULT_VERSION.to_owned()
+}
+
+/// Default supported versions from the centralized constant.
+fn default_supported_versions() -> Vec<String> {
+    protocol::SUPPORTED_VERSIONS.iter().map(|s| (*s).to_owned()).collect()
+}
+
 // -----------------------------------------------------------------------------
 // Validation
 // -----------------------------------------------------------------------------
@@ -143,6 +170,7 @@ pub(super) fn build_config(cfg: McpBrokerConfig) -> Result<(McpBrokerConfig, Vec
         return Err("mcp: max_body_bytes must be greater than 0".into());
     }
 
+    validate_versions(&cfg)?;
     validate_path("mcp", &cfg.path)?;
     validate_unique_server_names(&cfg.servers)?;
     validate_server_clusters(&cfg.servers)?;
@@ -153,6 +181,29 @@ pub(super) fn build_config(cfg: McpBrokerConfig) -> Result<(McpBrokerConfig, Vec
     validate_unique_exposed_names(&catalog)?;
 
     Ok((cfg, catalog))
+}
+
+/// Validate that every configured version is implemented by this build
+/// and that `default_version` appears in `supported_versions`.
+fn validate_versions(cfg: &McpBrokerConfig) -> Result<(), FilterError> {
+    if cfg.supported_versions.is_empty() {
+        return Err("mcp: supported_versions must not be empty".into());
+    }
+    for v in &cfg.supported_versions {
+        if !protocol::is_supported_version(v) {
+            return Err(
+                format!("mcp: supported_versions contains '{v}' which is not implemented by this build").into(),
+            );
+        }
+    }
+    if !cfg.supported_versions.iter().any(|v| v == &cfg.default_version) {
+        return Err(format!(
+            "mcp: default_version '{}' must appear in supported_versions",
+            cfg.default_version,
+        )
+        .into());
+    }
+    Ok(())
 }
 
 /// Validate that all server names are unique and non-empty.

--- a/filter/src/builtins/http/ai/agentic/mcp/broker/mod.rs
+++ b/filter/src/builtins/http/ai/agentic/mcp/broker/mod.rs
@@ -25,6 +25,7 @@ use rand::{TryRngCore, rngs::OsRng};
 use tracing::{debug, trace};
 
 use self::config::{CatalogTool, McpBrokerConfig, build_config};
+use super::protocol;
 use crate::{
     FilterAction, FilterError, Rejection,
     body::{BodyAccess, BodyMode},
@@ -42,9 +43,6 @@ use crate::{
 // -----------------------------------------------------------------------------
 // Constants
 // -----------------------------------------------------------------------------
-
-/// MCP protocol version currently supported by Praxis.
-const SUPPORTED_PROTOCOL_VERSION: &str = "2025-03-26";
 
 /// Server name reported in MCP initialize responses.
 const SERVER_NAME: &str = "praxis";
@@ -86,12 +84,19 @@ const SERVER_NAME: &str = "praxis";
 pub(crate) struct McpBrokerFilter {
     /// Static tool catalog built from config.
     catalog: Vec<CatalogTool>,
+    /// Protocol version the broker uses in `initialize` responses.
+    default_version: String,
     /// Shared JSON-RPC parser configuration.
     json_rpc_config: JsonRpcConfig,
     /// Maximum body bytes for `StreamBuffer`.
     max_body_bytes: usize,
+    /// Configured protocol profile (stored for future profile-aware dispatch).
+    #[allow(dead_code, reason = "plumbing for follow-up profile-aware behavior")]
+    protocol_profile: protocol::ProtocolProfile,
     /// Public path this MCP broker handles (e.g. `/mcp`).
     public_path: String,
+    /// Implemented versions used for protocol version negotiation.
+    supported_versions: Vec<String>,
 }
 
 impl McpBrokerFilter {
@@ -114,9 +119,12 @@ impl McpBrokerFilter {
 
         Ok(Box::new(Self {
             catalog,
+            default_version: validated.default_version.clone(),
             json_rpc_config,
             max_body_bytes: validated.max_body_bytes,
+            protocol_profile: validated.protocol_profile,
             public_path: validated.path.clone(),
+            supported_versions: validated.supported_versions.clone(),
         }))
     }
 }
@@ -149,6 +157,7 @@ impl HttpFilter for McpBrokerFilter {
         }
     }
 
+    #[allow(clippy::too_many_lines, reason = "sequential parse-extract-dispatch pipeline")]
     async fn on_request_body(
         &self,
         ctx: &mut HttpFilterContext<'_>,
@@ -188,7 +197,15 @@ impl HttpFilter for McpBrokerFilter {
             ctx.set_metadata("mcp.method", method_str.clone());
         }
 
-        dispatch_method(ctx, &self.catalog, &value, &envelope, method_str)
+        dispatch_method(
+            ctx,
+            &self.catalog,
+            &value,
+            &envelope,
+            method_str,
+            &self.supported_versions,
+            &self.default_version,
+        )
     }
 }
 
@@ -199,12 +216,18 @@ impl HttpFilter for McpBrokerFilter {
 /// Maps a JSON-RPC method to the MCP handler that owns it.
 /// Never returns [`FilterAction::Release`] — all paths produce
 /// a terminal synthetic response.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "project threshold is 5; version plumbing adds two"
+)]
 fn dispatch_method(
     ctx: &mut HttpFilterContext<'_>,
     catalog: &[CatalogTool],
     value: &serde_json::Value,
     envelope: &JsonRpcEnvelope,
     method_str: &str,
+    supported_versions: &[String],
+    default_version: &str,
 ) -> Result<FilterAction, FilterError> {
     if method_str.starts_with("notifications/") {
         return Ok(handle_notification(envelope));
@@ -215,7 +238,7 @@ fn dispatch_method(
     }
 
     let action = match method_str {
-        "initialize" => handle_initialize(ctx, value, envelope)?,
+        "initialize" => handle_initialize(ctx, value, envelope, supported_versions, default_version)?,
         "tools/list" => handle_tools_list(catalog, envelope)?,
         "tools/call" => json_rpc_error_action(envelope, -32601, "method not yet supported"),
         "ping" => handle_ping(envelope),
@@ -278,8 +301,11 @@ fn handle_initialize(
     ctx: &mut HttpFilterContext<'_>,
     value: &serde_json::Value,
     envelope: &JsonRpcEnvelope,
+    supported_versions: &[String],
+    default_version: &str,
 ) -> Result<FilterAction, FilterError> {
     record_client_protocol_version(ctx, value);
+    let response_version = negotiate_protocol_version(value, supported_versions, default_version);
     let session_id = generate_session_id()?;
 
     debug!(session_id_len = session_id.len(), "MCP initialize");
@@ -289,8 +315,33 @@ fn handle_initialize(
         Rejection::status(200)
             .with_header("content-type", "application/json")
             .with_header("mcp-session-id", &session_id)
-            .with_body(Bytes::from(initialize_response_body(envelope).to_string())),
+            .with_body(Bytes::from(
+                initialize_response_body(envelope, response_version).to_string(),
+            )),
     ))
+}
+
+/// Select the protocol version for the initialize response.
+///
+/// Echoes the client's requested version when the broker supports it,
+/// otherwise falls back to `default_version`.
+fn negotiate_protocol_version<'a>(
+    value: &serde_json::Value,
+    supported_versions: &'a [String],
+    default_version: &'a str,
+) -> &'a str {
+    let requested = value
+        .get("params")
+        .and_then(|p| p.get("protocolVersion"))
+        .and_then(|v| v.as_str());
+
+    if let Some(req) = requested
+        && let Some(matched) = supported_versions.iter().find(|v| v.as_str() == req)
+    {
+        return matched.as_str();
+    }
+
+    default_version
 }
 
 /// Persist the client's advertised MCP protocol version for later negotiation
@@ -306,13 +357,13 @@ fn record_client_protocol_version(ctx: &mut HttpFilterContext<'_>, value: &serde
     }
 }
 
-/// Build the initialize response from dynamic crate and protocol constants.
-fn initialize_response_body(envelope: &JsonRpcEnvelope) -> serde_json::Value {
+/// Build the initialize response from the configured protocol version.
+fn initialize_response_body(envelope: &JsonRpcEnvelope, protocol_version: &str) -> serde_json::Value {
     serde_json::json!({
         "jsonrpc": "2.0",
         "id": id_value(envelope),
         "result": {
-            "protocolVersion": SUPPORTED_PROTOCOL_VERSION,
+            "protocolVersion": protocol_version,
             "capabilities": {
                 "tools": {
                     "listChanged": false,

--- a/filter/src/builtins/http/ai/agentic/mcp/broker/tests.rs
+++ b/filter/src/builtins/http/ai/agentic/mcp/broker/tests.rs
@@ -1138,11 +1138,280 @@ async fn delete_with_query_param_matches_configured_mcp_path() {
 }
 
 // -----------------------------------------------------------------------------
+// Protocol Profile Config Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn default_profile_config_preserves_current_behavior() {
+    let filter = make_broker_filter();
+    assert_eq!(
+        filter.protocol_profile,
+        protocol::ProtocolProfile::Current,
+        "default profile should be Current"
+    );
+    assert_eq!(
+        filter.default_version,
+        protocol::PROTOCOL_VERSION_CURRENT,
+        "default version should match centralized constant"
+    );
+    assert!(
+        !filter.supported_versions.is_empty(),
+        "supported versions should not be empty"
+    );
+    assert!(
+        filter.supported_versions.contains(&filter.default_version),
+        "default version should appear in supported versions"
+    );
+}
+
+#[test]
+fn explicit_current_profile_parses() {
+    let yaml = r#"
+protocol_profile: current
+servers:
+  - name: s
+    cluster: c
+    tools: []
+"#;
+    let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+    let (validated, _catalog) = build_config(cfg).unwrap();
+    assert_eq!(
+        validated.protocol_profile,
+        protocol::ProtocolProfile::Current,
+        "explicit 'current' should parse"
+    );
+}
+
+#[test]
+fn unsupported_profile_rejects_at_config_load() {
+    let yaml = r#"
+protocol_profile: nonexistent
+servers:
+  - name: s
+    cluster: c
+    tools: []
+"#;
+    let result = serde_yaml::from_str::<McpBrokerConfig>(yaml);
+    assert!(result.is_err(), "unknown protocol_profile should reject at parse time");
+}
+
+#[test]
+fn explicit_supported_versions_parses() {
+    let yaml = r#"
+supported_versions: ["2025-03-26"]
+default_version: "2025-03-26"
+servers:
+  - name: s
+    cluster: c
+    tools: []
+"#;
+    let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+    let (validated, _catalog) = build_config(cfg).unwrap();
+    assert_eq!(
+        validated.supported_versions,
+        vec!["2025-03-26"],
+        "explicit supported_versions should parse"
+    );
+    assert_eq!(
+        validated.default_version, "2025-03-26",
+        "explicit default_version should parse"
+    );
+}
+
+#[test]
+fn default_version_not_in_supported_versions_rejected() {
+    let yaml = r#"
+supported_versions: ["2025-03-26"]
+default_version: "9999-12-31"
+servers: []
+"#;
+    let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+    let result = build_config(cfg);
+    assert!(result.is_err(), "default_version not in supported_versions should fail");
+    assert!(
+        result
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("must appear in supported_versions"),
+        "error should mention supported_versions"
+    );
+}
+
+#[test]
+fn empty_supported_versions_rejected() {
+    let yaml = r#"
+supported_versions: []
+servers: []
+"#;
+    let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+    let result = build_config(cfg);
+    assert!(result.is_err(), "empty supported_versions should fail");
+    assert!(
+        result.err().unwrap().to_string().contains("must not be empty"),
+        "error should mention empty supported_versions"
+    );
+}
+
+#[test]
+fn unsupported_supported_version_rejected() {
+    let yaml = r#"
+supported_versions: ["9999-12-31"]
+default_version: "9999-12-31"
+servers: []
+"#;
+    let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+    let result = build_config(cfg);
+    assert!(result.is_err(), "version not implemented by this build should fail");
+    assert!(
+        result
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("not implemented by this build"),
+        "error should mention build implementation"
+    );
+}
+
+#[test]
+fn unsupported_default_version_rejected_even_when_listed() {
+    let yaml = r#"
+supported_versions: ["2025-03-26", "9999-12-31"]
+default_version: "9999-12-31"
+servers: []
+"#;
+    let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+    let result = build_config(cfg);
+    assert!(
+        result.is_err(),
+        "unimplemented version in supported_versions should fail even if default_version matches"
+    );
+}
+
+#[tokio::test]
+async fn explicit_current_version_preserves_initialize_response() {
+    let filter = make_broker_filter_with_versions("2025-03-26");
+    let body_str =
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{}}}"#;
+    let req = make_mcp_request();
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match action {
+        FilterAction::Reject(ref rejection) => {
+            assert_eq!(rejection.status, 200, "initialize should return 200");
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(
+                parsed["result"]["protocolVersion"], "2025-03-26",
+                "explicit default_version should appear in initialize response"
+            );
+            assert!(
+                rejection.headers.iter().any(|(k, _)| k == "mcp-session-id"),
+                "initialize should still return mcp-session-id"
+            );
+        },
+        _ => panic!("expected Reject with 200"),
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Version Negotiation Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn initialize_echoes_supported_requested_version() {
+    let filter = make_broker_filter_with_versions("2025-03-26");
+    let body_str =
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{}}}"#;
+    let req = make_mcp_request();
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match action {
+        FilterAction::Reject(ref rejection) => {
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(
+                parsed["result"]["protocolVersion"], "2025-03-26",
+                "should echo the client's requested version when it is supported"
+            );
+        },
+        _ => panic!("expected Reject with 200"),
+    }
+}
+
+#[tokio::test]
+async fn initialize_unsupported_requested_version_falls_back_to_default() {
+    let filter = make_broker_filter_with_versions("2025-03-26");
+    let body_str =
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"9999-12-31","capabilities":{}}}"#;
+    let req = make_mcp_request();
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match action {
+        FilterAction::Reject(ref rejection) => {
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(
+                parsed["result"]["protocolVersion"], "2025-03-26",
+                "unsupported client version should fall back to default_version"
+            );
+        },
+        _ => panic!("expected Reject with 200"),
+    }
+}
+
+#[tokio::test]
+async fn initialize_missing_version_falls_back_to_default() {
+    let filter = make_broker_filter_with_versions("2025-03-26");
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}"#;
+    let req = make_mcp_request();
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+    match action {
+        FilterAction::Reject(ref rejection) => {
+            let body_str = std::str::from_utf8(rejection.body.as_ref().unwrap()).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(body_str).unwrap();
+            assert_eq!(
+                parsed["result"]["protocolVersion"], "2025-03-26",
+                "missing client version should fall back to default_version"
+            );
+        },
+        _ => panic!("expected Reject with 200"),
+    }
+}
+
+#[test]
+fn default_version_only_config_uses_default_supported_versions() {
+    let yaml = r#"
+default_version: "2025-03-26"
+servers: []
+"#;
+    let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
+    let (validated, _catalog) = build_config(cfg).unwrap();
+    assert_eq!(
+        validated.supported_versions,
+        vec!["2025-03-26"],
+        "omitting supported_versions should default to implemented versions"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
 
-fn make_broker_filter() -> McpBrokerFilter {
-    let yaml = r#"
+const BROKER_SERVERS_YAML: &str = r#"
 servers:
   - name: weather
     cluster: weather-mcp
@@ -1160,14 +1429,28 @@ servers:
       - name: create_event
         description: Create a calendar event
 "#;
+
+fn make_broker_filter() -> McpBrokerFilter {
+    build_broker_filter_from_yaml(BROKER_SERVERS_YAML)
+}
+
+fn make_broker_filter_with_versions(version: &str) -> McpBrokerFilter {
+    let yaml = format!("default_version: \"{version}\"\nsupported_versions: [\"{version}\"]\n{BROKER_SERVERS_YAML}");
+    build_broker_filter_from_yaml(&yaml)
+}
+
+fn build_broker_filter_from_yaml(yaml: &str) -> McpBrokerFilter {
     let cfg: McpBrokerConfig = serde_yaml::from_str(yaml).unwrap();
     let (validated, catalog) = build_config(cfg).unwrap();
     let json_rpc_config = build_json_rpc_config(validated.max_body_bytes);
     McpBrokerFilter {
         catalog,
+        default_version: validated.default_version.clone(),
         json_rpc_config,
         max_body_bytes: validated.max_body_bytes,
+        protocol_profile: validated.protocol_profile,
         public_path: validated.path.clone(),
+        supported_versions: validated.supported_versions.clone(),
     }
 }
 

--- a/filter/src/builtins/http/ai/agentic/mcp/mod.rs
+++ b/filter/src/builtins/http/ai/agentic/mcp/mod.rs
@@ -6,6 +6,7 @@
 mod broker;
 pub(crate) mod config;
 pub(crate) mod envelope;
+pub(crate) mod protocol;
 
 #[cfg(test)]
 #[allow(

--- a/filter/src/builtins/http/ai/agentic/mcp/protocol.rs
+++ b/filter/src/builtins/http/ai/agentic/mcp/protocol.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! MCP protocol version and profile types.
+//!
+//! Centralizes the protocol version string so it is not scattered through
+//! handlers and tests. Future MCP spec versions can be added to
+//! [`SUPPORTED_VERSIONS`] without modifying individual request handlers.
+
+use serde::Deserialize;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Protocol version implemented by the current broker behavior.
+pub(crate) const PROTOCOL_VERSION_CURRENT: &str = "2025-03-26";
+
+/// All protocol versions this build of Praxis can handle.
+pub(crate) const SUPPORTED_VERSIONS: &[&str] = &[PROTOCOL_VERSION_CURRENT];
+
+/// Fallback protocol version used when no explicit version is configured.
+pub(crate) const DEFAULT_VERSION: &str = PROTOCOL_VERSION_CURRENT;
+
+// -----------------------------------------------------------------------------
+// ProtocolProfile
+// -----------------------------------------------------------------------------
+
+/// MCP protocol profile governing session semantics and header requirements.
+///
+/// The `Current` profile preserves the existing `initialize`/session behavior.
+/// Future profiles can be added when the MCP spec finalizes additional
+/// transport modes.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ProtocolProfile {
+    /// Current MCP Streamable HTTP behavior: `initialize` handshake,
+    /// optional `MCP-Session-Id`, and session-aware DELETE.
+    #[default]
+    Current,
+}
+
+impl ProtocolProfile {
+    /// String label for logging and metadata.
+    #[allow(dead_code, reason = "plumbing for follow-up profile-aware logging")]
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Current => "current",
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+/// Returns `true` when `version` appears in [`SUPPORTED_VERSIONS`].
+pub(crate) fn is_supported_version(version: &str) -> bool {
+    SUPPORTED_VERSIONS.contains(&version)
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::needless_raw_strings,
+    clippy::needless_raw_string_hashes,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_version_is_supported() {
+        assert!(
+            is_supported_version(DEFAULT_VERSION),
+            "DEFAULT_VERSION must appear in SUPPORTED_VERSIONS"
+        );
+    }
+
+    #[test]
+    fn current_version_is_supported() {
+        assert!(
+            is_supported_version(PROTOCOL_VERSION_CURRENT),
+            "PROTOCOL_VERSION_CURRENT must be supported"
+        );
+    }
+
+    #[test]
+    fn unknown_version_is_not_supported() {
+        assert!(
+            !is_supported_version("9999-12-31"),
+            "arbitrary version should not be supported"
+        );
+    }
+
+    #[test]
+    fn default_profile_is_current() {
+        assert_eq!(
+            ProtocolProfile::default(),
+            ProtocolProfile::Current,
+            "default profile should be Current"
+        );
+    }
+
+    #[test]
+    fn profile_as_str_round_trips() {
+        assert_eq!(ProtocolProfile::Current.as_str(), "current");
+    }
+
+    #[test]
+    fn profile_deserializes_from_yaml() {
+        let profile: ProtocolProfile = serde_yaml::from_str("current").unwrap();
+        assert_eq!(profile, ProtocolProfile::Current, "should parse 'current'");
+    }
+
+    #[test]
+    fn profile_rejects_unknown_value() {
+        let result = serde_yaml::from_str::<ProtocolProfile>("unknown");
+        assert!(result.is_err(), "unknown profile value should fail to parse");
+    }
+}


### PR DESCRIPTION
Adds minimal MCP protocol profile/version plumbing for the existing static broker without changing current runtime behavior.

  This PR:

  - Adds a centralized MCP protocol module with:
    - `PROTOCOL_VERSION_CURRENT`
    - `SUPPORTED_VERSIONS`
    - `DEFAULT_VERSION`
    - `ProtocolProfile`
    - `is_supported_version()`
  - Adds broker config fields:
    - `protocol_profile`
    - `default_version`
    - `supported_versions`
  - Defaults the new config fields to the broker behavior already implemented today.
  - Validates that `supported_versions` are non-empty.
  - Validates that every configured supported version is implemented by this build.
  - Validates that `default_version` appears in `supported_versions`.
  - Threads `default_version` into the broker `initialize` response instead of using a local hard-coded string.

  ## Scope

  - This is plumbing only. It intentionally does not implement new MCP 2026-07-28 RC behavior.
  - The existing broker behavior remains the default behavior: initialize still returns the current session-bearing response, `tools/list` still uses the static configured catalog, notifications and ping keep their existing handling, and `tools/call` is still not forwarded to backends in this PR.
  -The new profile/version fields are constrained to versions implemented by this build. They create a safe extension point for future finalized MCP profile behavior without changing today’s wire contract.

  ## Why

- Centralizing the current version and adding constrained config plumbing gives future MCP work a place to add profile-specific behavior.
- We could probably go ahead and implement the [2026-07-28 RC](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/) since it probably won't change much at this point. This PR preps for that followup.


