### PR TITLE
docs: add key architectural patterns to CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -220,6 +220,41 @@ Branches rejoin at configurable points (next,
 terminal, named filter, re-entrance with iteration
 limits).
 
+## Key Patterns
+
+- **Classify → route**: classifier filters promote
+  facts to internal headers (`x-praxis-ai-*`) and
+  the router matches those headers to select
+  clusters. See
+  `examples/configs/ai/openai/responses/format-routing.yaml`.
+- **Branch on filter results**: branch chains split
+  or rejoin request-phase pipelines based on filter
+  results (`on_result`). See
+  `examples/configs/pipeline/branch-chains.yaml`
+  and `tests/integration/tests/suite/responses_format.rs`.
+  Branch sub-chains only run `on_request`;
+  `on_request_body` and `on_response_body` are not
+  executed for filters inside branch chains.
+  Body-transforming filters must be in the main
+  pipeline path or gated with normal filter
+  conditions.
+- **Prefer existing routing mechanisms**: use
+  classifier-promoted headers, router matches,
+  filter conditions, and branch chains before
+  adding new routing or capability mechanisms.
+- **Do not buffer full streaming responses**:
+  streaming and SSE filters should use
+  `BodyMode::Stream` and process chunks
+  incrementally unless the feature explicitly
+  requires buffering.
+- **Validate only proxy-needed fields**: let the
+  backend handle parameter ranges, model
+  availability, and role ordering.
+- **Use dedicated rewrite filters for URL/path
+  translation**: use `path_rewrite` or `url_rewrite`;
+  provider and protocol filters should not set
+  `ctx.rewritten_path` directly.
+
 ## Filter Organization
 
 Filters live under


### PR DESCRIPTION
## Summary

Adds a "Key Patterns" section to CLAUDE.md documenting architectural patterns for AI filter development.

## Motivation

During the Anthropic Messages API filter work (#420, #455), we proposed new mechanisms for post-routing translation decisions (cluster metadata, two-phase filters) before realizing the existing classify → route → branch pattern already handles this. Seb [pointed this out](https://github.com/praxis-proxy/praxis/pull/420#discussion_r3347449094) by referencing the `responses_format` example config, which demonstrates the pattern we should have followed from the start.

These patterns were not explicitly documented, making them easy to miss when designing new filters. This change makes them explicit so future contributors (human or AI) follow existing patterns rather than reinventing routing mechanisms.

## Patterns documented

- **Classify → route → branch**: classifiers promote facts to headers, routers match headers, branch chains split pipelines
- **No full-response SSE buffering**: per-chunk processing per Inference Proxy Conformance Guidelines
- **Proxy-only validation**: defer parameter validation to the backend
- **Use `path_rewrite` for URL translation**: don't set `ctx.rewritten_path` from inside filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)