### PR TITLE
feat: centralize filter time handling

### DIFF
--- a/benchmarks/microbenchmarks/common.rs
+++ b/benchmarks/microbenchmarks/common.rs
@@ -46,6 +46,7 @@ pub(crate) fn make_ctx(req: &Request) -> HttpFilterContext<'_> {
         filter_results: std::collections::HashMap::new(),
         health_registry: None,
         kv_stores: None,
+        time_source: &praxis_core::time::SystemTimeSource,
         request: req,
         request_body_bytes: 0,
         request_body_mode: praxis_filter::BodyMode::Stream,

--- a/benchmarks/microbenchmarks/common.rs
+++ b/benchmarks/microbenchmarks/common.rs
@@ -46,7 +46,6 @@ pub(crate) fn make_ctx(req: &Request) -> HttpFilterContext<'_> {
         filter_results: std::collections::HashMap::new(),
         health_registry: None,
         kv_stores: None,
-        time_source: &praxis_core::time::SystemTimeSource,
         request: req,
         request_body_bytes: 0,
         request_body_mode: praxis_filter::BodyMode::Stream,
@@ -57,6 +56,7 @@ pub(crate) fn make_ctx(req: &Request) -> HttpFilterContext<'_> {
         response_headers_modified: false,
         rewritten_path: None,
         selected_endpoint_index: None,
+        time_source: &praxis_core::time::SystemTimeSource,
         upstream: None,
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -19,6 +19,8 @@ pub mod kv;
 pub mod logging;
 /// Server factory and runtime options.
 pub mod server;
+/// Wall-clock time abstraction for filters.
+pub mod time;
 
 pub use errors::ProxyError;
 pub use server::{PingoraServerRuntime, RuntimeOptions};

--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -86,7 +86,7 @@ impl TimeSource for FixedTimeSource {
 }
 
 // -----------------------------------------------------------------------------
-// Helpers
+// Utilities
 // -----------------------------------------------------------------------------
 
 /// Extract duration since epoch, warning once on pre-epoch clocks.

