### PR TITLE
feat(filter): add native llm-d static endpoint picker

### DIFF
--- a/docs/operating/filter-reference.md
+++ b/docs/operating/filter-reference.md
@@ -35,6 +35,7 @@ and the [extensions guide](../filters/extensions.md).
 | `url_rewrite` | Transformation | HTTP |
 | `sni_router` | Traffic Management | TCP |
 | `tcp_load_balancer` | Traffic Management | TCP |
+| `llmd_endpoint_picker` | AI / Inference | HTTP (requires `ai-inference` feature) |
 | `model_to_header` | AI / Inference | HTTP (requires `ai-inference` feature) |
 | `prompt_enrich` | AI / Inference | HTTP (requires `ai-inference` feature) |
 
@@ -681,6 +682,57 @@ non-empty `content` string. JSON is re-serialized, so
 byte-for-byte body identity is not preserved. In chains
 that also use `json_body_field` or `model_to_header`,
 place `prompt_enrich` first.
+
+## llm-d Endpoint Picker
+
+Native endpoint picker for llm-d compatible inference
+workloads. Buffers OpenAI-compatible request bodies,
+extracts the `model` field, filters endpoints by model
+and health, scores by queue depth and KV-cache pressure,
+and routes to the highest-scored endpoint. Requires the
+`ai-inference` feature. See [llmd-endpoint-picker.yaml].
+
+[llmd-endpoint-picker.yaml]: ../../examples/configs/ai/llmd-endpoint-picker.yaml
+
+```yaml
+- filter: llmd_endpoint_picker
+  pool_name: llmd-pool
+  queue_weight: 2.0
+  kv_cache_weight: 2.0
+  endpoints:
+    - name: vllm-a
+      address: "10.0.1.1:8000"
+      models: ["meta-llama/Llama-3.2-3B-Instruct"]
+      running_requests: 2
+      waiting_requests: 0
+      kv_cache_usage_percent: 15.0
+```
+
+| Field | Type | Default | Description |
+| ------- | ------ | --------- | ------------- |
+| `pool_name` | string | `"llmd"` | Logical pool name for metadata and cluster accounting |
+| `max_body_bytes` | integer | 10485760 | Maximum body size to buffer (10 MiB) |
+| `queue_weight` | float | `2.0` | Weight for inverse queue-depth scoring |
+| `kv_cache_weight` | float | `2.0` | Weight for inverse KV-cache pressure scoring |
+| `endpoints` | list | (required) | Static endpoint definitions (at least one) |
+
+Each endpoint entry:
+
+| Field | Type | Default | Description |
+| ------- | ------ | --------- | ------------- |
+| `name` | string | (required) | Stable endpoint name for metadata and logs |
+| `address` | string | (required) | Upstream address in `host:port` form |
+| `models` | list | (required) | Models served by this endpoint (at least one) |
+| `running_requests` | integer | `0` | Current running request count |
+| `waiting_requests` | integer | `0` | Current waiting request count |
+| `kv_cache_usage_percent` | float | `0.0` | KV-cache utilization percentage (0-100) |
+| `healthy` | boolean | `true` | Whether the endpoint is eligible for requests |
+
+Scoring formula:
+`score = queue_weight / (1 + queue_depth) + kv_cache_weight * (1 - kv/100)`.
+The endpoint with the highest score is selected. Only
+healthy endpoints serving the requested model are
+considered.
 
 ## Conditions
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -125,6 +125,7 @@ page.
 | [ai-inference-body-based-routing.yaml](configs/ai/ai-inference-body-based-routing.yaml) | Route LLM requests by model field in JSON body |
 | [credential-injection.yaml](configs/ai/credential-injection.yaml) | Inject per-cluster API credentials and strip client tokens |
 | [json-rpc-routing.yaml](configs/ai/json-rpc-routing.yaml) | Route JSON-RPC 2.0 requests by method for MCP and A2A protocols |
+| [llmd-endpoint-picker.yaml](configs/ai/llmd-endpoint-picker.yaml) | Native llm-d endpoint picker with static model-aware and load-aware routing |
 | [mcp-classifier-routing.yaml](configs/ai/mcp-classifier-routing.yaml) | Route MCP requests by body-derived method and tool name |
 | [model-to-header-routing.yaml](configs/ai/model-to-header-routing.yaml) | Route by model field in JSON body via X-Model header |
 | [prompt-enrichment.yaml](configs/ai/prompt-enrichment.yaml) | Inject system messages into chat completion requests |

--- a/examples/configs/ai/llmd-endpoint-picker.yaml
+++ b/examples/configs/ai/llmd-endpoint-picker.yaml
@@ -1,0 +1,61 @@
+# llm-d Endpoint Picker - Static Configuration
+#
+# Requires the ai-inference feature:
+#   cargo build -p praxis --features ai-inference
+#
+# Static Praxis config that mirrors the first EPP scheduling slice.
+# For this static path, endpoint selection runs in-process as
+# a Praxis HTTP filter instead of calling an external picker.
+#
+# Conceptual mapping to the llm-d EPP pipeline:
+#   OpenAI parser    -> extracts top-level `model` from request body
+#   model filter     -> matches against endpoint `models` lists
+#   queue/KV scorers -> uses configured static endpoint state
+#   max-score picker -> highest total score wins
+#
+# This example uses static endpoint state defined inline. Each
+# endpoint declares models it serves and its configured queue depth
+# and KV-cache pressure. The filter scores endpoints as:
+#
+#   score = queue_weight / (1 + queue_depth) + kv_cache_weight * (1 - kv/100)
+#
+# This static example does not configure live vLLM metrics scraping.
+# Queue and KV values are supplied directly in the endpoint list.
+#
+# Example request:
+#
+#   curl -X POST http://localhost:8080/v1/chat/completions \
+#     -H "Content-Type: application/json" \
+#     -d '{"model": "meta-llama/Llama-3.2-3B-Instruct", "messages": [{"role": "user", "content": "hi"}]}'
+
+listeners:
+  - name: inference-gateway
+    address: "0.0.0.0:8080" # dev value; binds all interfaces
+    filter_chains: [main]
+
+filter_chains:
+  - name: main
+    filters:
+      - filter: llmd_endpoint_picker
+        pool_name: llmd-pool
+        queue_weight: 2.0
+        kv_cache_weight: 2.0
+        endpoints:
+          - name: vllm-a
+            address: "10.0.1.1:8000"
+            models: ["meta-llama/Llama-3.2-3B-Instruct"]
+            running_requests: 2
+            waiting_requests: 0
+            kv_cache_usage_percent: 15.0
+          - name: vllm-b
+            address: "10.0.1.2:8000"
+            models: ["meta-llama/Llama-3.2-3B-Instruct", "Qwen/Qwen3-0.6B"]
+            running_requests: 8
+            waiting_requests: 3
+            kv_cache_usage_percent: 75.0
+          - name: vllm-c
+            address: "10.0.2.1:8000"
+            models: ["Qwen/Qwen3-0.6B"]
+            running_requests: 0
+            waiting_requests: 0
+            kv_cache_usage_percent: 5.0

