### PR TITLE
docs: add sccache shared build cache section to getting started

### DIFF
--- a/docs/developing/getting-started.md
+++ b/docs/developing/getting-started.md
@@ -107,6 +107,45 @@ insecure_options:
   allow_private_health_checks: true
 ```
 
+## Shared Build Cache with sccache
+
+[sccache] caches compiled artifacts so that switching
+branches, cleaning `target/`, or working across
+multiple git worktrees does not require rebuilding
+every dependency from scratch.
+
+### Setup
+
+[Install sccache][sccache-install], then add the
+following to your shell profile (`~/.bashrc`,
+`~/.zshrc`, etc.):
+
+```sh
+export RUSTC_WRAPPER=$(which sccache)
+```
+
+### Warming the cache
+
+After setting up sccache, run a full clippy pass in any
+worktree to populate the cache:
+
+```console
+cargo clippy --workspace --all-targets
+```
+
+Subsequent builds reuse the cached artifacts
+automatically. Cargo still prints `Compiling` /
+`Checking` for every crate, but cache-hit compilations
+complete in milliseconds instead of seconds.
+
+Check hit rates with `sccache --show-stats`. See
+[sccache usage][sccache-usage] for more configuration
+options.
+
+[sccache]: https://github.com/mozilla/sccache
+[sccache-install]: https://github.com/mozilla/sccache#installation
+[sccache-usage]: https://github.com/mozilla/sccache#usage
+
 ## Performance & Benchmarking
 
 See [benchmarks.md](../benchmarks.md).

--- a/docs/developing/getting-started.md
+++ b/docs/developing/getting-started.md
@@ -121,7 +121,7 @@ following to your shell profile (`~/.bashrc`,
 `~/.zshrc`, etc.):
 
 ```sh
-export RUSTC_WRAPPER=$(which sccache)
+export RUSTC_WRAPPER=sccache
 ```
 
 ### Warming the cache


### PR DESCRIPTION
## Summary

- Adds a new "Shared Build Cache with sccache" section to `docs/developing/getting-started.md`
- Documents setup, cache warming, and links to upstream sccache docs for installation and configuration
- Helps contributors avoid full dependency rebuilds when switching branches or working across worktrees

## Test plan

- [ ] Verify the doc renders correctly on GitHub
- [ ] Follow the setup instructions on a fresh checkout to confirm they work