### PR TITLE
feat(filter): add set_token_usage() convenience method to HttpFilterContext

### DIFF
--- a/filter/src/context.rs
+++ b/filter/src/context.rs
@@ -204,6 +204,22 @@ impl HttpFilterContext<'_> {
     pub fn set_response_body_mode(&mut self, mode: BodyMode) {
         merge_body_mode(&mut self.response_body_mode, mode);
     }
+
+    /// Store token usage counts in [`filter_metadata`] so that downstream
+    /// filters, access log templates, and metrics can read them.
+    ///
+    /// Writes the well-known keys `token.input`, `token.output`, and
+    /// `token.total`. If `total` is `None`, it defaults to
+    /// `input.saturating_add(output)`.
+    ///
+    /// [`filter_metadata`]: Self::filter_metadata
+    pub fn set_token_usage(&mut self, input: u64, output: u64, total: Option<u64>) {
+        let total = total.unwrap_or_else(|| input.saturating_add(output));
+
+        self.set_metadata("token.input", input.to_string());
+        self.set_metadata("token.output", output.to_string());
+        self.set_metadata("token.total", total.to_string());
+    }
 }
 
 // -----------------------------------------------------------------------------
@@ -569,5 +585,71 @@ mod tests {
             store.lookup(".main", MatchType::Suffix).unwrap().is_some(),
             "suffix lookup should match route.web.main"
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // Token Usage Tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn token_metadata_absent_by_default() {
+        let req = crate::test_utils::make_request(Method::GET, "/");
+        let ctx = crate::test_utils::make_filter_context(&req);
+        assert!(ctx.get_metadata("token.input").is_none());
+        assert!(ctx.get_metadata("token.output").is_none());
+        assert!(ctx.get_metadata("token.total").is_none());
+    }
+
+    #[test]
+    fn set_token_usage_writes_all_metadata_keys() {
+        let req = crate::test_utils::make_request(Method::GET, "/");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        ctx.set_token_usage(150, 80, Some(230));
+        assert_eq!(ctx.get_metadata("token.input"), Some("150"));
+        assert_eq!(ctx.get_metadata("token.output"), Some("80"));
+        assert_eq!(ctx.get_metadata("token.total"), Some("230"));
+    }
+
+    #[test]
+    fn set_token_usage_computes_total_when_none() {
+        let req = crate::test_utils::make_request(Method::GET, "/");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        ctx.set_token_usage(100, 50, None);
+        assert_eq!(ctx.get_metadata("token.total"), Some("150"));
+    }
+
+    #[test]
+    fn set_token_usage_uses_explicit_total() {
+        let req = crate::test_utils::make_request(Method::GET, "/");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        ctx.set_token_usage(100, 50, Some(200));
+        assert_eq!(
+            ctx.get_metadata("token.total"),
+            Some("200"),
+            "explicit total should override computed sum"
+        );
+    }
+
+    #[test]
+    fn set_token_usage_saturates_on_overflow() {
+        let req = crate::test_utils::make_request(Method::GET, "/");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        ctx.set_token_usage(u64::MAX, 1, None);
+        assert_eq!(
+            ctx.get_metadata("token.total"),
+            Some(&u64::MAX.to_string()[..]),
+            "total should saturate instead of wrapping"
+        );
+    }
+
+    #[test]
+    fn set_token_usage_overwrites_previous() {
+        let req = crate::test_utils::make_request(Method::GET, "/");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        ctx.set_token_usage(100, 50, None);
+        ctx.set_token_usage(200, 80, Some(280));
+        assert_eq!(ctx.get_metadata("token.input"), Some("200"));
+        assert_eq!(ctx.get_metadata("token.output"), Some("80"));
+        assert_eq!(ctx.get_metadata("token.total"), Some("280"));
     }
 }