--- a/core/src/time.rs
+++ b/core/src/time.rs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis contributors
+
+//! Wall-clock time abstraction for filters.
+
+use std::{
+    sync::Once,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+// -----------------------------------------------------------------------------
+// TimeSource Trait
+// -----------------------------------------------------------------------------
+
+/// Abstraction over wall-clock time.
+///
+/// Filters use this instead of calling [`SystemTime::now`] directly,
+/// enabling deterministic timestamps in tests and warning on
+/// pre-epoch clocks in production.
+///
+/// ```
+/// use praxis_core::time::{SystemTimeSource, TimeSource};
+///
+/// let ts = SystemTimeSource;
+/// let d = ts.now();
+/// assert!(d.as_secs() > 0);
+/// ```
+pub trait TimeSource: Send + Sync {
+    /// Duration since the Unix epoch.
+    fn now(&self) -> Duration;
+}
+
+// -----------------------------------------------------------------------------
+// SystemTimeSource
+// -----------------------------------------------------------------------------
+
+/// Production [`TimeSource`] backed by [`SystemTime::now`].
+///
+/// Logs a warning (once per process) if the system clock returns
+/// a pre-epoch value, then falls back to [`Duration::ZERO`].
+///
+/// ```
+/// use praxis_core::time::{SystemTimeSource, TimeSource};
+///
+/// let ts = SystemTimeSource;
+/// assert!(ts.now().as_secs() > 0);
+/// ```
+pub struct SystemTimeSource;
+
+impl TimeSource for SystemTimeSource {
+    fn now(&self) -> Duration {
+        duration_since_epoch(SystemTime::now())
+    }
+}
+
+// -----------------------------------------------------------------------------
+// FixedTimeSource
+// -----------------------------------------------------------------------------
+
+/// Test [`TimeSource`] that always returns a fixed duration.
+///
+/// ```
+/// use std::time::Duration;
+///
+/// use praxis_core::time::{FixedTimeSource, TimeSource};
+///
+/// let ts = FixedTimeSource::new(Duration::from_secs(1_700_000_000));
+/// assert_eq!(ts.now().as_secs(), 1_700_000_000);
+/// ```
+pub struct FixedTimeSource {
+    /// Fixed duration to return from [`TimeSource::now`].
+    duration: Duration,
+}
+
+impl FixedTimeSource {
+    /// Create a fixed time source returning the given duration.
+    pub fn new(duration: Duration) -> Self {
+        Self { duration }
+    }
+}
+
+impl TimeSource for FixedTimeSource {
+    fn now(&self) -> Duration {
+        self.duration
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+/// Extract duration since epoch, warning once on pre-epoch clocks.
+///
+/// Returns [`Duration::ZERO`] when the system clock is before 1970.
+pub(crate) fn duration_since_epoch(time: SystemTime) -> Duration {
+    if let Ok(d) = time.duration_since(UNIX_EPOCH) {
+        d
+    } else {
+        static WARN_ONCE: Once = Once::new();
+        WARN_ONCE.call_once(|| {
+            tracing::warn!(
+                "system clock is before Unix epoch; \
+                 timestamps will be zero until clock is corrected"
+            );
+        });
+        Duration::ZERO
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn system_time_source_returns_nonzero() {
+        let ts = SystemTimeSource;
+        assert!(ts.now().as_secs() > 0, "wall clock should be after epoch");
+    }
+
+    #[test]
+    fn fixed_time_source_returns_exact_value() {
+        let d = Duration::from_secs(1_700_000_000);
+        let ts = FixedTimeSource::new(d);
+        assert_eq!(ts.now(), d, "should return the fixed duration");
+    }
+
+    #[test]
+    fn pre_epoch_returns_zero() {
+        let pre_epoch = UNIX_EPOCH - Duration::from_secs(1);
+        let result = duration_since_epoch(pre_epoch);
+        assert_eq!(result, Duration::ZERO, "pre-epoch should return ZERO");
+    }
+
+    #[test]
+    fn post_epoch_returns_positive() {
+        let result = duration_since_epoch(SystemTime::now());
+        assert!(result.as_secs() > 0, "post-epoch should return positive duration");
+    }
+}

--- a/filter/src/builtins/http/observability/request_id.rs
+++ b/filter/src/builtins/http/observability/request_id.rs
@@ -9,7 +9,6 @@ use std::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 use async_trait::async_trait;
@@ -99,13 +98,9 @@ impl RequestIdFilter {
     /// Combines the current time in microseconds with a per-instance
     /// monotone counter. Not cryptographically random but unique
     /// within a filter instance for any realistic request rate.
-    fn generate_id(&self) -> String {
+    fn generate_id(&self, time_source: &dyn praxis_core::time::TimeSource) -> String {
         #[allow(clippy::cast_possible_truncation, reason = "micros fit u64")]
-        let micros = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_micros()
-            .min(u128::from(u64::MAX)) as u64;
+        let micros = time_source.now().as_micros().min(u128::from(u64::MAX)) as u64;
 
         let seq = self.counter.fetch_add(1, Ordering::Relaxed);
 
@@ -168,7 +163,7 @@ impl HttpFilter for RequestIdFilter {
             .headers
             .get(&*self.header_name)
             .and_then(|v| v.to_str().ok())
-            .map_or_else(|| self.generate_id(), str::to_owned);
+            .map_or_else(|| self.generate_id(ctx.time_source), str::to_owned);
 
         debug!(request_id = %id, header = %self.header_name, "forwarding request ID");
 
@@ -309,10 +304,23 @@ mod tests {
 
     #[test]
     fn generated_ids_are_unique() {
+        let ts = praxis_core::time::FixedTimeSource::new(std::time::Duration::from_secs(1_700_000_000));
         let filter = make_filter("");
-        let id1 = filter.generate_id();
-        let id2 = filter.generate_id();
+        let id1 = filter.generate_id(&ts);
+        let id2 = filter.generate_id(&ts);
         assert_ne!(id1, id2, "consecutive generated IDs must be unique");
+    }
+
+    #[test]
+    fn generate_id_uses_time_source() {
+        let ts = praxis_core::time::FixedTimeSource::new(std::time::Duration::from_micros(0x0011_2233_4455_6677));
+        let filter = make_filter("");
+        let id = filter.generate_id(&ts);
+        assert!(
+            id.starts_with("00112233"),
+            "ID should start with hex-encoded fixed micros, got: {id}"
+        );
+        assert_eq!(id.len(), 32, "generated ID should be 32 hex chars");
     }
 
     // -------------------------------------------------------------------------

--- a/filter/src/builtins/http/traffic_management/rate_limit/limiter.rs
+++ b/filter/src/builtins/http/traffic_management/rate_limit/limiter.rs
@@ -34,17 +34,18 @@ impl RateLimitFilter {
         clippy::cast_sign_loss,
         reason = "token count truncation"
     )]
-    pub(super) fn rate_limit_headers(&self, remaining: f64) -> (Vec<(&'static str, String)>, u64) {
+    pub(super) fn rate_limit_headers(
+        &self,
+        remaining: f64,
+        time_source: &dyn praxis_core::time::TimeSource,
+    ) -> (Vec<(&'static str, String)>, u64) {
         let retry_secs = if remaining < 1.0 {
             ((1.0 - remaining) / self.rate).ceil().max(1.0) as u64
         } else {
             0
         };
-        let now_unix = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-        let reset_unix = now_unix + retry_secs;
+        let now_unix = time_source.now().as_secs();
+        let reset_unix = now_unix.saturating_add(retry_secs);
         let remaining_int = remaining.max(0.0) as u64;
 
         let headers = vec![

--- a/filter/src/builtins/http/traffic_management/rate_limit/mod.rs
+++ b/filter/src/builtins/http/traffic_management/rate_limit/mod.rs
@@ -197,7 +197,7 @@ impl HttpFilter for RateLimitFilter {
                     client = ?ctx.client_addr,
                     "rate_limit: rejecting request (429)"
                 );
-                let (headers, retry_secs) = self.rate_limit_headers(remaining);
+                let (headers, retry_secs) = self.rate_limit_headers(remaining, ctx.time_source);
 
                 let mut rejection = Rejection::status(429).with_header("Retry-After", format!("{retry_secs}"));
                 for (name, value) in headers {
@@ -210,7 +210,7 @@ impl HttpFilter for RateLimitFilter {
 
     async fn on_response(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
         let remaining = self.current_remaining(ctx.client_addr);
-        let (headers, _retry_secs) = self.rate_limit_headers(remaining);
+        let (headers, _retry_secs) = self.rate_limit_headers(remaining, ctx.time_source);
 
         if let Some(ref mut resp) = ctx.response_header {
             for (name, value) in &headers {

--- a/filter/src/builtins/http/traffic_management/rate_limit/tests.rs
+++ b/filter/src/builtins/http/traffic_management/rate_limit/tests.rs
@@ -452,6 +452,20 @@ fn eviction_reclaims_below_soft_cap() {
     );
 }
 
+#[test]
+fn rate_limit_headers_saturate_near_u64_max() {
+    let ts = praxis_core::time::FixedTimeSource::new(std::time::Duration::from_secs(u64::MAX - 1));
+    let filter = make_filter("global", 10.0, 10);
+    let (headers, _retry_secs) = filter.rate_limit_headers(0.0, &ts);
+    let reset_val = &headers.iter().find(|(n, _)| *n == "X-RateLimit-Reset").unwrap().1;
+    let reset_unix: u64 = reset_val.parse().expect("X-RateLimit-Reset should be numeric");
+    assert_eq!(
+        reset_unix,
+        u64::MAX,
+        "reset should saturate to u64::MAX instead of wrapping"
+    );
+}
+
 // -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------

--- a/filter/src/context.rs
+++ b/filter/src/context.rs
@@ -6,7 +6,7 @@
 use std::{borrow::Cow, collections::HashMap, net::IpAddr, sync::Arc, time::Instant};
 
 use http::{HeaderMap, Method, StatusCode, Uri};
-use praxis_core::{connectivity::Upstream, health::HealthRegistry, kv::KvStoreRegistry};
+use praxis_core::{connectivity::Upstream, health::HealthRegistry, kv::KvStoreRegistry, time::TimeSource};
 
 use crate::{body::BodyMode, pipeline::body::merge_body_mode, results::FilterResultSet};
 
@@ -81,6 +81,9 @@ pub struct HttpFilterContext<'a> {
 
     /// Named key-value stores for runtime mappings.
     pub kv_stores: Option<&'a KvStoreRegistry>,
+
+    /// Wall-clock time source for timestamp generation.
+    pub time_source: &'a dyn TimeSource,
 
     /// Transport-agnostic request headers, URI, and method.
     pub request: &'a Request,

--- a/filter/src/context.rs
+++ b/filter/src/context.rs
@@ -82,9 +82,6 @@ pub struct HttpFilterContext<'a> {
     /// Named key-value stores for runtime mappings.
     pub kv_stores: Option<&'a KvStoreRegistry>,
 
-    /// Wall-clock time source for timestamp generation.
-    pub time_source: &'a dyn TimeSource,
-
     /// Transport-agnostic request headers, URI, and method.
     pub request: &'a Request,
 
@@ -124,6 +121,9 @@ pub struct HttpFilterContext<'a> {
     /// for use by passive health checking in the
     /// protocol layer.
     pub selected_endpoint_index: Option<usize>,
+
+    /// Wall-clock time source for timestamp generation.
+    pub time_source: &'a dyn TimeSource,
 
     /// Rewritten URI path for the upstream request.
     ///

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -265,6 +265,7 @@ pub(crate) mod test_utils {
             filter_results: std::collections::HashMap::new(),
             health_registry: None,
             kv_stores: None,
+            time_source: &praxis_core::time::SystemTimeSource,
             request: req,
             request_body_bytes: 0,
             request_body_mode: crate::body::BodyMode::Stream,

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -265,7 +265,6 @@ pub(crate) mod test_utils {
             filter_results: std::collections::HashMap::new(),
             health_registry: None,
             kv_stores: None,
-            time_source: &praxis_core::time::SystemTimeSource,
             request: req,
             request_body_bytes: 0,
             request_body_mode: crate::body::BodyMode::Stream,
@@ -276,6 +275,7 @@ pub(crate) mod test_utils {
             response_headers_modified: false,
             rewritten_path: None,
             selected_endpoint_index: None,
+            time_source: &praxis_core::time::SystemTimeSource,
             upstream: None,
         }
     }

--- a/filter/src/pipeline/build.rs
+++ b/filter/src/pipeline/build.rs
@@ -5,7 +5,7 @@
 
 use std::{collections::HashMap, mem, sync::Arc};
 
-use praxis_core::config::FilterEntry;
+use praxis_core::{config::FilterEntry, time::SystemTimeSource};
 use tracing::{debug, warn};
 
 use super::{FilterPipeline, body::compute_body_capabilities, filter::PipelineFilter};
@@ -53,6 +53,7 @@ impl FilterPipeline {
             filters,
             health_registry: None,
             kv_stores: None,
+            time_source: Arc::new(SystemTimeSource),
         })
     }
 
@@ -82,6 +83,7 @@ impl FilterPipeline {
             filters,
             health_registry: None,
             kv_stores: None,
+            time_source: Arc::new(SystemTimeSource),
         })
     }
 

--- a/filter/src/pipeline/mod.rs
+++ b/filter/src/pipeline/mod.rs
@@ -31,10 +31,13 @@ mod tcp;
 )]
 mod tests;
 
+use std::sync::Arc;
+
 use praxis_core::{
     config::{FailureMode, InsecureOptions},
     health::HealthRegistry,
     kv::KvStoreRegistry,
+    time::TimeSource,
 };
 use tracing::warn;
 
@@ -73,6 +76,9 @@ pub struct FilterPipeline {
 
     /// Named key-value stores for runtime mappings.
     kv_stores: Option<KvStoreRegistry>,
+
+    /// Wall-clock time source for filters that need timestamps.
+    time_source: Arc<dyn TimeSource>,
 }
 
 impl FilterPipeline {
@@ -164,6 +170,16 @@ impl FilterPipeline {
     /// Set the shared [`KvStoreRegistry`] for this pipeline.
     pub fn set_kv_stores(&mut self, stores: KvStoreRegistry) {
         self.kv_stores = Some(stores);
+    }
+
+    /// The wall-clock time source.
+    pub fn time_source(&self) -> &dyn TimeSource {
+        &*self.time_source
+    }
+
+    /// Override the [`TimeSource`] for this pipeline.
+    pub fn set_time_source(&mut self, source: Arc<dyn TimeSource>) {
+        self.time_source = source;
     }
 
     /// Apply [`InsecureOptions`] to all filters in the pipeline.

--- a/filter/src/pipeline/tcp.rs
+++ b/filter/src/pipeline/tcp.rs
@@ -445,6 +445,7 @@ mod tests {
             filters,
             health_registry: None,
             kv_stores: None,
+            time_source: Arc::new(praxis_core::time::SystemTimeSource),
         }
     }
 

--- a/filter/src/pipeline/tests.rs
+++ b/filter/src/pipeline/tests.rs
@@ -623,6 +623,7 @@ fn apply_body_limits_no_limits_leaves_stream_mode() {
         filters: vec![],
         health_registry: None,
         kv_stores: None,
+        time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
     pipeline.apply_body_limits(None, None, false).unwrap();
 
@@ -655,6 +656,7 @@ fn apply_body_limits_converts_default_stream_to_size_limit() {
         filters: vec![],
         health_registry: None,
         kv_stores: None,
+        time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
     pipeline
         .apply_body_limits(Some(1_048_576), Some(524_288), false)
@@ -696,6 +698,7 @@ fn apply_body_limits_preserves_filter_declared_stream() {
         filters: vec![],
         health_registry: None,
         kv_stores: None,
+        time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
     pipeline
         .apply_body_limits(Some(1_048_576), Some(524_288), false)
@@ -1268,6 +1271,7 @@ fn apply_body_limits_default_stream_becomes_size_limit() {
         filters: vec![],
         health_registry: None,
         kv_stores: None,
+        time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
     pipeline.apply_body_limits(Some(4096), Some(8192), false).unwrap();
     assert_eq!(
@@ -1293,6 +1297,7 @@ fn apply_body_limits_filter_stricter_than_config() {
         filters: vec![],
         health_registry: None,
         kv_stores: None,
+        time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
     pipeline.apply_body_limits(Some(1000), None, false).unwrap();
     assert_eq!(
@@ -1315,6 +1320,7 @@ fn apply_body_limits_config_stricter_than_filter() {
         filters: vec![],
         health_registry: None,
         kv_stores: None,
+        time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
     pipeline.apply_body_limits(Some(1000), None, false).unwrap();
     assert_eq!(
@@ -1337,6 +1343,7 @@ fn apply_body_limits_rejects_unbounded_stream_buffer() {
         filters: vec![],
         health_registry: None,
         kv_stores: None,
+        time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
     let err = pipeline.apply_body_limits(None, None, false).unwrap_err();
     assert!(
@@ -1358,6 +1365,7 @@ fn apply_body_limits_allows_unbounded_stream_buffer_with_override() {
         filters: vec![],
         health_registry: None,
         kv_stores: None,
+        time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
     pipeline
         .apply_body_limits(None, None, true)
@@ -1565,6 +1573,7 @@ async fn skip_to_excludes_skipped_filters_from_response() {
         filters: vec![filter_a, filter_b, filter_c],
         health_registry: None,
         kv_stores: None,
+        time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
 
     let req = crate::test_utils::make_request(Method::GET, "/");
@@ -1608,6 +1617,7 @@ async fn all_executed_filters_run_on_response() {
         ],
         health_registry: None,
         kv_stores: None,
+        time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
 
     let req = crate::test_utils::make_request(Method::GET, "/");
@@ -1658,6 +1668,7 @@ async fn skipped_filter_skips_its_branches() {
         filters: vec![parent],
         health_registry: None,
         kv_stores: None,
+        time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
 
     let req = crate::test_utils::make_request(Method::GET, "/other");
@@ -2671,6 +2682,7 @@ fn make_pipeline(filters: Vec<Box<dyn HttpFilter>>) -> FilterPipeline {
         filters,
         health_registry: None,
         kv_stores: None,
+        time_source: Arc::new(praxis_core::time::SystemTimeSource),
     }
 }
 
@@ -2690,6 +2702,7 @@ fn make_pipeline_with_conditions(
         filters,
         health_registry: None,
         kv_stores: None,
+        time_source: Arc::new(praxis_core::time::SystemTimeSource),
     }
 }
 
@@ -2709,6 +2722,7 @@ fn make_pipeline_with_response_conditions(
         filters,
         health_registry: None,
         kv_stores: None,
+        time_source: Arc::new(praxis_core::time::SystemTimeSource),
     }
 }
 

--- a/protocol/src/http/pingora/context.rs
+++ b/protocol/src/http/pingora/context.rs
@@ -195,6 +195,7 @@ macro_rules! filter_context {
             filter_results: std::mem::take(&mut $ctx.filter_results),
             health_registry: $pipeline.health_registry(),
             kv_stores: $pipeline.kv_stores(),
+            time_source: $pipeline.time_source(),
             request: $request,
             request_body_bytes: $ctx.request_body_bytes,
             request_body_mode: $ctx.request_body_mode,

--- a/protocol/src/http/pingora/context.rs
+++ b/protocol/src/http/pingora/context.rs
@@ -195,7 +195,6 @@ macro_rules! filter_context {
             filter_results: std::mem::take(&mut $ctx.filter_results),
             health_registry: $pipeline.health_registry(),
             kv_stores: $pipeline.kv_stores(),
-            time_source: $pipeline.time_source(),
             request: $request,
             request_body_bytes: $ctx.request_body_bytes,
             request_body_mode: $ctx.request_body_mode,
@@ -206,6 +205,7 @@ macro_rules! filter_context {
             response_headers_modified: false,
             rewritten_path: $ctx.rewritten_path.take(),
             selected_endpoint_index: $ctx.selected_endpoint_index,
+            time_source: $pipeline.time_source(),
             upstream: $ctx.upstream.take(),
         }
     };

--- a/server/src/pipelines.rs
+++ b/server/src/pipelines.rs
@@ -35,7 +35,6 @@ pub fn resolve_pipelines(
         .map(|c| (c.name.as_str(), c.filters.as_slice()))
         .collect();
 
-
     let mut pipelines = HashMap::with_capacity(config.listeners.len());
 
     for listener in &config.listeners {
@@ -60,7 +59,6 @@ pub fn resolve_pipelines(
         if !kv_stores.is_empty() {
             pipeline.set_kv_stores(kv_stores.clone());
         }
-
         pipeline.apply_insecure_options(&config.insecure_options);
 
         let skip = config.insecure_options.skip_pipeline_validation;

--- a/tests/fuzz/fuzz_targets/fuzz_filter_pipeline.rs
+++ b/tests/fuzz/fuzz_targets/fuzz_filter_pipeline.rs
@@ -59,6 +59,7 @@ fuzz_target!(|data: &str| {
             filter_results: std::collections::HashMap::new(),
             health_registry: None,
             kv_stores: None,
+            time_source: &praxis_core::time::SystemTimeSource,
             request: &request,
             request_body_bytes: 0,
             request_body_mode: praxis_filter::BodyMode::Stream,

--- a/tests/fuzz/fuzz_targets/fuzz_filter_pipeline.rs
+++ b/tests/fuzz/fuzz_targets/fuzz_filter_pipeline.rs
@@ -59,7 +59,6 @@ fuzz_target!(|data: &str| {
             filter_results: std::collections::HashMap::new(),
             health_registry: None,
             kv_stores: None,
-            time_source: &praxis_core::time::SystemTimeSource,
             request: &request,
             request_body_bytes: 0,
             request_body_mode: praxis_filter::BodyMode::Stream,
@@ -72,6 +71,7 @@ fuzz_target!(|data: &str| {
             response_headers_modified: false,
             rewritten_path: None,
             selected_endpoint_index: None,
+            time_source: &praxis_core::time::SystemTimeSource,
             upstream: None,
         };
 


### PR DESCRIPTION
## Summary

Introduces a `TimeSource` trait in `praxis-core` to replace direct `SystemTime::now()` calls in filters, addressing praxis-proxy/ai#12. The trait is injected through `FilterPipeline` → `HttpFilterContext` (same pattern as `KvStoreRegistry` / `HealthRegistry`), enabling deterministic timestamps in tests and adding a once-per-process warning when the system clock is before the Unix epoch.

- `RequestIdFilter` and `RateLimitFilter` migrated to use `ctx.time_source` instead of `SystemTime::now()` directly
- `saturating_add` applied to rate limit reset timestamp for overflow safety
- All struct literal construction sites (tests, fuzz, benchmarks) updated

## Test plan

- [x] `cargo test -p praxis-core -- time` — 4 unit tests including pre-epoch behavior
- [x] `cargo test -p praxis-filter -- request_id` — deterministic ID generation with `FixedTimeSource`
- [x] `cargo test -p praxis-filter -- rate_limit` — all 24 rate limit tests pass
- [x] `make lint` — clean
- [x] `make doc` — clean
- [x] `cargo check --workspace` — clean

Closes praxis-proxy/ai#12