--- a/filter/src/builtins/http/ai/inference/llmd_endpoint_picker/config.rs
+++ b/filter/src/builtins/http/ai/inference/llmd_endpoint_picker/config.rs
@@ -1,0 +1,449 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Configuration types for the llm-d endpoint picker filter.
+
+use serde::Deserialize;
+
+use crate::{FilterError, body::DEFAULT_JSON_BODY_MAX_BYTES};
+
+// -----------------------------------------------------------------------------
+// Defaults
+// -----------------------------------------------------------------------------
+
+/// Default logical pool name used in metadata.
+pub(super) const DEFAULT_POOL_NAME: &str = "llmd";
+/// Default weight for queue-depth scoring.
+pub(super) const DEFAULT_QUEUE_WEIGHT: f64 = 2.0;
+/// Default weight for KV-cache pressure scoring.
+pub(super) const DEFAULT_KV_CACHE_WEIGHT: f64 = 2.0;
+
+// -----------------------------------------------------------------------------
+// Top-Level Config
+// -----------------------------------------------------------------------------
+
+/// YAML configuration for the llm-d endpoint picker filter.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct LlmdEndpointPickerConfig {
+    /// Static endpoint definitions (at least one required).
+    pub endpoints: Vec<EndpointConfig>,
+
+    /// Weight applied to inverse KV-cache pressure scoring.
+    #[serde(default = "default_kv_cache_weight")]
+    pub kv_cache_weight: f64,
+
+    /// Maximum request body size in bytes for `StreamBuffer` mode.
+    #[serde(default = "default_max_body_bytes")]
+    pub max_body_bytes: usize,
+
+    /// Logical pool name for request metadata.
+    #[serde(default = "default_pool_name")]
+    pub pool_name: String,
+
+    /// Weight applied to inverse queue-depth scoring.
+    #[serde(default = "default_queue_weight")]
+    pub queue_weight: f64,
+}
+
+// -----------------------------------------------------------------------------
+// Endpoint Config
+// -----------------------------------------------------------------------------
+
+/// YAML configuration for one inference endpoint.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct EndpointConfig {
+    /// Stable endpoint name used in metadata and logs.
+    pub name: String,
+
+    /// Upstream address in `host:port` form.
+    pub address: String,
+
+    /// Whether this endpoint is eligible for new requests.
+    #[serde(default = "default_healthy")]
+    pub healthy: bool,
+
+    /// Current KV-cache utilization percentage, 0-100.
+    #[serde(default)]
+    pub kv_cache_usage_percent: f64,
+
+    /// Models served by this endpoint.
+    pub models: Vec<String>,
+
+    /// Current running request count.
+    #[serde(default)]
+    pub running_requests: u64,
+
+    /// Current waiting request count.
+    #[serde(default)]
+    pub waiting_requests: u64,
+}
+
+// -----------------------------------------------------------------------------
+// Default Helpers
+// -----------------------------------------------------------------------------
+
+/// Returns [`DEFAULT_POOL_NAME`].
+fn default_pool_name() -> String {
+    DEFAULT_POOL_NAME.to_owned()
+}
+
+/// Returns [`DEFAULT_JSON_BODY_MAX_BYTES`].
+fn default_max_body_bytes() -> usize {
+    DEFAULT_JSON_BODY_MAX_BYTES
+}
+
+/// Returns [`DEFAULT_QUEUE_WEIGHT`].
+fn default_queue_weight() -> f64 {
+    DEFAULT_QUEUE_WEIGHT
+}
+
+/// Returns [`DEFAULT_KV_CACHE_WEIGHT`].
+fn default_kv_cache_weight() -> f64 {
+    DEFAULT_KV_CACHE_WEIGHT
+}
+
+/// Returns `true`.
+fn default_healthy() -> bool {
+    true
+}
+
+// -----------------------------------------------------------------------------
+// Validation
+// -----------------------------------------------------------------------------
+
+/// Validate top-level endpoint picker config.
+pub(super) fn validate_config(cfg: &LlmdEndpointPickerConfig) -> Result<(), FilterError> {
+    if cfg.pool_name.trim().is_empty() {
+        return Err("llmd_endpoint_picker: pool_name must not be empty".into());
+    }
+    if cfg.max_body_bytes == 0 {
+        return Err("llmd_endpoint_picker: max_body_bytes must be greater than zero".into());
+    }
+    validate_endpoints_present(cfg)?;
+    validate_scoring_weights(cfg)?;
+    Ok(())
+}
+
+/// Validate that at least one endpoint is configured.
+fn validate_endpoints_present(cfg: &LlmdEndpointPickerConfig) -> Result<(), FilterError> {
+    if cfg.endpoints.is_empty() {
+        return Err("llmd_endpoint_picker: endpoints must not be empty".into());
+    }
+    Ok(())
+}
+
+/// Validate scoring weight fields.
+fn validate_scoring_weights(cfg: &LlmdEndpointPickerConfig) -> Result<(), FilterError> {
+    if !cfg.queue_weight.is_finite() || cfg.queue_weight < 0.0 {
+        return Err("llmd_endpoint_picker: queue_weight must be a finite non-negative number".into());
+    }
+    if !cfg.kv_cache_weight.is_finite() || cfg.kv_cache_weight < 0.0 {
+        return Err("llmd_endpoint_picker: kv_cache_weight must be a finite non-negative number".into());
+    }
+    Ok(())
+}
+
+/// Validate one static endpoint config.
+pub(super) fn validate_endpoint_config(cfg: &EndpointConfig) -> Result<(), FilterError> {
+    if cfg.name.trim().is_empty() {
+        return Err("llmd_endpoint_picker: endpoint name must not be empty".into());
+    }
+    if cfg.address.trim().is_empty() {
+        return Err("llmd_endpoint_picker: endpoint address must not be empty".into());
+    }
+    validate_endpoint_models(cfg)?;
+    if !cfg.kv_cache_usage_percent.is_finite() {
+        return Err(format!(
+            "llmd_endpoint_picker: endpoint '{name}' has non-finite kv_cache_usage_percent",
+            name = cfg.name,
+        )
+        .into());
+    }
+    if cfg.kv_cache_usage_percent < 0.0 {
+        return Err(format!(
+            "llmd_endpoint_picker: endpoint '{name}' has negative kv_cache_usage_percent",
+            name = cfg.name,
+        )
+        .into());
+    }
+    if cfg.kv_cache_usage_percent > 100.0 {
+        return Err(format!(
+            "llmd_endpoint_picker: endpoint '{name}' has kv_cache_usage_percent > 100",
+            name = cfg.name,
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// Validate the models list for a single endpoint.
+fn validate_endpoint_models(cfg: &EndpointConfig) -> Result<(), FilterError> {
+    if cfg.models.is_empty() {
+        return Err(format!(
+            "llmd_endpoint_picker: endpoint '{name}' must serve at least one model",
+            name = cfg.name,
+        )
+        .into());
+    }
+    if cfg.models.iter().any(|m| m.trim().is_empty()) {
+        return Err(format!(
+            "llmd_endpoint_picker: endpoint '{name}' has an empty model",
+            name = cfg.name,
+        )
+        .into());
+    }
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_valid_config() {
+        let yaml: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+endpoints:
+  - name: ep1
+    address: "127.0.0.1:8000"
+    models: ["model"]
+"#,
+        )
+        .unwrap();
+        let cfg: LlmdEndpointPickerConfig = serde_yaml::from_value(yaml).unwrap();
+        assert!(validate_config(&cfg).is_ok(), "valid config should be accepted");
+    }
+
+    #[test]
+    fn rejects_empty_endpoints() {
+        let yaml: serde_yaml::Value = serde_yaml::from_str("endpoints: []").unwrap();
+        let cfg: LlmdEndpointPickerConfig = serde_yaml::from_value(yaml).unwrap();
+        let err = validate_config(&cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("endpoints must not be empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_pool_name() {
+        let yaml: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+pool_name: ""
+endpoints:
+  - name: ep
+    address: "127.0.0.1:8000"
+    models: ["model"]
+"#,
+        )
+        .unwrap();
+        let cfg: LlmdEndpointPickerConfig = serde_yaml::from_value(yaml).unwrap();
+        assert!(validate_config(&cfg).is_err(), "empty pool_name should be rejected");
+    }
+
+    #[test]
+    fn rejects_zero_max_body_bytes() {
+        let yaml: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+max_body_bytes: 0
+endpoints:
+  - name: ep
+    address: "127.0.0.1:8000"
+    models: ["model"]
+"#,
+        )
+        .unwrap();
+        let cfg: LlmdEndpointPickerConfig = serde_yaml::from_value(yaml).unwrap();
+        assert!(validate_config(&cfg).is_err(), "zero max_body_bytes should be rejected");
+    }
+
+    #[test]
+    fn rejects_negative_queue_weight() {
+        let yaml: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+queue_weight: -1.0
+endpoints:
+  - name: ep
+    address: "127.0.0.1:8000"
+    models: ["model"]
+"#,
+        )
+        .unwrap();
+        let cfg: LlmdEndpointPickerConfig = serde_yaml::from_value(yaml).unwrap();
+        assert!(
+            validate_config(&cfg).is_err(),
+            "negative queue_weight should be rejected"
+        );
+    }
+
+    #[test]
+    fn rejects_infinite_kv_cache_weight() {
+        let yaml: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+kv_cache_weight: .inf
+endpoints:
+  - name: ep
+    address: "127.0.0.1:8000"
+    models: ["model"]
+"#,
+        )
+        .unwrap();
+        let cfg: LlmdEndpointPickerConfig = serde_yaml::from_value(yaml).unwrap();
+        assert!(
+            validate_config(&cfg).is_err(),
+            "infinite kv_cache_weight should be rejected"
+        );
+    }
+
+    #[test]
+    fn endpoint_rejects_empty_name() {
+        let cfg = EndpointConfig {
+            name: String::new(),
+            address: "127.0.0.1:8000".to_owned(),
+            models: vec!["model".to_owned()],
+            running_requests: 0,
+            waiting_requests: 0,
+            kv_cache_usage_percent: 0.0,
+            healthy: true,
+        };
+        assert!(validate_endpoint_config(&cfg).is_err(), "empty name should be rejected");
+    }
+
+    #[test]
+    fn endpoint_rejects_empty_address() {
+        let cfg = EndpointConfig {
+            name: "ep".to_owned(),
+            address: String::new(),
+            models: vec!["model".to_owned()],
+            running_requests: 0,
+            waiting_requests: 0,
+            kv_cache_usage_percent: 0.0,
+            healthy: true,
+        };
+        assert!(
+            validate_endpoint_config(&cfg).is_err(),
+            "empty address should be rejected"
+        );
+    }
+
+    #[test]
+    fn endpoint_rejects_empty_models() {
+        let cfg = EndpointConfig {
+            name: "ep".to_owned(),
+            address: "127.0.0.1:8000".to_owned(),
+            models: vec![],
+            running_requests: 0,
+            waiting_requests: 0,
+            kv_cache_usage_percent: 0.0,
+            healthy: true,
+        };
+        assert!(
+            validate_endpoint_config(&cfg).is_err(),
+            "empty models should be rejected"
+        );
+    }
+
+    #[test]
+    fn endpoint_rejects_non_finite_kv_cache() {
+        let cfg = EndpointConfig {
+            name: "ep".to_owned(),
+            address: "127.0.0.1:8000".to_owned(),
+            models: vec!["model".to_owned()],
+            running_requests: 0,
+            waiting_requests: 0,
+            kv_cache_usage_percent: f64::INFINITY,
+            healthy: true,
+        };
+        assert!(
+            validate_endpoint_config(&cfg).is_err(),
+            "non-finite kv_cache should be rejected"
+        );
+    }
+
+    #[test]
+    fn endpoint_rejects_negative_kv_cache() {
+        let cfg = EndpointConfig {
+            name: "ep".to_owned(),
+            address: "127.0.0.1:8000".to_owned(),
+            models: vec!["model".to_owned()],
+            running_requests: 0,
+            waiting_requests: 0,
+            kv_cache_usage_percent: -1.0,
+            healthy: true,
+        };
+        assert!(
+            validate_endpoint_config(&cfg).is_err(),
+            "negative kv_cache should be rejected"
+        );
+    }
+
+    #[test]
+    fn endpoint_rejects_kv_cache_over_100() {
+        let cfg = EndpointConfig {
+            name: "ep".to_owned(),
+            address: "127.0.0.1:8000".to_owned(),
+            models: vec!["model".to_owned()],
+            running_requests: 0,
+            waiting_requests: 0,
+            kv_cache_usage_percent: 100.1,
+            healthy: true,
+        };
+        assert!(
+            validate_endpoint_config(&cfg).is_err(),
+            "kv_cache > 100 should be rejected"
+        );
+    }
+
+    #[test]
+    fn defaults_applied_correctly() {
+        let yaml: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+endpoints:
+  - name: ep
+    address: "127.0.0.1:8000"
+    models: ["m"]
+"#,
+        )
+        .unwrap();
+        let cfg: LlmdEndpointPickerConfig = serde_yaml::from_value(yaml).unwrap();
+
+        assert_eq!(cfg.pool_name, DEFAULT_POOL_NAME, "default pool_name");
+        assert_eq!(cfg.queue_weight, DEFAULT_QUEUE_WEIGHT, "default queue_weight");
+        assert_eq!(cfg.kv_cache_weight, DEFAULT_KV_CACHE_WEIGHT, "default kv_cache_weight");
+        assert_eq!(
+            cfg.max_body_bytes, DEFAULT_JSON_BODY_MAX_BYTES,
+            "default max_body_bytes"
+        );
+    }
+
+    #[test]
+    fn endpoint_defaults_applied() {
+        let yaml: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+name: ep
+address: "127.0.0.1:8000"
+models: ["m"]
+"#,
+        )
+        .unwrap();
+        let cfg: EndpointConfig = serde_yaml::from_value(yaml).unwrap();
+
+        assert_eq!(cfg.running_requests, 0, "default running_requests");
+        assert_eq!(cfg.waiting_requests, 0, "default waiting_requests");
+        assert_eq!(cfg.kv_cache_usage_percent, 0.0, "default kv_cache");
+        assert!(cfg.healthy, "default healthy");
+    }
+}