--- a/protocol/src/http/pingora/context.rs
+++ b/protocol/src/http/pingora/context.rs
@@ -357,7 +357,7 @@ mod tests {
     use bytes::Bytes;
     use http::{HeaderMap, Method, Uri};
     use praxis_core::connectivity::Upstream;
-    use praxis_filter::{BodyBuffer, BodyMode};
+    use praxis_filter::{BodyBuffer, BodyMode, FilterPipeline, FilterRegistry};
 
     use super::*;
 
@@ -594,6 +594,71 @@ mod tests {
             BodyMode::StreamBuffer { max_bytes: Some(8192) },
             "response_body_mode should match assigned value"
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // Token Usage Metadata Tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn token_metadata_absent_by_default() {
+        let registry = FilterRegistry::with_builtins();
+        let pipeline = FilterPipeline::build(&mut [], &registry).unwrap();
+        let request = Request {
+            method: Method::GET,
+            uri: "/".parse::<Uri>().unwrap(),
+            headers: HeaderMap::new(),
+        };
+
+        let mut ctx = default_ctx();
+        let fctx = ctx.build_filter_context(&pipeline, &request, None);
+        assert!(fctx.get_metadata("token.input").is_none());
+        assert!(fctx.get_metadata("token.output").is_none());
+        assert!(fctx.get_metadata("token.total").is_none());
+    }
+
+    #[test]
+    fn token_metadata_roundtrip_through_filter_context() {
+        let registry = FilterRegistry::with_builtins();
+        let pipeline = FilterPipeline::build(&mut [], &registry).unwrap();
+        let request = Request {
+            method: Method::GET,
+            uri: "/".parse::<Uri>().unwrap(),
+            headers: HeaderMap::new(),
+        };
+
+        let mut ctx = default_ctx();
+        ctx.filter_metadata.insert("token.input".to_owned(), "150".to_owned());
+        ctx.filter_metadata.insert("token.output".to_owned(), "80".to_owned());
+        ctx.filter_metadata.insert("token.total".to_owned(), "230".to_owned());
+
+        let fctx = ctx.build_filter_context(&pipeline, &request, None);
+        assert_eq!(fctx.get_metadata("token.input"), Some("150"));
+        assert_eq!(fctx.get_metadata("token.output"), Some("80"));
+        assert_eq!(fctx.get_metadata("token.total"), Some("230"));
+    }
+
+    #[test]
+    fn set_token_usage_persists_via_filter_metadata() {
+        let registry = FilterRegistry::with_builtins();
+        let pipeline = FilterPipeline::build(&mut [], &registry).unwrap();
+        let request = Request {
+            method: Method::GET,
+            uri: "/".parse::<Uri>().unwrap(),
+            headers: HeaderMap::new(),
+        };
+
+        let mut ctx = default_ctx();
+        let mut fctx = ctx.build_filter_context(&pipeline, &request, None);
+        fctx.set_token_usage(42, 18, None);
+
+        assert_eq!(fctx.get_metadata("token.input"), Some("42"));
+        assert_eq!(fctx.get_metadata("token.output"), Some("18"));
+        assert_eq!(fctx.get_metadata("token.total"), Some("60"));
+
+        ctx.filter_metadata = fctx.filter_metadata;
+        assert_eq!(ctx.filter_metadata.get("token.input").map(String::as_str), Some("42"));
+        assert_eq!(ctx.filter_metadata.get("token.total").map(String::as_str), Some("60"));
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a `set_token_usage(input, output, total)` convenience method to
`HttpFilterContext` that writes token counts to `filter_metadata` using
well-known keys (`token.input`, `token.output`, `token.total`).

This follows the metadata-based approach used by mcp, a2a, and responses
filters — no new struct fields are added to the core context.

## Related

- Epic: praxis-proxy/ai#71
- Task: praxis-proxy/ai#221
- Proposal: praxis-proxy/praxis#462

## What it does

- Adds `set_token_usage()` to `HttpFilterContext` — computes total via
  `saturating_add` when not explicitly provided, writes all three values
  to `filter_metadata`
- Consumers (rate limiters, access logs, cost trackers) read values via
  `get_metadata("token.input")` etc.
- Includes unit tests for metadata writes, overflow saturation, overwrite
  behavior, and roundtrip through `filter_context!` macro

## Test plan

- Unit tests for `set_token_usage()` (6 tests in filter crate)
- Unit tests for metadata persistence across pipeline phases (3 tests in protocol crate)
- All existing tests pass (0 regressions)