--- a/filter/src/builtins/http/ai/inference/llmd_endpoint_picker/mod.rs
+++ b/filter/src/builtins/http/ai/inference/llmd_endpoint_picker/mod.rs
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! llm-d native endpoint picker filter.
+
+mod config;
+mod state;
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use config::LlmdEndpointPickerConfig;
+use praxis_core::connectivity::{ConnectionOptions, Upstream};
+use state::{EndpointSnapshot, EndpointState};
+use tracing::debug;
+
+use crate::{
+    FilterAction, FilterError, Rejection,
+    body::{BodyAccess, BodyMode},
+    factory::parse_filter_config,
+    filter::{HttpFilter, HttpFilterContext},
+};
+
+// -----------------------------------------------------------------------------
+// LlmdEndpointPickerFilter
+// -----------------------------------------------------------------------------
+
+/// Selects an upstream endpoint for OpenAI-compatible inference requests
+/// based on model affinity, health, queue depth, and KV-cache pressure.
+pub struct LlmdEndpointPickerFilter {
+    /// Plain HTTP connection options for selected upstreams.
+    connection: Arc<ConnectionOptions>,
+
+    /// Weight applied to inverse KV-cache pressure scoring.
+    kv_cache_weight: f64,
+
+    /// Request body size limit for `StreamBuffer`.
+    max_body_bytes: usize,
+
+    /// Logical pool name used for metadata and cluster accounting.
+    pool_name: Arc<str>,
+
+    /// Weight applied to inverse queue-depth scoring.
+    queue_weight: f64,
+
+    /// Static endpoint snapshot.
+    snapshot: Arc<EndpointSnapshot>,
+}
+
+impl LlmdEndpointPickerFilter {
+    /// Build from parsed YAML config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError`] when endpoint config is invalid.
+    pub fn from_config(yaml: &serde_yaml::Value) -> Result<Box<dyn HttpFilter>, FilterError> {
+        let cfg: LlmdEndpointPickerConfig = parse_filter_config("llmd_endpoint_picker", yaml)?;
+        config::validate_config(&cfg)?;
+        build_filter(cfg)
+    }
+
+    /// Select the highest-scored healthy endpoint for the given model.
+    fn select_endpoint<'a>(&self, snapshot: &'a EndpointSnapshot, model: &str) -> Option<(&'a EndpointState, f64)> {
+        build_candidates(snapshot, model)
+            .into_iter()
+            .map(|ep| (ep, self.score(ep)))
+            .max_by(|(_, a), (_, b)| a.total_cmp(b))
+    }
+
+    /// Score one endpoint using queue depth and KV-cache pressure.
+    fn score(&self, endpoint: &EndpointState) -> f64 {
+        let queue_depth = endpoint.running_requests.saturating_add(endpoint.waiting_requests);
+        let bounded = u32::try_from(queue_depth).unwrap_or(u32::MAX);
+        let queue_score = 1.0 / (1.0 + f64::from(bounded));
+        // defensive clamp; config validation rejects out-of-range values
+        let kv_pressure = endpoint.kv_cache_usage_percent.clamp(0.0, 100.0);
+        let kv_score = 1.0 - (kv_pressure / 100.0);
+        (self.queue_weight * queue_score) + (self.kv_cache_weight * kv_score)
+    }
+
+    /// Select an endpoint from a buffered request body and apply it.
+    fn pick_from_body(&self, ctx: &mut HttpFilterContext<'_>, body: &Option<Bytes>) -> FilterAction {
+        let raw = match body.as_ref() {
+            Some(b) => b.as_ref(),
+            None => return reject(400, "llmd_endpoint_picker: missing request body"),
+        };
+        let model = match extract_model(raw) {
+            Ok(m) => m,
+            Err(action) => return action,
+        };
+
+        let snapshot = &self.snapshot;
+        let Some((endpoint, score)) = self.select_endpoint(snapshot, &model) else {
+            debug!(model = %model, "llm-d endpoint picker found no eligible endpoint");
+            return reject(503, "llmd_endpoint_picker: no eligible endpoint");
+        };
+
+        self.apply_selection(ctx, &model, endpoint, score);
+        FilterAction::Release
+    }
+
+    /// Store the selected endpoint in the request context.
+    fn apply_selection(&self, ctx: &mut HttpFilterContext<'_>, model: &str, endpoint: &EndpointState, score: f64) {
+        debug!(
+            model = %model,
+            pool = %self.pool_name,
+            endpoint = %endpoint.name,
+            upstream = %endpoint.address,
+            score,
+            "llm-d endpoint selected"
+        );
+
+        ctx.cluster = Some(Arc::clone(&self.pool_name));
+        ctx.set_metadata("llmd.model", model.to_owned());
+        ctx.set_metadata("llmd.endpoint", endpoint.name.as_ref().to_owned());
+        ctx.upstream = Some(Upstream {
+            address: Arc::clone(&endpoint.address),
+            connection: Arc::clone(&self.connection),
+            tls: None,
+        });
+    }
+}
+
+#[async_trait]
+impl HttpFilter for LlmdEndpointPickerFilter {
+    fn name(&self) -> &'static str {
+        "llmd_endpoint_picker"
+    }
+
+    fn request_body_access(&self) -> BodyAccess {
+        BodyAccess::ReadOnly
+    }
+
+    fn request_body_mode(&self) -> BodyMode {
+        BodyMode::StreamBuffer {
+            max_bytes: Some(self.max_body_bytes),
+        }
+    }
+
+    async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        Ok(FilterAction::Continue)
+    }
+
+    async fn on_request_body(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        body: &mut Option<Bytes>,
+        end_of_stream: bool,
+    ) -> Result<FilterAction, FilterError> {
+        if !end_of_stream {
+            return Ok(FilterAction::Continue);
+        }
+
+        Ok(self.pick_from_body(ctx, body))
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+/// Build a filter instance from validated config.
+fn build_filter(cfg: LlmdEndpointPickerConfig) -> Result<Box<dyn HttpFilter>, FilterError> {
+    let static_endpoints: Vec<EndpointState> = cfg
+        .endpoints
+        .into_iter()
+        .map(EndpointState::try_from)
+        .collect::<Result<_, _>>()?;
+
+    let snapshot = Arc::new(EndpointSnapshot {
+        endpoints: static_endpoints,
+    });
+
+    Ok(Box::new(LlmdEndpointPickerFilter {
+        connection: Arc::new(ConnectionOptions::default()),
+        kv_cache_weight: cfg.kv_cache_weight,
+        max_body_bytes: cfg.max_body_bytes,
+        pool_name: Arc::from(cfg.pool_name),
+        queue_weight: cfg.queue_weight,
+        snapshot,
+    }))
+}
+
+/// Return healthy endpoints that serve `model`.
+fn build_candidates<'a>(snapshot: &'a EndpointSnapshot, model: &str) -> Vec<&'a EndpointState> {
+    snapshot
+        .endpoints
+        .iter()
+        .filter(|ep| ep.healthy && ep.models.iter().any(|m| m.as_ref() == model))
+        .collect()
+}
+
+/// Extract the `model` field from a JSON request body.
+///
+/// Returns a 400 rejection for invalid JSON or a missing model field.
+fn extract_model(body: &[u8]) -> Result<String, FilterAction> {
+    let value = serde_json::from_slice::<serde_json::Value>(body)
+        .map_err(|_err| reject(400, "llmd_endpoint_picker: invalid JSON request body"))?;
+
+    value
+        .get("model")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|m| !m.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| reject(400, "llmd_endpoint_picker: missing model field"))
+}
+
+/// Build a plain-text rejection response.
+fn reject(status: u16, message: &'static str) -> FilterAction {
+    FilterAction::Reject(
+        Rejection::status(status)
+            .with_header("content-type", "text/plain; charset=utf-8")
+            .with_body(Bytes::from_static(message.as_bytes())),
+    )
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_config_rejects_empty_endpoints() {
+        let yaml: serde_yaml::Value = serde_yaml::from_str("endpoints: []").unwrap();
+        let Err(err) = LlmdEndpointPickerFilter::from_config(&yaml) else {
+            panic!("empty endpoints should fail");
+        };
+
+        assert!(
+            err.to_string().contains("endpoints must not be empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn body_access_uses_stream_buffer() {
+        let filter = make_filter();
+
+        assert_eq!(filter.request_body_access(), BodyAccess::ReadOnly);
+        assert_eq!(
+            filter.request_body_mode(),
+            BodyMode::StreamBuffer {
+                max_bytes: Some(crate::body::DEFAULT_JSON_BODY_MAX_BYTES)
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn selects_lowest_pressure_matching_endpoint() {
+        let filter = make_filter();
+        let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        let mut body = Some(Bytes::from_static(br#"{"model":"fake-model","messages":[]}"#));
+
+        let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+        assert!(matches!(action, FilterAction::Release));
+        assert_eq!(ctx.upstream_addr(), Some("127.0.0.1:18082"));
+        assert_eq!(ctx.get_metadata("llmd.model"), Some("fake-model"));
+        assert_eq!(ctx.get_metadata("llmd.endpoint"), Some("less-loaded"));
+    }
+
+    #[tokio::test]
+    async fn filters_by_requested_model() {
+        let filter = make_filter();
+        let req = crate::test_utils::make_request(http::Method::POST, "/v1/completions");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        let mut body = Some(Bytes::from_static(br#"{"model":"other-model","prompt":"hi"}"#));
+
+        let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+        assert!(matches!(action, FilterAction::Release));
+        assert_eq!(ctx.upstream_addr(), Some("127.0.0.1:18083"));
+        assert_eq!(ctx.get_metadata("llmd.endpoint"), Some("other-model"));
+    }
+
+    #[tokio::test]
+    async fn rejects_when_model_is_missing() {
+        let filter = make_filter();
+        let req = crate::test_utils::make_request(http::Method::POST, "/v1/completions");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        let mut body = Some(Bytes::from_static(br#"{"prompt":"hi"}"#));
+
+        let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+        assert!(matches!(action, FilterAction::Reject(r) if r.status == 400));
+        assert!(ctx.upstream.is_none(), "missing model must not select an upstream");
+    }
+
+    #[tokio::test]
+    async fn rejects_when_no_endpoint_serves_model() {
+        let filter = make_filter();
+        let req = crate::test_utils::make_request(http::Method::POST, "/v1/completions");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        let mut body = Some(Bytes::from_static(br#"{"model":"missing","prompt":"hi"}"#));
+
+        let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+        assert!(matches!(action, FilterAction::Reject(r) if r.status == 503));
+        assert!(
+            ctx.upstream.is_none(),
+            "no eligible endpoint must not select an upstream"
+        );
+    }
+
+    #[tokio::test]
+    async fn unhealthy_endpoint_is_skipped() {
+        let mut unhealthy = make_endpoint("unhealthy-best", "127.0.0.1:9001");
+        unhealthy.healthy = false;
+
+        let mut healthy = make_endpoint("healthy-worse", "127.0.0.1:9002");
+        healthy.kv_cache_usage_percent = 80.0;
+        healthy.running_requests = 10;
+        healthy.waiting_requests = 5;
+
+        let filter = make_filter_with_endpoints(vec![unhealthy, healthy]);
+        let req = crate::test_utils::make_request(http::Method::POST, "/v1/chat/completions");
+        let mut ctx = crate::test_utils::make_filter_context(&req);
+        let mut body = Some(Bytes::from_static(br#"{"model":"test-model","messages":[]}"#));
+
+        let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+
+        assert!(matches!(action, FilterAction::Release));
+        assert_eq!(
+            ctx.upstream_addr(),
+            Some("127.0.0.1:9002"),
+            "unhealthy endpoint should be skipped even when it has a better score"
+        );
+        assert_eq!(
+            ctx.get_metadata("llmd.endpoint"),
+            Some("healthy-worse"),
+            "healthy endpoint should be selected"
+        );
+    }
+
+    // Test Utilities
+
+    fn make_endpoint(name: &str, address: &str) -> EndpointState {
+        EndpointState {
+            name: Arc::from(name),
+            address: Arc::from(address),
+            healthy: true,
+            kv_cache_usage_percent: 0.0,
+            models: vec![Arc::from("test-model")],
+            running_requests: 0,
+            waiting_requests: 0,
+        }
+    }
+
+    fn make_filter_with_endpoints(endpoints: Vec<EndpointState>) -> LlmdEndpointPickerFilter {
+        LlmdEndpointPickerFilter {
+            connection: Arc::new(ConnectionOptions::default()),
+            kv_cache_weight: 2.0,
+            max_body_bytes: 1_048_576, // 1 MiB
+            pool_name: Arc::from("test"),
+            queue_weight: 2.0,
+            snapshot: Arc::new(EndpointSnapshot { endpoints }),
+        }
+    }
+
+    fn make_filter() -> Box<dyn HttpFilter> {
+        let yaml: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+endpoints:
+  - name: loaded
+    address: "127.0.0.1:18081"
+    models: ["fake-model"]
+    running_requests: 8
+    waiting_requests: 4
+    kv_cache_usage_percent: 92.0
+  - name: less-loaded
+    address: "127.0.0.1:18082"
+    models: ["fake-model"]
+    running_requests: 1
+    waiting_requests: 0
+    kv_cache_usage_percent: 10.0
+  - name: other-model
+    address: "127.0.0.1:18083"
+    models: ["other-model"]
+    running_requests: 0
+    waiting_requests: 0
+    kv_cache_usage_percent: 0.0
+"#,
+        )
+        .unwrap();
+        LlmdEndpointPickerFilter::from_config(&yaml).unwrap()
+    }
+}

--- a/filter/src/builtins/http/ai/inference/llmd_endpoint_picker/state.rs
+++ b/filter/src/builtins/http/ai/inference/llmd_endpoint_picker/state.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Endpoint state types for the llm-d endpoint picker.
+
+use std::sync::Arc;
+
+use super::config::EndpointConfig;
+use crate::FilterError;
+
+// -----------------------------------------------------------------------------
+// Endpoint State
+// -----------------------------------------------------------------------------
+
+/// Runtime state for one inference endpoint.
+#[derive(Debug, Clone)]
+pub(super) struct EndpointState {
+    /// Stable endpoint name.
+    pub name: Arc<str>,
+
+    /// Upstream address in `host:port` form.
+    pub address: Arc<str>,
+
+    /// Whether this endpoint should receive new traffic.
+    pub healthy: bool,
+
+    /// Current KV-cache pressure percentage (0-100).
+    pub kv_cache_usage_percent: f64,
+
+    /// Models served by the endpoint.
+    pub models: Vec<Arc<str>>,
+
+    /// Current running request count.
+    pub running_requests: u64,
+
+    /// Current waiting request count.
+    pub waiting_requests: u64,
+}
+
+impl TryFrom<EndpointConfig> for EndpointState {
+    type Error = FilterError;
+
+    fn try_from(cfg: EndpointConfig) -> Result<Self, Self::Error> {
+        super::config::validate_endpoint_config(&cfg)?;
+
+        Ok(Self {
+            name: Arc::from(cfg.name),
+            address: Arc::from(cfg.address),
+            healthy: cfg.healthy,
+            kv_cache_usage_percent: cfg.kv_cache_usage_percent,
+            models: cfg.models.into_iter().map(Arc::from).collect(),
+            running_requests: cfg.running_requests,
+            waiting_requests: cfg.waiting_requests,
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Endpoint Snapshot
+// -----------------------------------------------------------------------------
+
+/// Immutable endpoint state snapshot read by request filters.
+#[derive(Debug)]
+pub(super) struct EndpointSnapshot {
+    /// Endpoint states visible to request filters.
+    pub endpoints: Vec<EndpointState>,
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_from_config_creates_valid_state() {
+        let cfg = EndpointConfig {
+            name: "ep".to_owned(),
+            address: "127.0.0.1:8000".to_owned(),
+            models: vec!["model-a".to_owned()],
+            running_requests: 3,
+            waiting_requests: 1,
+            kv_cache_usage_percent: 42.5,
+            healthy: true,
+        };
+
+        let state = EndpointState::try_from(cfg).unwrap();
+
+        assert_eq!(state.name.as_ref(), "ep", "name");
+        assert_eq!(state.address.as_ref(), "127.0.0.1:8000", "address");
+        assert_eq!(state.models.len(), 1, "model count");
+        assert_eq!(state.running_requests, 3, "running requests");
+        assert_eq!(state.kv_cache_usage_percent, 42.5, "kv cache");
+    }
+
+    #[test]
+    fn try_from_config_rejects_empty_name() {
+        let cfg = EndpointConfig {
+            name: String::new(),
+            address: "127.0.0.1:8000".to_owned(),
+            models: vec!["model".to_owned()],
+            running_requests: 0,
+            waiting_requests: 0,
+            kv_cache_usage_percent: 0.0,
+            healthy: true,
+        };
+
+        assert!(EndpointState::try_from(cfg).is_err(), "empty name should be rejected");
+    }
+}

--- a/filter/src/builtins/http/ai/inference/mod.rs
+++ b/filter/src/builtins/http/ai/inference/mod.rs
@@ -3,6 +3,8 @@
 
 //! AI inference proxy filters.
 
+mod llmd_endpoint_picker;
 mod model_to_header;
 
+pub use llmd_endpoint_picker::LlmdEndpointPickerFilter;
 pub use model_to_header::ModelToHeaderFilter;

--- a/filter/src/builtins/http/ai/mod.rs
+++ b/filter/src/builtins/http/ai/mod.rs
@@ -14,6 +14,8 @@ mod prompt_enrich;
 
 pub use agentic::{A2aFilter, JsonRpcFilter, McpFilter};
 #[cfg(feature = "ai-inference")]
+pub use inference::LlmdEndpointPickerFilter;
+#[cfg(feature = "ai-inference")]
 pub use inference::ModelToHeaderFilter;
 #[cfg(feature = "ai-inference")]
 pub use openai::ResponsesFormatFilter;

--- a/filter/src/builtins/http/mod.rs
+++ b/filter/src/builtins/http/mod.rs
@@ -12,6 +12,8 @@ mod transformation;
 pub(crate) mod value_safety;
 
 #[cfg(feature = "ai-inference")]
+pub use ai::LlmdEndpointPickerFilter;
+#[cfg(feature = "ai-inference")]
 pub use ai::ModelToHeaderFilter;
 #[cfg(feature = "ai-inference")]
 pub use ai::PromptEnrichFilter;

--- a/filter/src/builtins/mod.rs
+++ b/filter/src/builtins/mod.rs
@@ -7,6 +7,8 @@ pub(crate) mod http;
 mod tcp;
 
 #[cfg(feature = "ai-inference")]
+pub use http::LlmdEndpointPickerFilter;
+#[cfg(feature = "ai-inference")]
 pub use http::ModelToHeaderFilter;
 #[cfg(feature = "ai-inference")]
 pub use http::PromptEnrichFilter;

--- a/filter/src/registry.rs
+++ b/filter/src/registry.rs
@@ -146,6 +146,12 @@ fn register_http_builtins(factories: &mut HashMap<String, FilterFactory>) {
     #[cfg(feature = "ai-inference")]
     register_http(
         factories,
+        "llmd_endpoint_picker",
+        crate::builtins::LlmdEndpointPickerFilter::from_config,
+    );
+    #[cfg(feature = "ai-inference")]
+    register_http(
+        factories,
         "model_to_header",
         crate::builtins::ModelToHeaderFilter::from_config,
     );
@@ -269,6 +275,11 @@ mod tests {
         );
         assert!(names.contains(&"json_rpc"), "json_rpc should be registered");
         assert!(names.contains(&"mcp"), "mcp should be registered");
+        #[cfg(feature = "ai-inference")]
+        assert!(
+            names.contains(&"llmd_endpoint_picker"),
+            "llmd_endpoint_picker should be registered"
+        );
         #[cfg(feature = "ai-inference")]
         assert!(
             names.contains(&"model_to_header"),

--- a/tests/integration/tests/suite/examples/llmd_endpoint_picker.rs
+++ b/tests/integration/tests/suite/examples/llmd_endpoint_picker.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Tests for the llm-d endpoint picker example config.
+
+use std::collections::HashMap;
+
+use praxis_test_utils::{
+    free_port, http_send, json_post, parse_body, parse_status, start_backend_with_shutdown, start_proxy,
+};
+
+use super::load_example_config;
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn llmd_endpoint_picker_example_routes_to_least_loaded() {
+    let vllm_a_guard = start_backend_with_shutdown("vllm-a-response");
+    let vllm_b_guard = start_backend_with_shutdown("vllm-b-response");
+    let vllm_c_guard = start_backend_with_shutdown("vllm-c-response");
+    let proxy_port = free_port();
+
+    let port_map = HashMap::from([
+        ("10.0.1.1:8000", vllm_a_guard.port()),
+        ("10.0.1.2:8000", vllm_b_guard.port()),
+        ("10.0.2.1:8000", vllm_c_guard.port()),
+    ]);
+    let config = load_example_config("ai/llmd-endpoint-picker.yaml", proxy_port, port_map);
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post(
+            "/v1/chat/completions",
+            r#"{"model":"meta-llama/Llama-3.2-3B-Instruct","messages":[{"role":"user","content":"hi"}]}"#,
+        ),
+    );
+
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        "vllm-a-response",
+        "should route to vllm-a (lowest load for Llama-3.2-3B-Instruct)"
+    );
+}
+
+#[test]
+fn llmd_endpoint_picker_example_routes_by_model() {
+    let vllm_a_guard = start_backend_with_shutdown("vllm-a-response");
+    let vllm_b_guard = start_backend_with_shutdown("vllm-b-response");
+    let vllm_c_guard = start_backend_with_shutdown("vllm-c-response");
+    let proxy_port = free_port();
+
+    let port_map = HashMap::from([
+        ("10.0.1.1:8000", vllm_a_guard.port()),
+        ("10.0.1.2:8000", vllm_b_guard.port()),
+        ("10.0.2.1:8000", vllm_c_guard.port()),
+    ]);
+    let config = load_example_config("ai/llmd-endpoint-picker.yaml", proxy_port, port_map);
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post(
+            "/v1/chat/completions",
+            r#"{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"hi"}]}"#,
+        ),
+    );
+
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        "vllm-c-response",
+        "should route to vllm-c (lowest load for Qwen3-0.6B)"
+    );
+}

--- a/tests/integration/tests/suite/examples/mod.rs
+++ b/tests/integration/tests/suite/examples/mod.rs
@@ -23,6 +23,8 @@ mod header_manipulation;
 mod health_checks;
 mod hostname_upstream;
 mod least_connections;
+#[cfg(feature = "ai-inference")]
+mod llmd_endpoint_picker;
 mod logging;
 mod max_body_guard;
 mod max_connections;

--- a/tests/integration/tests/suite/llmd_endpoint_picker.rs
+++ b/tests/integration/tests/suite/llmd_endpoint_picker.rs
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Integration tests for the native llm-d endpoint picker filter.
+
+use praxis_core::config::Config;
+use praxis_test_utils::{
+    Backend, free_port, http_send, json_post, parse_body, parse_header, parse_status, start_backend_with_shutdown,
+    start_proxy,
+};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn llmd_endpoint_picker_selects_lowest_pressure_endpoint() {
+    let loaded_guard = start_backend_with_shutdown("loaded-backend");
+    let better_guard = start_backend_with_shutdown("better-backend");
+    let proxy_port = free_port();
+    let yaml = picker_yaml(
+        proxy_port,
+        &[
+            endpoint_yaml(
+                "loaded",
+                loaded_guard.port(),
+                "fake-model",
+                EndpointLoad {
+                    running: 8,
+                    waiting: 4,
+                    kv: 90.0,
+                },
+            ),
+            endpoint_yaml(
+                "better",
+                better_guard.port(),
+                "fake-model",
+                EndpointLoad {
+                    running: 0,
+                    waiting: 1,
+                    kv: 10.0,
+                },
+            ),
+        ],
+    );
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post(
+            "/v1/chat/completions",
+            r#"{"model":"fake-model","messages":[{"role":"user","content":"hi"}]}"#,
+        ),
+    );
+
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        "better-backend",
+        "endpoint picker should route to the endpoint with better queue/KV score"
+    );
+}
+
+#[test]
+fn llmd_endpoint_picker_filters_by_model() {
+    let model_a_guard = start_backend_with_shutdown("model-a-backend");
+    let model_b_guard = start_backend_with_shutdown("model-b-backend");
+    let proxy_port = free_port();
+    let yaml = picker_yaml(
+        proxy_port,
+        &[
+            endpoint_yaml("model-a", model_a_guard.port(), "model-a", IDLE),
+            endpoint_yaml("model-b", model_b_guard.port(), "model-b", IDLE),
+        ],
+    );
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/v1/completions", r#"{"model":"model-b","prompt":"hi","max_tokens":8}"#),
+    );
+
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        "model-b-backend",
+        "endpoint picker should only select endpoints serving the requested model"
+    );
+}
+
+#[test]
+fn llmd_endpoint_picker_rejects_missing_model() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+    let yaml = picker_yaml(
+        proxy_port,
+        &[endpoint_yaml("ep", backend_guard.port(), "fake-model", IDLE)],
+    );
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(proxy.addr(), &json_post("/v1/chat/completions", r#"{"prompt":"hi"}"#));
+
+    assert_eq!(
+        parse_status(&raw),
+        400,
+        "request without model field should be rejected with 400"
+    );
+}
+
+#[test]
+fn llmd_endpoint_picker_rejects_no_eligible_endpoint() {
+    let backend_guard = start_backend_with_shutdown("backend");
+    let proxy_port = free_port();
+    let yaml = picker_yaml(
+        proxy_port,
+        &[endpoint_yaml("ep", backend_guard.port(), "served-model", IDLE)],
+    );
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post("/v1/chat/completions", r#"{"model":"unknown-model","messages":[]}"#),
+    );
+
+    assert_eq!(
+        parse_status(&raw),
+        503,
+        "request for unserved model should be rejected with 503"
+    );
+}
+
+#[test]
+fn llmd_endpoint_picker_passes_sse_response_through() {
+    let sse_body = "data: {\"token\":\"a\"}\n\ndata: {\"token\":\"b\"}\n\n";
+    let sse_guard = Backend::fixed(sse_body)
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-cache")
+        .start_with_shutdown();
+    let proxy_port = free_port();
+    let yaml = picker_yaml(
+        proxy_port,
+        &[endpoint_yaml("sse", sse_guard.port(), "fake-model", IDLE)],
+    );
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &json_post(
+            "/v1/chat/completions",
+            r#"{"model":"fake-model","messages":[],"stream":true}"#,
+        ),
+    );
+
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_header(&raw, "content-type").as_deref(),
+        Some("text/event-stream"),
+        "SSE content-type should pass through"
+    );
+    assert_eq!(parse_body(&raw), sse_body, "SSE response body should be unchanged");
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+/// Build proxy YAML with the llm-d endpoint picker filter.
+fn picker_yaml(proxy_port: u16, endpoints: &[String]) -> String {
+    let endpoints_yaml = endpoints.join("\n");
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: llmd_endpoint_picker
+        endpoints:
+{endpoints_yaml}
+"#
+    )
+}
+
+/// Static endpoint load for test YAML generation.
+#[derive(Clone, Copy)]
+struct EndpointLoad {
+    running: u64,
+    waiting: u64,
+    kv: f64,
+}
+
+/// Idle endpoint with no queue pressure or cache usage.
+const IDLE: EndpointLoad = EndpointLoad {
+    running: 0,
+    waiting: 0,
+    kv: 0.0,
+};
+
+/// Build one endpoint entry for the picker YAML.
+fn endpoint_yaml(name: &str, port: u16, model: &str, EndpointLoad { running, waiting, kv }: EndpointLoad) -> String {
+    format!(
+        r#"          - name: {name}
+            address: "127.0.0.1:{port}"
+            models: ["{model}"]
+            running_requests: {running}
+            waiting_requests: {waiting}
+            kv_cache_usage_percent: {kv}"#
+    )
+}

--- a/tests/integration/tests/suite/main.rs
+++ b/tests/integration/tests/suite/main.rs
@@ -54,6 +54,8 @@ mod hot_reload;
 mod ip_acl;
 mod json_body_field;
 mod json_rpc;
+#[cfg(feature = "ai-inference")]
+mod llmd_endpoint_picker;
 mod mcp;
 mod mcp_broker;
 #[cfg(feature = "ai-inference")]


### PR DESCRIPTION
## Summary

  Adds the first PR in the native llm-d endpoint picker stack: a static `llmd_endpoint_picker` HTTP filter for OpenAI-compatible inference requests.

  This is the initial implementation slice for the in-process EPP track in:

  - Parent epic: https://github.com/praxis-proxy/ai/issues/168
  - Native endpoint picker track: https://github.com/praxis-proxy/ai/issues/169

  The goal of this PR is deliberately narrow: prove that Praxis can run the core filter/scorer/picker request path inside the proxy process for statically
  configured endpoints.

  ## What This Adds

  - Registers a new `llmd_endpoint_picker` HTTP filter behind the `ai-inference` feature.
  - Buffers request bodies with `BodyAccess::ReadOnly` + `StreamBuffer`.
  - Extracts the top-level OpenAI-compatible JSON `model` field.
  - Filters static endpoints by:
    - model availability;
    - endpoint health.
  - Scores eligible endpoints using configured queue depth and KV-cache pressure.
  - Selects the highest-scored endpoint and writes it directly to `ctx.upstream`.
  - Records request metadata:
    - `llmd.model`
    - `llmd.endpoint`
  - Adds static config validation for endpoint names, addresses, model lists, scoring weights, and KV-cache percentage bounds.
  - Adds product docs and an example config for static model-aware/load-aware routing.

  ## Routing Behavior

  The filter scores each healthy endpoint that serves the requested model:

  ```text
  queue_depth = running_requests + waiting_requests
  score = queue_weight / (1 + queue_depth) + kv_cache_weight * (1 - kv_cache_usage_percent / 100)
  ```

  The highest-scored endpoint is selected and assigned directly as the request upstream.

  This PR intentionally uses static endpoint state only. Dynamic metrics-backed state is left for the next stacked
  PR.

  Only healthy endpoints serving the requested model are considered. The selected endpoint is assigned directly as the upstream, so this filter does not
  require a separate load balancer filter for the selected backend.

  ## End-to-end flow

1. Client sends an OpenAI-compatible request to Praxis, for example /v1/chat/completions.
2. Praxis buffers the request body with the existing body filter path.
3. llmd_endpoint_picker parses the JSON body and extracts the top-level model.
4. The filter checks its static endpoint list from config.
5. It keeps only endpoints that are healthy and advertise the requested model.
6. It scores candidates using configured static queue depth and KV-cache pressure:
     `queue_weight / (1 + queue_depth) + kv_cache_weight * (1 - kv/100)`
7. The highest-scoring endpoint wins.
8. Praxis sets ctx.upstream directly to that endpoint address.
9. Pingora forwards the original request to the selected backend.
10. If the request has no model, Praxis returns 400; if no endpoint serves the model, it returns 503.

More details on a full e2e validation and PR stack [here](https://github.com/nerdalert/praxis-research-spikes/tree/main/demo/llm-d-praxis).

  ## Background

  Issue praxis-proxy/ai#168 describes the broader llm-d integration spike: evaluating Praxis as an llm-d proxy layer and addressing pain points in the current Envoy +  ext_proc + Go EPP request path.

  Issue praxis-proxy/ai#169 defines Track A: implementing a native llmd_endpoint_picker HttpFilter that embeds a simplified version of the llm-d EPP scheduling pipeline directly in Praxis.

  This PR implements the first reviewable chunk of that track:

```text
  request body -> model extraction -> endpoint filter -> endpoint scorer -> picker -> ctx.upstream
```

  The llm-d EPP path normally performs inference-aware endpoint selection outside the proxy request path. This PR
  starts the native Praxis track by moving the useful filter/scorer/picker path into the proxy process for a static
  endpoint set.

  This proves the basic shape of:

  OpenAI request body
    -> model extraction
    -> endpoint eligibility filtering
    -> load-aware scoring
    -> endpoint selection
    -> ctx.upstream

  ## Tests

  Adds unit coverage for:

  - config validation;
  - model extraction behavior;
  - model-aware endpoint filtering;
  - load-aware endpoint scoring;
  - missing model rejection;
  - no eligible endpoint rejection;
  - unhealthy endpoint skipping;
  - endpoint state construction.

  Adds integration coverage for:

  - routing to the lower-pressure backend;
  - routing by requested model;
  - rejecting a request with no model;
  - rejecting a request for an unserved model;
  - preserving SSE response behavior through the selected backend;
  - validating the example config routes correctly.


  ## References

Stacked PRs so this first PR stays reviewable and lands the static request-path foundation cleanly.

  - Epic: https://github.com/praxis-proxy/ai/issues/168
  - Native endpoint picker track: https://github.com/praxis-proxy/ai/issues/169
  - llm-d router / Go EPP reference: https://github.com/llm-d/llm-d-router
