### PR TITLE
feat: add local A2A task routing

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -122,6 +122,7 @@ page.
 | File | Description |
 | ------ | ------------- |
 | [a2a-classifier-routing.yaml](configs/ai/a2a-classifier-routing.yaml) | Route A2A requests by method, family, task ID, and streaming detection |
+| [a2a-task-routing.yaml](configs/ai/a2a-task-routing.yaml) | Local A2A task ownership routing from JSON responses |
 | [ai-inference-body-based-routing.yaml](configs/ai/ai-inference-body-based-routing.yaml) | Route LLM requests by model field in JSON body |
 | [credential-injection.yaml](configs/ai/credential-injection.yaml) | Inject per-cluster API credentials and strip client tokens |
 | [json-rpc-routing.yaml](configs/ai/json-rpc-routing.yaml) | Route JSON-RPC 2.0 requests by method for MCP and A2A protocols |

--- a/examples/configs/ai/a2a-task-routing.yaml
+++ b/examples/configs/ai/a2a-task-routing.yaml
@@ -1,0 +1,79 @@
+# A2A Task Routing
+#
+# Captures task ownership from non-streaming JSON SendMessage responses
+# and routes follow-up task operations back to the backend cluster that
+# created the task.
+#
+# Local task routing is useful for development, single-process deployments,
+# and proving the routing path. Multi-replica task routing requires the
+# follow-up Redis/ValKey state store.
+#
+# Flow:
+# 1. SendMessage is routed to agent-a by static router rules.
+# 2. The a2a filter captures task IDs from the JSON response body
+#    and records task_id -> cluster_name in a local in-process store.
+# 3. Follow-up GetTask, CancelTask, SubscribeToTask, or push-notification
+#    config calls with a known task ID inject x-praxis-a2a-route-cluster,
+#    which the router matches to select the owning cluster.
+# 4. Unknown task IDs follow the static fallback route.
+
+listeners:
+  - name: a2a
+    address: "127.0.0.1:8080"
+    filter_chains: [a2a-task-routing]
+
+filter_chains:
+  - name: a2a-task-routing
+    filters:
+      - filter: a2a
+        max_body_bytes: 65536
+        on_invalid: continue
+        headers:
+          method: x-praxis-a2a-method
+          family: x-praxis-a2a-family
+          task_id: x-praxis-a2a-task-id
+          streaming: x-praxis-a2a-streaming
+        task_routing:
+          enabled: true
+          store: local
+          route_cluster_header: x-praxis-a2a-route-cluster
+          ttl_seconds: 3600
+          terminal_ttl_seconds: 300
+          max_response_body_bytes: 65536
+
+      - filter: router
+        routes:
+          # Task route hit: route to the cluster that owns the task
+          - path_prefix: "/"
+            headers:
+              x-praxis-a2a-route-cluster: "agent-a"
+            cluster: "agent-a"
+          - path_prefix: "/"
+            headers:
+              x-praxis-a2a-route-cluster: "agent-b"
+            cluster: "agent-b"
+
+          # Initial SendMessage goes to the primary agent
+          - path_prefix: "/"
+            headers:
+              x-praxis-a2a-method: "SendMessage"
+            cluster: "agent-a"
+
+          # Streaming methods to streaming-capable backend
+          - path_prefix: "/"
+            headers:
+              x-praxis-a2a-streaming: "true"
+            cluster: "agent-a"
+
+          # Default fallback for unknown tasks and non-A2A traffic
+          - path_prefix: "/"
+            cluster: "agent-b"
+
+      - filter: load_balancer
+        clusters:
+          - name: "agent-a"
+            endpoints:
+              - "127.0.0.1:9001"
+          - name: "agent-b"
+            endpoints:
+              - "127.0.0.1:9002"

--- a/examples/configs/ai/a2a-task-routing.yaml
+++ b/examples/configs/ai/a2a-task-routing.yaml
@@ -4,9 +4,9 @@
 # and routes follow-up task operations back to the backend cluster that
 # created the task.
 #
-# Local task routing is useful for development, single-process deployments,
-# and proving the routing path. Multi-replica task routing requires the
-# follow-up Redis/ValKey state store.
+# This example uses `local` storage mode. This is useful for development and
+# testing or single-instance deployments of Praxis, but multi-replica task routing
+# requires the an external state store (e.g. Valkey).
 #
 # Flow:
 # 1. SendMessage is routed to agent-a by static router rules.

--- a/filter/src/builtins/http/ai/agentic/a2a/config.rs
+++ b/filter/src/builtins/http/ai/agentic/a2a/config.rs
@@ -16,6 +16,18 @@ use crate::{FilterError, body::limits::MAX_JSON_BODY_BYTES};
 /// Default maximum request body size for `StreamBuffer` mode (64 `KiB`).
 pub(crate) const DEFAULT_MAX_BODY_BYTES: usize = 65_536;
 
+/// Default route cluster header name for task routing.
+const DEFAULT_ROUTE_CLUSTER_HEADER: &str = "x-praxis-a2a-route-cluster";
+
+/// Default TTL for non-terminal task routes (1 hour).
+const DEFAULT_TTL_SECONDS: u64 = 3_600; // 1 hour
+
+/// Default TTL for terminal task routes (5 minutes).
+const DEFAULT_TERMINAL_TTL_SECONDS: u64 = 300; // 5 minutes
+
+/// Default maximum response body bytes for task route capture (64 `KiB`).
+const DEFAULT_MAX_RESPONSE_BODY_BYTES: usize = 65_536;
+
 // -----------------------------------------------------------------------------
 // Behavior Enums
 // -----------------------------------------------------------------------------
@@ -30,6 +42,97 @@ pub(crate) enum InvalidA2aBehavior {
 
     /// Continue processing without A2A metadata.
     Continue,
+}
+
+/// Task route lookup miss behavior.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum OnLookupMiss {
+    /// Continue without a route header; let the router fallback decide.
+    #[default]
+    Continue,
+}
+
+/// Task route store backend.
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TaskRouteStore {
+    /// In-process local store.
+    #[default]
+    Local,
+}
+
+// -----------------------------------------------------------------------------
+// TaskRoutingConfig
+// -----------------------------------------------------------------------------
+
+/// Configuration for A2A task-ownership routing.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TaskRoutingConfig {
+    /// Whether task routing is enabled.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Maximum response body bytes to buffer for task route capture.
+    #[serde(default = "default_max_response_body_bytes")]
+    pub max_response_body_bytes: usize,
+
+    /// Behavior when a task route lookup misses.
+    #[serde(default)]
+    #[allow(dead_code, reason = "validated at parse time, used in follow-up PRs")]
+    pub on_lookup_miss: OnLookupMiss,
+
+    /// Internal header name injected on task route hit.
+    #[serde(default = "default_route_cluster_header")]
+    pub route_cluster_header: String,
+
+    /// Storage backend for task routes.
+    #[serde(default)]
+    #[allow(dead_code, reason = "validated at parse time, only local supported in this PR")]
+    pub store: TaskRouteStore,
+
+    /// TTL in seconds for terminal task routes (0 = remove immediately).
+    #[serde(default = "default_terminal_ttl_seconds")]
+    pub terminal_ttl_seconds: u64,
+
+    /// TTL in seconds for non-terminal task routes.
+    #[serde(default = "default_ttl_seconds")]
+    pub ttl_seconds: u64,
+}
+
+impl Default for TaskRoutingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_response_body_bytes: DEFAULT_MAX_RESPONSE_BODY_BYTES,
+            on_lookup_miss: OnLookupMiss::default(),
+            route_cluster_header: DEFAULT_ROUTE_CLUSTER_HEADER.to_owned(),
+            store: TaskRouteStore::default(),
+            terminal_ttl_seconds: DEFAULT_TERMINAL_TTL_SECONDS,
+            ttl_seconds: DEFAULT_TTL_SECONDS,
+        }
+    }
+}
+
+/// Default route cluster header.
+fn default_route_cluster_header() -> String {
+    DEFAULT_ROUTE_CLUSTER_HEADER.to_owned()
+}
+
+/// Default TTL seconds.
+fn default_ttl_seconds() -> u64 {
+    DEFAULT_TTL_SECONDS
+}
+
+/// Default terminal TTL seconds.
+fn default_terminal_ttl_seconds() -> u64 {
+    DEFAULT_TERMINAL_TTL_SECONDS
+}
+
+/// Default max response body bytes.
+fn default_max_response_body_bytes() -> usize {
+    DEFAULT_MAX_RESPONSE_BODY_BYTES
 }
 
 // -----------------------------------------------------------------------------
@@ -155,6 +258,10 @@ pub(crate) struct A2aConfig {
     /// Invalid input handling behavior.
     #[serde(default)]
     pub on_invalid: InvalidA2aBehavior,
+
+    /// Task-ownership routing configuration.
+    #[serde(default)]
+    pub task_routing: TaskRoutingConfig,
 }
 
 /// Default max body bytes.
@@ -167,6 +274,7 @@ fn default_max_body_bytes() -> usize {
 // -----------------------------------------------------------------------------
 
 /// Validate and build the final configuration.
+#[allow(clippy::too_many_lines, reason = "sequential validation of config fields")]
 pub(crate) fn build_config(cfg: A2aConfig) -> Result<A2aConfig, FilterError> {
     if cfg.max_body_bytes == 0 {
         return Err("a2a: 'max_body_bytes' must be greater than 0".into());
@@ -180,7 +288,6 @@ pub(crate) fn build_config(cfg: A2aConfig) -> Result<A2aConfig, FilterError> {
         .into());
     }
 
-    // Validate header names
     validate_header_name("method", cfg.headers.method.as_deref())?;
     validate_header_name("family", cfg.headers.family.as_deref())?;
     validate_header_name("task_id", cfg.headers.task_id.as_deref())?;
@@ -188,7 +295,10 @@ pub(crate) fn build_config(cfg: A2aConfig) -> Result<A2aConfig, FilterError> {
     validate_header_name("streaming", cfg.headers.streaming.as_deref())?;
     validate_header_name("version", cfg.headers.version.as_deref())?;
 
-    // Validate method aliases
+    if cfg.task_routing.enabled {
+        validate_task_routing(&cfg.task_routing)?;
+    }
+
     for (alias, canonical) in &cfg.method_aliases {
         if alias.is_empty() {
             return Err("a2a: alias key must be non-empty".into());
@@ -196,7 +306,6 @@ pub(crate) fn build_config(cfg: A2aConfig) -> Result<A2aConfig, FilterError> {
         if canonical.is_empty() {
             return Err("a2a: alias value must be non-empty".into());
         }
-        // Validate that canonical method maps to a known A2A method
         if !is_known_a2a_method(canonical) {
             return Err(format!("a2a: alias target '{canonical}' is not a known A2A method").into());
         }
@@ -216,6 +325,40 @@ fn validate_header_name(field: &str, header_name: Option<&str>) -> Result<(), Fi
     if http::HeaderName::from_bytes(header_name.as_bytes()).is_err() {
         return Err(format!("a2a: {field} header name is not a valid HTTP header name").into());
     }
+    Ok(())
+}
+
+/// Validate task routing configuration.
+fn validate_task_routing(tr: &TaskRoutingConfig) -> Result<(), FilterError> {
+    if tr.ttl_seconds == 0 {
+        return Err("a2a: task_routing.ttl_seconds must be greater than 0".into());
+    }
+
+    if tr.max_response_body_bytes == 0 {
+        return Err("a2a: task_routing.max_response_body_bytes must be greater than 0".into());
+    }
+
+    if tr.max_response_body_bytes > MAX_JSON_BODY_BYTES {
+        return Err(format!(
+            "a2a: task_routing.max_response_body_bytes ({}) exceeds maximum ({MAX_JSON_BODY_BYTES})",
+            tr.max_response_body_bytes
+        )
+        .into());
+    }
+
+    validate_header_name("task_routing.route_cluster_header", Some(&tr.route_cluster_header))?;
+
+    // The route header must use the reserved x-praxis-a2a- prefix so that
+    // the protocol layer's reserved-header rejection guard prevents clients
+    // from injecting it directly.
+    if !tr.route_cluster_header.starts_with("x-praxis-a2a-") {
+        return Err(format!(
+            "a2a: task_routing.route_cluster_header '{}' must start with 'x-praxis-a2a-'",
+            tr.route_cluster_header
+        )
+        .into());
+    }
+
     Ok(())
 }
 

--- a/filter/src/builtins/http/ai/agentic/a2a/envelope.rs
+++ b/filter/src/builtins/http/ai/agentic/a2a/envelope.rs
@@ -138,6 +138,21 @@ impl A2aMethod {
         matches!(self, Self::GetTask | Self::CancelTask | Self::SubscribeToTask)
     }
 
+    /// Whether a follow-up request with this method should be routed
+    /// by stored task ownership.
+    pub(crate) fn is_task_routable(&self) -> bool {
+        matches!(
+            self,
+            Self::GetTask
+                | Self::CancelTask
+                | Self::SubscribeToTask
+                | Self::CreateTaskPushNotificationConfig
+                | Self::GetTaskPushNotificationConfig
+                | Self::ListTaskPushNotificationConfigs
+                | Self::DeleteTaskPushNotificationConfig
+        )
+    }
+
     /// Whether this method should extract task ID from `params.taskId`.
     pub(crate) fn extracts_task_id_from_params(&self) -> bool {
         matches!(

--- a/filter/src/builtins/http/ai/agentic/a2a/mod.rs
+++ b/filter/src/builtins/http/ai/agentic/a2a/mod.rs
@@ -5,6 +5,7 @@
 
 pub(crate) mod config;
 pub(crate) mod envelope;
+pub(crate) mod task_routing;
 
 #[cfg(test)]
 #[allow(
@@ -19,15 +20,16 @@ pub(crate) mod envelope;
 )]
 mod tests;
 
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::Arc};
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use tracing::trace;
+use tracing::{debug, trace};
 
 use self::{
     config::{A2aConfig, InvalidA2aBehavior, build_config},
     envelope::{A2aEnvelope, extract_a2a_envelope},
+    task_routing::LocalTaskRouteStore,
 };
 use crate::{
     FilterAction, FilterError, Rejection,
@@ -89,6 +91,9 @@ pub struct A2aFilter {
 
     /// Maximum body bytes for `StreamBuffer`.
     max_body_bytes: usize,
+
+    /// Local task route store, present only when task routing is enabled.
+    task_route_store: Option<Arc<LocalTaskRouteStore>>,
 }
 
 impl A2aFilter {
@@ -105,10 +110,17 @@ impl A2aFilter {
         let max_body_bytes = validated_config.max_body_bytes;
         let json_rpc_config = build_json_rpc_config(max_body_bytes);
 
+        let task_route_store = if validated_config.task_routing.enabled {
+            Some(Arc::new(LocalTaskRouteStore::new()))
+        } else {
+            None
+        };
+
         Ok(Box::new(Self {
             config: validated_config,
             json_rpc_config,
             max_body_bytes,
+            task_route_store,
         }))
     }
 }
@@ -127,6 +139,18 @@ impl HttpFilter for A2aFilter {
         BodyMode::StreamBuffer {
             max_bytes: Some(self.max_body_bytes),
         }
+    }
+
+    fn response_body_access(&self) -> BodyAccess {
+        if self.task_route_store.is_some() {
+            BodyAccess::ReadOnly
+        } else {
+            BodyAccess::None
+        }
+    }
+
+    fn response_body_mode(&self) -> BodyMode {
+        BodyMode::Stream
     }
 
     async fn on_request(&self, _ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
@@ -172,6 +196,10 @@ impl HttpFilter for A2aFilter {
         promote_a2a_headers(&a2a_envelope, &envelope, &self.config, &mut ctx.extra_request_headers);
         promote_filter_results(ctx, &envelope, &a2a_envelope)?;
 
+        if let Some(store) = &self.task_route_store {
+            lookup_task_route(ctx, &a2a_envelope, store, &self.config);
+        }
+
         trace!(
             a2a_method = a2a_envelope.method.as_str(),
             a2a_family = a2a_envelope.family.as_str(),
@@ -183,11 +211,262 @@ impl HttpFilter for A2aFilter {
 
         Ok(FilterAction::Release)
     }
+
+    #[allow(clippy::too_many_lines, reason = "sequential guard-clause pipeline")]
+    async fn on_response(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        if self.task_route_store.is_none() {
+            return Ok(FilterAction::Continue);
+        }
+
+        // Task route capture only runs for non-streaming SendMessage
+        // responses. Terminal TTL only applies here; GetTask and other
+        // task-routable methods do not update stored TTLs. SSE response
+        // capture is a follow-up.
+        let is_send_message = ctx.get_metadata("a2a.method").is_some_and(|m| m == "SendMessage");
+
+        if !is_send_message {
+            return Ok(FilterAction::Continue);
+        }
+
+        let is_success = ctx.response_header.as_ref().is_some_and(|r| r.status.is_success());
+
+        if !is_success {
+            return Ok(FilterAction::Continue);
+        }
+
+        let is_sse = ctx
+            .response_header
+            .as_ref()
+            .and_then(|r| r.headers.get("content-type"))
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(is_event_stream_content_type);
+
+        if is_sse {
+            ctx.filter_metadata
+                .insert("a2a.response.is_sse".to_owned(), "true".to_owned());
+            return Ok(FilterAction::Continue);
+        }
+
+        if let Some(cluster) = ctx.cluster_name() {
+            ctx.filter_metadata
+                .insert("a2a.response.cluster".to_owned(), cluster.to_owned());
+            ctx.filter_metadata
+                .insert("a2a.response.capture_enabled".to_owned(), "true".to_owned());
+        }
+
+        Ok(FilterAction::Continue)
+    }
+
+    fn on_response_body(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+        body: &mut Option<Bytes>,
+        end_of_stream: bool,
+    ) -> Result<FilterAction, FilterError> {
+        let Some(store) = &self.task_route_store else {
+            return Ok(FilterAction::Continue);
+        };
+
+        if ctx.get_metadata("a2a.response.capture_enabled") != Some("true") {
+            return Ok(FilterAction::Continue);
+        }
+
+        if let Some(chunk) = body.as_ref()
+            && !accumulate_response_hex(ctx, chunk, self.config.task_routing.max_response_body_bytes)
+        {
+            return Ok(FilterAction::Continue);
+        }
+
+        try_capture_from_buffer(ctx, store, &self.config.task_routing, end_of_stream);
+
+        Ok(FilterAction::Continue)
+    }
 }
 
 // -----------------------------------------------------------------------------
 // Private Utilities
 // -----------------------------------------------------------------------------
+
+/// Look up a task route and inject the route cluster header on hit.
+#[allow(clippy::too_many_lines, reason = "sequential lookup-inject-trace pipeline")]
+fn lookup_task_route(
+    ctx: &mut HttpFilterContext<'_>,
+    a2a_envelope: &A2aEnvelope,
+    store: &LocalTaskRouteStore,
+    config: &A2aConfig,
+) {
+    if !a2a_envelope.method.is_task_routable() {
+        return;
+    }
+
+    let Some(task_id) = &a2a_envelope.task_id else {
+        return;
+    };
+
+    if let Some(cluster) = store.get_by_task_id(task_id) {
+        ctx.extra_request_headers.push((
+            Cow::Owned(config.task_routing.route_cluster_header.clone()),
+            cluster.to_string(),
+        ));
+        ctx.set_metadata("a2a.route_decision", "task_route_hit");
+        ctx.set_metadata("a2a.route_cluster", &*cluster);
+        debug!(
+            has_task_id = true,
+            task_id_len = task_id.len(),
+            lookup_hit = true,
+            cluster = %cluster,
+            method = a2a_envelope.method.as_str(),
+            "task route lookup hit"
+        );
+    } else {
+        ctx.set_metadata("a2a.route_decision", "task_route_miss");
+        debug!(
+            has_task_id = true,
+            task_id_len = task_id.len(),
+            lookup_hit = false,
+            method = a2a_envelope.method.as_str(),
+            "task route lookup miss"
+        );
+    }
+}
+
+/// Pingora may not deliver a separate EOS callback after the final data
+/// chunk, so we attempt to parse after every append rather than waiting
+/// for `end_of_stream`.
+fn try_capture_from_buffer(
+    ctx: &mut HttpFilterContext<'_>,
+    store: &LocalTaskRouteStore,
+    config: &config::TaskRoutingConfig,
+    end_of_stream: bool,
+) {
+    let parsed = ctx
+        .filter_metadata
+        .get("a2a.response.buffer_hex")
+        .and_then(|hex| decode_hex(hex))
+        .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok());
+
+    if let Some(value) = parsed {
+        if let Some(cluster) = ctx.filter_metadata.get("a2a.response.cluster") {
+            store_task_route(&value, cluster, store, config);
+        }
+        clear_capture_metadata(ctx);
+    } else if end_of_stream {
+        clear_capture_metadata(ctx);
+    }
+}
+
+/// Uses terminal TTL when the task state is final.
+fn store_task_route(
+    value: &serde_json::Value,
+    cluster: &str,
+    store: &LocalTaskRouteStore,
+    config: &config::TaskRoutingConfig,
+) {
+    let Some(extracted) = task_routing::extract_task_route(value) else {
+        return;
+    };
+
+    let ttl = task_routing::route_ttl(extracted.terminal, config);
+
+    if extracted.terminal && config.terminal_ttl_seconds == 0 {
+        store.remove(&extracted.task_id);
+        debug!(
+            has_task_id = true,
+            task_id_len = extracted.task_id.len(),
+            cluster = %cluster,
+            "terminal task route removed (terminal_ttl_seconds=0)"
+        );
+    } else {
+        store.put(&extracted.task_id, cluster, ttl);
+        debug!(
+            has_task_id = true,
+            task_id_len = extracted.task_id.len(),
+            cluster = %cluster,
+            terminal = extracted.terminal,
+            "stored task route from response"
+        );
+    }
+}
+
+/// Removes `a2a.response.*` keys from `filter_metadata`.
+fn clear_capture_metadata(ctx: &mut HttpFilterContext<'_>) {
+    ctx.filter_metadata.remove("a2a.response.capture_enabled");
+    ctx.filter_metadata.remove("a2a.response.buffer_hex");
+    ctx.filter_metadata.remove("a2a.response.buffer_bytes");
+    ctx.filter_metadata.remove("a2a.response.cluster");
+}
+
+/// Accumulate raw bytes as hex to avoid corruption when chunk boundaries
+/// split multibyte UTF-8 code points. Returns `false` if the byte limit
+/// was exceeded and capture state was cleared.
+fn accumulate_response_hex(ctx: &mut HttpFilterContext<'_>, chunk: &[u8], max_bytes: usize) -> bool {
+    let existing_bytes: usize = ctx
+        .filter_metadata
+        .get("a2a.response.buffer_bytes")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+
+    if existing_bytes.saturating_add(chunk.len()) > max_bytes {
+        debug!(
+            existing_bytes,
+            chunk_len = chunk.len(),
+            max_bytes,
+            "response body exceeds capture limit, skipping route capture"
+        );
+        ctx.filter_metadata.remove("a2a.response.capture_enabled");
+        ctx.filter_metadata.remove("a2a.response.buffer_hex");
+        ctx.filter_metadata.remove("a2a.response.buffer_bytes");
+        ctx.filter_metadata.remove("a2a.response.cluster");
+        return false;
+    }
+
+    let hex_buf = ctx
+        .filter_metadata
+        .entry("a2a.response.buffer_hex".to_owned())
+        .or_default();
+    for byte in chunk {
+        use std::fmt::Write;
+        let _ = write!(hex_buf, "{byte:02x}");
+    }
+
+    let new_total = existing_bytes + chunk.len();
+    ctx.filter_metadata
+        .insert("a2a.response.buffer_bytes".to_owned(), new_total.to_string());
+
+    true
+}
+
+/// Inverse of the hex encoding in [`accumulate_response_hex`].
+fn decode_hex(hex: &str) -> Option<Vec<u8>> {
+    if !hex.len().is_multiple_of(2) {
+        return None;
+    }
+
+    hex.as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let hi = hex_digit(*pair.first()?)?;
+            let lo = hex_digit(*pair.last()?)?;
+            Some(hi << 4 | lo)
+        })
+        .collect()
+}
+
+/// Supports lowercase `a`-`f` only (our encoder writes lowercase).
+fn hex_digit(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        _ => None,
+    }
+}
+
+/// Whether a content-type header value indicates `text/event-stream`.
+fn is_event_stream_content_type(ct: &str) -> bool {
+    ct.split(';')
+        .next()
+        .is_some_and(|media| media.trim().eq_ignore_ascii_case("text/event-stream"))
+}
 
 /// Build a `JsonRpcConfig` for the shared parser with A2A-appropriate defaults.
 fn build_json_rpc_config(max_body_bytes: usize) -> JsonRpcConfig {

--- a/filter/src/builtins/http/ai/agentic/a2a/task_routing.rs
+++ b/filter/src/builtins/http/ai/agentic/a2a/task_routing.rs
@@ -1,0 +1,463 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Local in-process task route store for A2A task-ownership routing.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+    time::{Duration, Instant},
+};
+
+use serde_json::Value;
+
+use super::config::TaskRoutingConfig;
+use crate::builtins::http::value_safety::contains_control_chars;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Maximum length for stored IDs, matching the existing A2A dynamic-value bound.
+const MAX_ID_LEN: usize = 256;
+
+// -----------------------------------------------------------------------------
+// TaskRoute
+// -----------------------------------------------------------------------------
+
+/// A stored mapping from a task (or context) ID to the cluster that owns it.
+#[derive(Debug, Clone)]
+struct TaskRoute {
+    /// Cluster name selected when the task was created.
+    cluster: Arc<str>,
+
+    /// When this entry expires and should be treated as a miss.
+    expires_at: Instant,
+}
+
+// -----------------------------------------------------------------------------
+// ExtractedTaskRoute
+// -----------------------------------------------------------------------------
+
+/// Task route information extracted from a JSON-RPC response body.
+#[derive(Debug, Clone)]
+pub(crate) struct ExtractedTaskRoute {
+    /// Whether the task is in a terminal state.
+    pub terminal: bool,
+
+    /// Task ID from the response.
+    pub task_id: String,
+}
+
+// -----------------------------------------------------------------------------
+// LocalTaskRouteStore
+// -----------------------------------------------------------------------------
+
+/// In-process task route store backed by `RwLock<HashMap>`.
+///
+/// Holds locks only for short synchronous map operations.
+/// Never held across `.await` boundaries.
+pub(crate) struct LocalTaskRouteStore {
+    /// Task ID → cluster mappings.
+    tasks: RwLock<HashMap<String, TaskRoute>>,
+}
+
+impl LocalTaskRouteStore {
+    /// Create an empty store.
+    pub(crate) fn new() -> Self {
+        Self {
+            tasks: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Look up a cluster by task ID. Returns `None` if absent or expired.
+    /// Lazily removes expired entries on miss.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal lock is poisoned.
+    #[allow(clippy::expect_used, reason = "poisoned lock is unrecoverable")]
+    pub(crate) fn get_by_task_id(&self, task_id: &str) -> Option<Arc<str>> {
+        let expired = {
+            let tasks = self.tasks.read().expect("task route store lock poisoned");
+            match tasks.get(task_id) {
+                Some(r) if Instant::now() < r.expires_at => return Some(Arc::clone(&r.cluster)),
+                Some(_) => true,
+                None => false,
+            }
+        };
+
+        if expired {
+            let mut tasks = self.tasks.write().expect("task route store lock poisoned");
+            // Re-check under write lock: another request may have
+            // refreshed this task between the read and write locks.
+            if tasks.get(task_id).is_some_and(|r| Instant::now() >= r.expires_at) {
+                tasks.remove(task_id);
+            }
+        }
+        None
+    }
+
+    /// Store a task route mapping with the given TTL.
+    ///
+    /// Silently ignores task IDs that fail validation (control chars, too long).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal lock is poisoned.
+    #[allow(clippy::expect_used, reason = "poisoned lock is unrecoverable")]
+    pub(crate) fn put(&self, task_id: &str, cluster: &str, ttl: Duration) {
+        if !validate_id(task_id) {
+            return;
+        }
+
+        let route = TaskRoute {
+            cluster: Arc::from(cluster),
+            expires_at: Instant::now() + ttl,
+        };
+
+        self.tasks
+            .write()
+            .expect("task route store lock poisoned")
+            .insert(task_id.to_owned(), route);
+    }
+
+    /// Remove a task route immediately (for `terminal_ttl_seconds` == 0).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal lock is poisoned.
+    #[allow(clippy::expect_used, reason = "poisoned lock is unrecoverable")]
+    pub(crate) fn remove(&self, task_id: &str) {
+        self.tasks
+            .write()
+            .expect("task route store lock poisoned")
+            .remove(task_id);
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Response Extraction
+// -----------------------------------------------------------------------------
+
+/// Extract task route information from a parsed JSON-RPC response.
+///
+/// Supports two shapes:
+/// - `result.task.id` (task nested under result)
+/// - `result.id` with `result.status` (direct task object in result)
+///
+/// Returns `None` for message-only responses or malformed JSON.
+pub(crate) fn extract_task_route(value: &Value) -> Option<ExtractedTaskRoute> {
+    let result = value.get("result")?;
+
+    if let Some(task_obj) = result.get("task") {
+        return extract_from_task_object(task_obj);
+    }
+
+    if result.get("id").is_some() && result.get("status").is_some() {
+        return extract_from_task_object(result);
+    }
+
+    None
+}
+
+/// Extract route info from a task object (either `result.task` or `result` itself).
+fn extract_from_task_object(task: &Value) -> Option<ExtractedTaskRoute> {
+    let task_id = task.get("id")?.as_str()?;
+
+    if !validate_id(task_id) {
+        return None;
+    }
+
+    let terminal = task
+        .get("status")
+        .and_then(|s| s.get("state"))
+        .and_then(Value::as_str)
+        .is_some_and(is_terminal_state);
+
+    Some(ExtractedTaskRoute {
+        task_id: task_id.to_owned(),
+        terminal,
+    })
+}
+
+/// Compute the TTL to use for a task route entry.
+pub(crate) fn route_ttl(terminal: bool, config: &TaskRoutingConfig) -> Duration {
+    if terminal {
+        Duration::from_secs(config.terminal_ttl_seconds)
+    } else {
+        Duration::from_secs(config.ttl_seconds)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Private Utilities
+// -----------------------------------------------------------------------------
+
+/// Whether the given state string represents a terminal task state.
+fn is_terminal_state(state: &str) -> bool {
+    matches!(
+        state,
+        "TASK_STATE_COMPLETED"
+            | "TASK_STATE_FAILED"
+            | "TASK_STATE_CANCELED"
+            | "TASK_STATE_REJECTED"
+            | "completed"
+            | "failed"
+            | "canceled"
+            | "cancelled"
+            | "rejected"
+    )
+}
+
+/// Whether an ID is safe for storage: no control characters, bounded length.
+fn validate_id(id: &str) -> bool {
+    !id.is_empty() && id.len() <= MAX_ID_LEN && !contains_control_chars(id)
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    reason = "tests"
+)]
+mod tests {
+    use std::thread::sleep;
+
+    use super::*;
+
+    // ---- Store Tests ----
+
+    #[test]
+    fn local_store_put_then_get_task_route() {
+        let store = LocalTaskRouteStore::new();
+        store.put("task-1", "agent-a", Duration::from_secs(60));
+
+        let cluster = store.get_by_task_id("task-1");
+        assert_eq!(
+            cluster.as_deref(),
+            Some("agent-a"),
+            "stored task route should be retrievable"
+        );
+    }
+
+    #[test]
+    fn local_store_expired_task_route_misses_and_removes_entry() {
+        let store = LocalTaskRouteStore::new();
+        store.put("task-1", "agent-a", Duration::from_millis(1));
+
+        sleep(Duration::from_millis(10));
+
+        let cluster = store.get_by_task_id("task-1");
+        assert!(cluster.is_none(), "expired task route should miss");
+
+        let still_present = store.tasks.read().unwrap().contains_key("task-1");
+        assert!(!still_present, "expired entry should be lazily removed from the map");
+    }
+
+    #[test]
+    fn local_store_terminal_zero_ttl_removes_route() {
+        let store = LocalTaskRouteStore::new();
+        store.put("task-1", "agent-a", Duration::from_secs(60));
+        store.remove("task-1");
+
+        assert!(
+            store.get_by_task_id("task-1").is_none(),
+            "removed task route should miss"
+        );
+    }
+
+    #[test]
+    fn local_store_rejects_control_char_task_id() {
+        let store = LocalTaskRouteStore::new();
+        let bad_id = "task\n-1";
+        store.put(bad_id, "agent-a", Duration::from_secs(60));
+
+        assert!(
+            store.get_by_task_id(bad_id).is_none(),
+            "task ID with control chars should not be stored"
+        );
+    }
+
+    #[test]
+    fn local_store_rejects_too_long_task_id() {
+        let store = LocalTaskRouteStore::new();
+        let long_id = "x".repeat(257);
+        store.put(&long_id, "agent-a", Duration::from_secs(60));
+
+        assert!(
+            store.get_by_task_id(&long_id).is_none(),
+            "task ID exceeding 256 bytes should not be stored"
+        );
+    }
+
+    #[test]
+    fn local_store_replaces_existing_task_route() {
+        let store = LocalTaskRouteStore::new();
+        store.put("task-1", "agent-a", Duration::from_secs(60));
+        store.put("task-1", "agent-b", Duration::from_secs(60));
+
+        let cluster = store.get_by_task_id("task-1");
+        assert_eq!(
+            cluster.as_deref(),
+            Some("agent-b"),
+            "later put should replace earlier route"
+        );
+    }
+
+    // ---- Response Extraction Tests ----
+
+    #[test]
+    fn extract_task_route_from_result_task() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "task": {
+                    "id": "task-123",
+                    "contextId": "ctx-123",
+                    "status": {"state": "TASK_STATE_WORKING"}
+                }
+            }
+        });
+
+        let route = extract_task_route(&json).expect("should extract route");
+        assert_eq!(route.task_id, "task-123");
+        assert!(!route.terminal, "TASK_STATE_WORKING is not terminal");
+    }
+
+    #[test]
+    fn extract_task_route_from_direct_result_task() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "id": "task-456",
+                "contextId": "ctx-456",
+                "status": {"state": "TASK_STATE_COMPLETED"}
+            }
+        });
+
+        let route = extract_task_route(&json).expect("should extract route");
+        assert_eq!(route.task_id, "task-456");
+        assert!(route.terminal, "TASK_STATE_COMPLETED is terminal");
+    }
+
+    #[test]
+    fn message_only_response_does_not_create_route() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "message": {
+                    "messageId": "msg-1",
+                    "role": "ROLE_AGENT",
+                    "parts": [{"text": "done"}]
+                }
+            }
+        });
+
+        assert!(
+            extract_task_route(&json).is_none(),
+            "message-only response should not produce a route"
+        );
+    }
+
+    #[test]
+    fn invalid_json_response_does_not_error() {
+        let json = serde_json::json!({"not": "a valid response"});
+        assert!(
+            extract_task_route(&json).is_none(),
+            "malformed response should return None, not error"
+        );
+    }
+
+    #[test]
+    fn missing_cluster_does_not_store_route() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "task": {
+                    "contextId": "ctx-1",
+                    "status": {"state": "TASK_STATE_WORKING"}
+                }
+            }
+        });
+
+        assert!(
+            extract_task_route(&json).is_none(),
+            "task without id should not produce a route"
+        );
+    }
+
+    #[test]
+    fn terminal_state_uses_terminal_ttl() {
+        let config = TaskRoutingConfig {
+            ttl_seconds: 3600,
+            terminal_ttl_seconds: 300,
+            ..TaskRoutingConfig::default()
+        };
+
+        let ttl = route_ttl(true, &config);
+        assert_eq!(ttl, Duration::from_secs(300), "terminal tasks should use terminal TTL");
+    }
+
+    #[test]
+    fn input_required_state_keeps_normal_route_ttl() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "task": {
+                    "id": "task-1",
+                    "status": {"state": "TASK_STATE_INPUT_REQUIRED"}
+                }
+            }
+        });
+
+        let route = extract_task_route(&json).expect("should extract route");
+        assert!(!route.terminal, "TASK_STATE_INPUT_REQUIRED should not be terminal");
+    }
+
+    #[test]
+    fn all_terminal_states_detected() {
+        let terminal_states = [
+            "TASK_STATE_COMPLETED",
+            "TASK_STATE_FAILED",
+            "TASK_STATE_CANCELED",
+            "TASK_STATE_REJECTED",
+            "completed",
+            "failed",
+            "canceled",
+            "cancelled",
+            "rejected",
+        ];
+
+        for state in terminal_states {
+            assert!(is_terminal_state(state), "{state} should be terminal");
+        }
+    }
+
+    #[test]
+    fn non_terminal_states_not_detected() {
+        let non_terminal = [
+            "TASK_STATE_WORKING",
+            "TASK_STATE_INPUT_REQUIRED",
+            "TASK_STATE_AUTH_REQUIRED",
+            "TASK_STATE_SUBMITTED",
+            "working",
+            "submitted",
+        ];
+
+        for state in non_terminal {
+            assert!(!is_terminal_state(state), "{state} should not be terminal");
+        }
+    }
+}

--- a/filter/src/builtins/http/ai/agentic/a2a/tests.rs
+++ b/filter/src/builtins/http/ai/agentic/a2a/tests.rs
@@ -3,7 +3,7 @@
 
 //! Unit tests for the A2A classifier filter.
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
 use bytes::Bytes;
 use http::HeaderMap;
@@ -12,6 +12,7 @@ use super::{
     A2aFilter,
     config::{A2aConfig, build_config},
     envelope::{A2aFamily, A2aMethod, extract_a2a_envelope},
+    task_routing::LocalTaskRouteStore,
 };
 use crate::{FilterAction, filter::HttpFilter};
 
@@ -1123,6 +1124,492 @@ async fn canonical_method_stores_same_in_json_rpc_method() {
 }
 
 // -----------------------------------------------------------------------------
+// Task Routing Config Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn task_routing_disabled_by_default() {
+    let cfg: A2aConfig = serde_yaml::from_str("{}").unwrap();
+    assert!(!cfg.task_routing.enabled, "task routing should be disabled by default");
+}
+
+#[test]
+fn task_routing_enabled_parses_defaults() {
+    let cfg: A2aConfig = serde_yaml::from_str(
+        r#"
+        task_routing:
+          enabled: true
+        "#,
+    )
+    .unwrap();
+    let validated = build_config(cfg).unwrap();
+    assert!(validated.task_routing.enabled, "task routing should be enabled");
+    assert_eq!(
+        validated.task_routing.route_cluster_header, "x-praxis-a2a-route-cluster",
+        "default route cluster header"
+    );
+    assert_eq!(validated.task_routing.ttl_seconds, 3600, "default TTL is 1 hour");
+    assert_eq!(
+        validated.task_routing.terminal_ttl_seconds, 300,
+        "default terminal TTL is 5 minutes"
+    );
+    assert_eq!(
+        validated.task_routing.max_response_body_bytes, 65_536,
+        "default max response body bytes is 64 KiB"
+    );
+}
+
+#[test]
+fn task_routing_rejects_unknown_store() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+        task_routing:
+          enabled: true
+          store: redis
+        "#,
+    )
+    .unwrap();
+    let err = A2aFilter::from_config(&yaml).err().expect("should fail");
+    assert!(
+        err.to_string().contains("unknown variant"),
+        "unknown store should be rejected: {err}"
+    );
+}
+
+#[test]
+fn task_routing_rejects_invalid_route_cluster_header() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+        task_routing:
+          enabled: true
+          route_cluster_header: "invalid header with spaces"
+        "#,
+    )
+    .unwrap();
+    let err = A2aFilter::from_config(&yaml).err().expect("should fail");
+    assert!(
+        err.to_string().contains("not a valid HTTP header name"),
+        "invalid header name should be rejected: {err}"
+    );
+}
+
+#[test]
+fn task_routing_rejects_zero_ttl() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+        task_routing:
+          enabled: true
+          ttl_seconds: 0
+        "#,
+    )
+    .unwrap();
+    let err = A2aFilter::from_config(&yaml).err().expect("should fail");
+    assert!(
+        err.to_string().contains("ttl_seconds must be greater than 0"),
+        "zero TTL should be rejected: {err}"
+    );
+}
+
+#[test]
+fn task_routing_rejects_zero_max_response_body_bytes() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+        task_routing:
+          enabled: true
+          max_response_body_bytes: 0
+        "#,
+    )
+    .unwrap();
+    let err = A2aFilter::from_config(&yaml).err().expect("should fail");
+    assert!(
+        err.to_string()
+            .contains("max_response_body_bytes must be greater than 0"),
+        "zero max_response_body_bytes should be rejected: {err}"
+    );
+}
+
+#[test]
+fn task_routing_rejects_non_reserved_route_cluster_header() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+        task_routing:
+          enabled: true
+          route_cluster_header: "x-custom-route"
+        "#,
+    )
+    .unwrap();
+    let err = A2aFilter::from_config(&yaml).err().expect("should fail");
+    assert!(
+        err.to_string().contains("must start with 'x-praxis-a2a-'"),
+        "non-reserved route cluster header should be rejected: {err}"
+    );
+}
+
+#[test]
+fn task_routing_allows_zero_terminal_ttl() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+        task_routing:
+          enabled: true
+          terminal_ttl_seconds: 0
+        "#,
+    )
+    .unwrap();
+    let filter = A2aFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.name(), "a2a", "zero terminal_ttl_seconds should be valid");
+}
+
+// -----------------------------------------------------------------------------
+// Task Route Lookup Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn task_route_hit_injects_route_cluster_header() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+    store.put("task-123", "agent-a", std::time::Duration::from_secs(60));
+
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"GetTask","params":{"id":"task-123"}}"#;
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Release), "should release");
+
+    let headers: std::collections::HashMap<_, _> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+
+    assert_eq!(
+        headers.get("x-praxis-a2a-route-cluster"),
+        Some(&"agent-a"),
+        "task route hit should inject route cluster header"
+    );
+}
+
+#[tokio::test]
+async fn task_route_miss_continues_without_route_cluster_header() {
+    let filter = make_task_routing_filter();
+
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"GetTask","params":{"id":"unknown-task"}}"#;
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    let action = filter.on_request_body(&mut ctx, &mut body, true).await.unwrap();
+    assert!(matches!(action, FilterAction::Release), "should release");
+
+    let headers: std::collections::HashMap<_, _> = ctx
+        .extra_request_headers
+        .iter()
+        .map(|(k, v)| (k.as_ref(), v.as_str()))
+        .collect();
+
+    assert!(
+        !headers.contains_key("x-praxis-a2a-route-cluster"),
+        "task route miss should not inject route cluster header"
+    );
+}
+
+#[tokio::test]
+async fn task_route_hit_records_bounded_route_metadata() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+    store.put("task-abc", "agent-b", std::time::Duration::from_secs(60));
+
+    let body_str = r#"{"jsonrpc":"2.0","id":1,"method":"GetTask","params":{"id":"task-abc"}}"#;
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    let mut body = Some(Bytes::from(body_str));
+
+    drop(filter.on_request_body(&mut ctx, &mut body, true).await.unwrap());
+
+    assert_eq!(
+        ctx.get_metadata("a2a.route_decision"),
+        Some("task_route_hit"),
+        "route decision metadata should be set"
+    );
+    assert_eq!(
+        ctx.get_metadata("a2a.route_cluster"),
+        Some("agent-b"),
+        "route cluster metadata should be set"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Response Body Tests
+// -----------------------------------------------------------------------------
+
+#[tokio::test]
+async fn json_response_split_across_chunks_captures_opportunistically() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_response_capture(&mut ctx);
+
+    let json =
+        r#"{"jsonrpc":"2.0","id":1,"result":{"task":{"id":"task-split","status":{"state":"TASK_STATE_WORKING"}}}}"#;
+    let (chunk1, chunk2) = json.split_at(40);
+
+    let mut body1 = Some(Bytes::from(chunk1.to_owned()));
+    drop(filter.on_response_body(&mut ctx, &mut body1, false).unwrap());
+    assert!(
+        store.get_by_task_id("task-split").is_none(),
+        "incomplete JSON should not capture"
+    );
+
+    let mut body2 = Some(Bytes::from(chunk2.to_owned()));
+    drop(filter.on_response_body(&mut ctx, &mut body2, false).unwrap());
+
+    assert_eq!(
+        store.get_by_task_id("task-split").as_deref(),
+        Some("agent-a"),
+        "route should be captured as soon as JSON is complete, before EOS"
+    );
+    assert_capture_scratch_cleared(&ctx);
+}
+
+#[tokio::test]
+async fn multibyte_char_split_across_chunks_still_captures_route() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_response_capture(&mut ctx);
+
+    // "é" is U+00E9, encoded as [0xC3, 0xA9] in UTF-8.
+    // Split the chunk boundary inside that two-byte sequence.
+    let json_bytes: Vec<u8> = format!(
+        r#"{{"jsonrpc":"2.0","id":1,"result":{{"task":{{"id":"task-mb","status":{{"state":"TASK_STATE_WORKING"}},"note":"caf{}"}}}}}}"#,
+        "é"
+    ).into_bytes();
+
+    let split = json_bytes.iter().position(|&b| b == 0xA9).expect("should contain 0xA9");
+
+    let mut body1 = Some(Bytes::from(json_bytes[..split].to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body1, false).unwrap());
+
+    let mut body2 = Some(Bytes::from(json_bytes[split..].to_vec()));
+    drop(filter.on_response_body(&mut ctx, &mut body2, true).unwrap());
+
+    assert_eq!(
+        store.get_by_task_id("task-mb").as_deref(),
+        Some("agent-a"),
+        "chunk split inside multibyte UTF-8 character should not prevent route capture"
+    );
+}
+
+#[tokio::test]
+async fn oversized_response_passes_through_without_route_capture() {
+    let filter = make_task_routing_filter_with_config(
+        r#"{"on_invalid": "continue", "task_routing": {"enabled": true, "max_response_body_bytes": 32}}"#,
+    );
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_response_capture(&mut ctx);
+
+    let large_json = format!(
+        r#"{{"jsonrpc":"2.0","id":1,"result":{{"task":{{"id":"task-big","status":{{"state":"TASK_STATE_WORKING"}}}},"padding":"{}"}}}}"#,
+        "x".repeat(64)
+    );
+    let mut body = Some(Bytes::from(large_json));
+    drop(filter.on_response_body(&mut ctx, &mut body, true).unwrap());
+
+    assert!(
+        store.get_by_task_id("task-big").is_none(),
+        "oversized response should skip route capture"
+    );
+    assert_capture_scratch_cleared(&ctx);
+}
+
+#[tokio::test]
+async fn invalid_json_response_body_does_not_error() {
+    let filter = make_task_routing_filter();
+    let store = filter.task_route_store.as_ref().unwrap();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    seed_response_capture(&mut ctx);
+
+    let mut body = Some(Bytes::from("not valid json at all"));
+    let action = filter.on_response_body(&mut ctx, &mut body, true).unwrap();
+
+    assert!(matches!(action, FilterAction::Continue), "should continue");
+    assert_eq!(
+        body.as_deref(),
+        Some(b"not valid json at all".as_slice()),
+        "response bytes should not be modified"
+    );
+    assert!(store.get_by_task_id("anything").is_none(), "no route should be stored");
+    assert_capture_scratch_cleared(&ctx);
+}
+
+#[tokio::test]
+async fn on_response_enables_capture_for_success_non_sse_send_message() {
+    let filter = make_task_routing_filter();
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.cluster = Some(Arc::from("agent-a"));
+    ctx.filter_metadata
+        .insert("a2a.method".to_owned(), "SendMessage".to_owned());
+
+    let mut resp = crate::context::Response {
+        status: http::StatusCode::OK,
+        headers: HeaderMap::new(),
+    };
+    ctx.response_header = Some(&mut resp);
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    assert_eq!(
+        ctx.get_metadata("a2a.response.capture_enabled"),
+        Some("true"),
+        "capture enabled"
+    );
+    assert_eq!(
+        ctx.get_metadata("a2a.response.cluster"),
+        Some("agent-a"),
+        "cluster recorded"
+    );
+}
+
+#[tokio::test]
+async fn sse_response_skips_task_route_capture() {
+    let filter = make_task_routing_filter();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.cluster = Some(Arc::from("agent-a"));
+    ctx.filter_metadata
+        .insert("a2a.method".to_owned(), "SendMessage".to_owned());
+
+    let mut resp = crate::context::Response {
+        status: http::StatusCode::OK,
+        headers: HeaderMap::new(),
+    };
+    resp.headers
+        .insert("content-type", "text/event-stream".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    assert_eq!(
+        ctx.get_metadata("a2a.response.is_sse"),
+        Some("true"),
+        "SSE response should be flagged"
+    );
+    assert!(
+        ctx.get_metadata("a2a.response.capture_enabled").is_none(),
+        "SSE response should not enable capture"
+    );
+}
+
+#[tokio::test]
+async fn mixed_case_sse_content_type_skips_capture() {
+    let filter = make_task_routing_filter();
+
+    let req = make_a2a_request(&[]);
+    let mut ctx = crate::test_utils::make_filter_context(&req);
+    ctx.cluster = Some(Arc::from("agent-a"));
+    ctx.filter_metadata
+        .insert("a2a.method".to_owned(), "SendMessage".to_owned());
+
+    let mut resp = crate::context::Response {
+        status: http::StatusCode::OK,
+        headers: HeaderMap::new(),
+    };
+    resp.headers
+        .insert("content-type", "Text/Event-Stream; charset=utf-8".parse().unwrap());
+    ctx.response_header = Some(&mut resp);
+
+    drop(filter.on_response(&mut ctx).await.unwrap());
+    ctx.response_header = None;
+
+    assert_eq!(
+        ctx.get_metadata("a2a.response.is_sse"),
+        Some("true"),
+        "mixed-case SSE content-type should be detected"
+    );
+    assert!(
+        ctx.get_metadata("a2a.response.capture_enabled").is_none(),
+        "mixed-case SSE should not enable capture"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Task Routable Method Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn task_routable_methods() {
+    let routable = [
+        A2aMethod::GetTask,
+        A2aMethod::CancelTask,
+        A2aMethod::SubscribeToTask,
+        A2aMethod::CreateTaskPushNotificationConfig,
+        A2aMethod::GetTaskPushNotificationConfig,
+        A2aMethod::ListTaskPushNotificationConfigs,
+        A2aMethod::DeleteTaskPushNotificationConfig,
+    ];
+    for method in &routable {
+        assert!(method.is_task_routable(), "{} should be task-routable", method.as_str());
+    }
+}
+
+#[test]
+fn non_task_routable_methods() {
+    let non_routable = [
+        A2aMethod::SendMessage,
+        A2aMethod::SendStreamingMessage,
+        A2aMethod::ListTasks,
+        A2aMethod::GetExtendedAgentCard,
+        A2aMethod::Unknown("custom".to_owned()),
+    ];
+    for method in &non_routable {
+        assert!(
+            !method.is_task_routable(),
+            "{} should not be task-routable",
+            method.as_str()
+        );
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Push Notification Task ID Extraction Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn list_task_push_notification_configs_extracts_task_id() {
+    let json = serde_json::json!({
+        "jsonrpc": "2.0", "method": "ListTaskPushNotificationConfigs",
+        "params": { "taskId": "task-pn-list" }, "id": 1
+    });
+    let envelope = extract_a2a_envelope(
+        &json,
+        "ListTaskPushNotificationConfigs",
+        &BTreeMap::new(),
+        &HeaderMap::new(),
+    );
+    assert_eq!(
+        envelope.task_id,
+        Some("task-pn-list".to_owned()),
+        "ListTaskPushNotificationConfigs requires params.taskId per A2A spec"
+    );
+    assert!(
+        envelope.method.is_task_routable(),
+        "ListTaskPushNotificationConfigs should be task-routable"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
 
@@ -1139,6 +1626,7 @@ fn make_filter(yaml: &str) -> A2aFilter {
         config: validated_config,
         json_rpc_config,
         max_body_bytes,
+        task_route_store: None,
     }
 }
 
@@ -1168,6 +1656,54 @@ fn canonical_method_cases() -> Vec<(&'static str, A2aMethod)> {
         ),
         ("GetExtendedAgentCard", A2aMethod::GetExtendedAgentCard),
     ]
+}
+
+fn seed_response_capture(ctx: &mut crate::filter::HttpFilterContext<'_>) {
+    ctx.filter_metadata
+        .insert("a2a.response.capture_enabled".to_owned(), "true".to_owned());
+    ctx.filter_metadata
+        .insert("a2a.response.cluster".to_owned(), "agent-a".to_owned());
+}
+
+fn assert_capture_scratch_cleared(ctx: &crate::filter::HttpFilterContext<'_>) {
+    assert!(
+        !ctx.filter_metadata.contains_key("a2a.response.capture_enabled"),
+        "capture_enabled not cleared"
+    );
+    assert!(
+        !ctx.filter_metadata.contains_key("a2a.response.buffer_hex"),
+        "buffer_hex not cleared"
+    );
+    assert!(
+        !ctx.filter_metadata.contains_key("a2a.response.buffer_bytes"),
+        "buffer_bytes not cleared"
+    );
+    assert!(
+        !ctx.filter_metadata.contains_key("a2a.response.cluster"),
+        "cluster not cleared"
+    );
+}
+
+fn make_task_routing_filter() -> A2aFilter {
+    make_task_routing_filter_with_config(r#"{"on_invalid": "continue", "task_routing": {"enabled": true}}"#)
+}
+
+fn make_task_routing_filter_with_config(yaml: &str) -> A2aFilter {
+    let cfg: A2aConfig = serde_yaml::from_str(yaml).unwrap();
+    let validated_config = build_config(cfg).unwrap();
+    let max_body_bytes = validated_config.max_body_bytes;
+    let json_rpc_config = super::build_json_rpc_config(max_body_bytes);
+    let task_route_store = if validated_config.task_routing.enabled {
+        Some(Arc::new(LocalTaskRouteStore::new()))
+    } else {
+        None
+    };
+    A2aFilter {
+        config: validated_config,
+        json_rpc_config,
+        max_body_bytes,
+        task_route_store,
+    }
 }
 
 fn make_a2a_request(extra_headers: &[(&str, &str)]) -> crate::context::Request {

--- a/tests/integration/tests/suite/a2a.rs
+++ b/tests/integration/tests/suite/a2a.rs
@@ -271,6 +271,184 @@ fn a2a_batch_input_returns_400() {
 }
 
 // -----------------------------------------------------------------------------
+// Task Routing Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn a2a_task_route_capture_then_lookup() {
+    let json_body = r#"{"jsonrpc":"2.0","id":1,"result":{"task":{"id":"task-123","contextId":"ctx-1","status":{"state":"TASK_STATE_WORKING"}}}}"#;
+    let agent_a_guard = Backend::fixed(json_body)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let agent_b_guard = start_backend_with_shutdown("agent-b");
+    let proxy_port = free_port();
+
+    let yaml = a2a_task_routing_enabled_yaml(proxy_port, agent_a_guard.port(), agent_b_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let send_body = r#"{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":"Hello"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", send_body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+    assert_eq!(parse_status(&raw), 200, "SendMessage should succeed");
+
+    let get_body = r#"{"jsonrpc":"2.0","id":2,"method":"GetTask","params":{"id":"task-123"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", get_body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        json_body,
+        "GetTask should route to agent-a (which created the task), not fallback agent-b"
+    );
+}
+
+#[test]
+fn a2a_message_only_response_does_not_create_mapping() {
+    let msg_body = r#"{"jsonrpc":"2.0","id":1,"result":{"message":{"messageId":"msg-1","role":"ROLE_AGENT","parts":[{"text":"done"}]}}}"#;
+    let agent_a_guard = Backend::fixed(msg_body)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let agent_b_guard = start_backend_with_shutdown("agent-b");
+    let proxy_port = free_port();
+
+    let yaml = a2a_task_routing_enabled_yaml(proxy_port, agent_a_guard.port(), agent_b_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let send_body = r#"{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":"Hello"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", send_body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+    assert_eq!(parse_status(&raw), 200, "SendMessage should succeed");
+
+    let get_body = r#"{"jsonrpc":"2.0","id":2,"method":"GetTask","params":{"id":"task-123"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", get_body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        "agent-b",
+        "GetTask should follow fallback because message-only response did not create a mapping"
+    );
+}
+
+#[test]
+fn a2a_task_route_miss_continues() {
+    let agent_a_guard = start_backend_with_shutdown("agent-a");
+    let agent_b_guard = start_backend_with_shutdown("agent-b");
+    let proxy_port = free_port();
+
+    let yaml = a2a_task_routing_enabled_yaml(proxy_port, agent_a_guard.port(), agent_b_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let get_body = r#"{"jsonrpc":"2.0","id":1,"method":"GetTask","params":{"id":"unknown-task"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", get_body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(parse_body(&raw), "agent-b", "unknown task should follow fallback route");
+}
+
+#[test]
+fn a2a_internal_route_header_cannot_be_spoofed() {
+    let agent_a_guard = start_backend_with_shutdown("agent-a");
+    let agent_b_guard = start_backend_with_shutdown("agent-b");
+    let proxy_port = free_port();
+
+    let yaml = a2a_task_routing_enabled_yaml(proxy_port, agent_a_guard.port(), agent_b_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let get_body = r#"{"jsonrpc":"2.0","id":1,"method":"GetTask","params":{"id":"no-mapping"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", get_body, &[("x-praxis-a2a-route-cluster", "agent-a")]);
+    let raw = http_send(proxy.addr(), &request);
+
+    assert_eq!(
+        parse_status(&raw),
+        400,
+        "client-supplied reserved internal headers should be rejected before reaching the filter pipeline"
+    );
+}
+
+#[test]
+fn a2a_task_route_captured_from_direct_result_shape() {
+    let json_body =
+        r#"{"jsonrpc":"2.0","id":1,"result":{"id":"task-direct-1","status":{"state":"TASK_STATE_WORKING"}}}"#;
+    let agent_a_guard = Backend::fixed(json_body)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let agent_b_guard = start_backend_with_shutdown("agent-b");
+    let proxy_port = free_port();
+
+    let yaml = a2a_task_routing_enabled_yaml(proxy_port, agent_a_guard.port(), agent_b_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let send_body = r#"{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":"Hello"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", send_body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+    assert_eq!(parse_status(&raw), 200, "SendMessage should succeed");
+    assert_eq!(
+        parse_body(&raw),
+        json_body,
+        "SendMessage response should come from agent-a"
+    );
+
+    let get_body = r#"{"jsonrpc":"2.0","id":2,"method":"GetTask","params":{"id":"task-direct-1"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", get_body, &[]);
+    let raw = http_send(proxy.addr(), &request);
+    assert_eq!(parse_status(&raw), 200);
+    assert_eq!(
+        parse_body(&raw),
+        json_body,
+        "direct result.id shape should also capture task route"
+    );
+}
+
+#[test]
+fn a2a_sse_response_unchanged_with_task_routing_enabled() {
+    let sse_body = "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"status\":\"working\"}}\n\n\
+                    data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"status\":\"completed\"}}\n\n";
+    let sse_guard = Backend::fixed(sse_body)
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-cache")
+        .start_with_shutdown();
+    let default_guard = start_backend_with_shutdown("default-backend");
+    let proxy_port = free_port();
+
+    let yaml = a2a_task_routing_sse_yaml(proxy_port, sse_guard.port(), default_guard.port());
+    let config = Config::from_yaml(&yaml).unwrap();
+    let _proxy = start_proxy(&config);
+
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"SendStreamingMessage","params":{"message":"Hello"}}"#;
+    let request = json_post_with_a2a_headers("/a2a/", body, &[]);
+
+    let mut stream = std::net::TcpStream::connect(format!("127.0.0.1:{proxy_port}")).unwrap();
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+        .unwrap();
+    stream.write_all(request.as_bytes()).unwrap();
+    stream.flush().unwrap();
+
+    let mut response = Vec::new();
+    let _bytes = stream.read_to_end(&mut response);
+    let raw = String::from_utf8_lossy(&response);
+
+    assert_eq!(parse_status(&raw), 200);
+    assert!(
+        raw.contains("text/event-stream"),
+        "SSE content-type should reach client with task routing enabled: {raw}"
+    );
+
+    let response_body = parse_body(&raw);
+    assert_eq!(
+        response_body, sse_body,
+        "SSE response body should pass through unchanged with task routing enabled"
+    );
+}
+
+// -----------------------------------------------------------------------------
 // Test Utilities
 // -----------------------------------------------------------------------------
 
@@ -459,6 +637,91 @@ filter_chains:
           - name: "backend"
             endpoints:
               - "127.0.0.1:{backend_port}"
+"#,
+    )
+}
+
+fn a2a_task_routing_enabled_yaml(proxy_port: u16, agent_a_port: u16, agent_b_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: a2a
+        max_body_bytes: 65536
+        on_invalid: continue
+        headers:
+          method: x-praxis-a2a-method
+          task_id: x-praxis-a2a-task-id
+        task_routing:
+          enabled: true
+          route_cluster_header: x-praxis-a2a-route-cluster
+      - filter: router
+        routes:
+          - path_prefix: "/a2a/"
+            headers:
+              x-praxis-a2a-route-cluster: "agent-a"
+            cluster: "agent-a"
+          - path_prefix: "/a2a/"
+            headers:
+              x-praxis-a2a-route-cluster: "agent-b"
+            cluster: "agent-b"
+          - path_prefix: "/a2a/"
+            headers:
+              x-praxis-a2a-method: "SendMessage"
+            cluster: "agent-a"
+          - path_prefix: "/a2a/"
+            cluster: "agent-b"
+      - filter: load_balancer
+        clusters:
+          - name: "agent-a"
+            endpoints:
+              - "127.0.0.1:{agent_a_port}"
+          - name: "agent-b"
+            endpoints:
+              - "127.0.0.1:{agent_b_port}"
+"#,
+    )
+}
+
+fn a2a_task_routing_sse_yaml(proxy_port: u16, streaming_port: u16, default_port: u16) -> String {
+    format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: a2a
+        max_body_bytes: 65536
+        on_invalid: continue
+        headers:
+          method: x-praxis-a2a-method
+          streaming: x-praxis-a2a-streaming
+        task_routing:
+          enabled: true
+      - filter: router
+        routes:
+          - path_prefix: "/a2a/"
+            headers:
+              x-praxis-a2a-streaming: "true"
+            cluster: "streaming"
+          - path_prefix: "/a2a/"
+            cluster: "default"
+      - filter: load_balancer
+        clusters:
+          - name: "streaming"
+            endpoints:
+              - "127.0.0.1:{streaming_port}"
+          - name: "default"
+            endpoints:
+              - "127.0.0.1:{default_port}"
 "#,
     )
 }

--- a/tests/integration/tests/suite/examples/agentic_routing.rs
+++ b/tests/integration/tests/suite/examples/agentic_routing.rs
@@ -6,8 +6,8 @@
 use std::collections::HashMap;
 
 use praxis_test_utils::{
-    free_port, http_send, json_post, load_example_config, parse_body, parse_status, start_backend_with_shutdown,
-    start_proxy,
+    Backend, free_port, http_send, json_post, load_example_config, parse_body, parse_status,
+    start_backend_with_shutdown, start_proxy,
 };
 
 // ---------------------------------------------------------------------------
@@ -372,6 +372,120 @@ fn a2a_classifier_routing_default_fallback() {
         parse_body(&raw),
         "default-response",
         "non-A2A traffic should route to default-backend"
+    );
+}
+
+#[test]
+fn a2a_task_routing_example_routes_send_message_to_agent_a() {
+    let task_json =
+        r#"{"jsonrpc":"2.0","id":1,"result":{"task":{"id":"task-example-1","status":{"state":"TASK_STATE_WORKING"}}}}"#;
+    let agent_a_guard = Backend::fixed(task_json)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let agent_b_guard = start_backend_with_shutdown("agent-b-response");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "ai/a2a-task-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:9001", agent_a_guard.port()),
+            ("127.0.0.1:9002", agent_b_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &a2a_json_post(
+            "/",
+            r#"{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":"Hello"}}"#,
+        ),
+    );
+    assert_eq!(parse_status(&raw), 200, "SendMessage should return 200");
+    assert_eq!(
+        parse_body(&raw),
+        task_json,
+        "SendMessage should route to agent-a cluster and return task JSON"
+    );
+}
+
+#[test]
+fn a2a_task_routing_example_routes_get_task_to_owning_cluster() {
+    let task_json =
+        r#"{"jsonrpc":"2.0","id":1,"result":{"task":{"id":"task-example-2","status":{"state":"TASK_STATE_WORKING"}}}}"#;
+    let agent_a_guard = Backend::fixed(task_json)
+        .header("content-type", "application/json")
+        .start_with_shutdown();
+    let agent_b_guard = start_backend_with_shutdown("agent-b-response");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "ai/a2a-task-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:9001", agent_a_guard.port()),
+            ("127.0.0.1:9002", agent_b_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let send_raw = http_send(
+        proxy.addr(),
+        &a2a_json_post(
+            "/",
+            r#"{"jsonrpc":"2.0","id":1,"method":"SendMessage","params":{"message":"Hello"}}"#,
+        ),
+    );
+    assert_eq!(parse_status(&send_raw), 200, "SendMessage should succeed");
+
+    let get_raw = http_send(
+        proxy.addr(),
+        &a2a_json_post(
+            "/",
+            r#"{"jsonrpc":"2.0","id":2,"method":"GetTask","params":{"id":"task-example-2"}}"#,
+        ),
+    );
+    assert_eq!(parse_status(&get_raw), 200, "GetTask should succeed");
+    assert_eq!(
+        parse_body(&get_raw),
+        task_json,
+        "GetTask for task-example-2 should route back to agent-a (which created the task)"
+    );
+}
+
+#[test]
+fn a2a_task_routing_example_unknown_task_follows_fallback() {
+    let agent_a_guard = start_backend_with_shutdown("agent-a-response");
+    let agent_b_guard = start_backend_with_shutdown("agent-b-response");
+    let proxy_port = free_port();
+
+    let config = load_example_config(
+        "ai/a2a-task-routing.yaml",
+        proxy_port,
+        HashMap::from([
+            ("127.0.0.1:9001", agent_a_guard.port()),
+            ("127.0.0.1:9002", agent_b_guard.port()),
+        ]),
+    );
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        &a2a_json_post(
+            "/",
+            r#"{"jsonrpc":"2.0","id":1,"method":"GetTask","params":{"id":"nonexistent"}}"#,
+        ),
+    );
+    assert_eq!(
+        parse_status(&raw),
+        200,
+        "GetTask for unknown should succeed via fallback"
+    );
+    assert_eq!(
+        parse_body(&raw),
+        "agent-b-response",
+        "unknown task should route to fallback (agent-b)"
     );
 }
 

--- a/tests/utils/src/net/backend/mod.rs
+++ b/tests/utils/src/net/backend/mod.rs
@@ -8,10 +8,7 @@ mod simple;
 mod specialized;
 mod websocket;
 
-pub use echo::{
-    start_echo_backend, start_echo_backend_with_shutdown, start_header_echo_backend,
-    start_header_echo_backend_with_shutdown, start_uri_echo_backend, start_uri_echo_backend_with_shutdown,
-};
+pub use echo::{start_echo_backend, start_header_echo_backend, start_uri_echo_backend};
 pub use simple::{
     Backend, ChunkedBackend, RoutedBackend, start_backend, start_backend_v6, start_backend_with_shutdown,
 };

--- a/tests/utils/src/net/backend/mod.rs
+++ b/tests/utils/src/net/backend/mod.rs
@@ -12,7 +12,9 @@ pub use echo::{
     start_echo_backend, start_echo_backend_with_shutdown, start_header_echo_backend,
     start_header_echo_backend_with_shutdown, start_uri_echo_backend, start_uri_echo_backend_with_shutdown,
 };
-pub use simple::{Backend, RoutedBackend, start_backend, start_backend_v6, start_backend_with_shutdown};
+pub use simple::{
+    Backend, ChunkedBackend, RoutedBackend, start_backend, start_backend_v6, start_backend_with_shutdown,
+};
 pub use specialized::{
     BackendGuard, start_hop_by_hop_response_backend, start_reserved_header_response_backend, start_slow_backend,
 };

--- a/tests/utils/src/net/backend/simple.rs
+++ b/tests/utils/src/net/backend/simple.rs
@@ -51,6 +51,15 @@ impl Backend {
         }
     }
 
+    /// Create a backend returning a chunked transfer-encoded response
+    /// where each entry becomes a separate chunk.
+    pub fn chunked(chunks: Vec<String>) -> ChunkedBackend {
+        ChunkedBackend {
+            chunks,
+            headers: Vec::new(),
+        }
+    }
+
     /// Add a response header.
     #[must_use]
     pub fn header(mut self, name: &str, value: &str) -> Self {
@@ -120,6 +129,65 @@ impl Backend {
             resp.push_str("\r\n");
             resp.push_str(&body);
             let _sent = stream.write_all(resp.as_bytes());
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
+// ChunkedBackend
+// -----------------------------------------------------------------------------
+
+/// A backend that sends a chunked transfer-encoded response.
+pub struct ChunkedBackend {
+    /// Response body chunks.
+    chunks: Vec<String>,
+
+    /// Extra response headers as `(name, value)` pairs.
+    headers: Vec<(String, String)>,
+}
+
+impl ChunkedBackend {
+    /// Add a response header.
+    #[must_use]
+    pub fn header(mut self, name: &str, value: &str) -> Self {
+        self.headers.push((name.to_owned(), value.to_owned()));
+        self
+    }
+
+    /// Start the backend and return a [`BackendGuard`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the server fails to bind.
+    pub fn start_with_shutdown(self) -> BackendGuard {
+        let chunks = self.chunks;
+        let headers = self.headers;
+
+        spawn_tcp_server_with_shutdown(move |mut stream| {
+            stream.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+            let _headers = read_until_headers_complete(&mut stream);
+
+            let mut resp =
+                "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\nServer: praxis-test-backend\r\n"
+                    .to_owned();
+            for (name, value) in &headers {
+                use std::fmt::Write;
+                let _written = write!(resp, "{name}: {value}\r\n");
+            }
+            resp.push_str("\r\n");
+            let _sent = stream.write_all(resp.as_bytes());
+            let _flushed = stream.flush();
+
+            for chunk in &chunks {
+                let hex_len = format!("{:x}\r\n", chunk.len());
+                let _sent = stream.write_all(hex_len.as_bytes());
+                let _sent = stream.write_all(chunk.as_bytes());
+                let _sent = stream.write_all(b"\r\n");
+                let _flushed = stream.flush();
+            }
+
+            let _sent = stream.write_all(b"0\r\n\r\n");
+            let _flushed = stream.flush();
         })
     }
 }


### PR DESCRIPTION
Adds local A2A task-ownership routing to the a2a filter. When task routing is enabled, Praxis records which backend cluster created a task from SendMessage JSON responses and routes follow-up task operations back to that cluster through a reserved internal header and the existing router.

  When an A2A `SendMessage` response creates a task, the `a2a` filter records which backend cluster produced that task. Follow-up task operations such as `GetTask`, `CancelTask`, `SubscribeToTask`, and push-notification config methods can then be routed back to the owning backend by injecting a reserved internal route header before the `router` filter runs.

  This PR adds:

  - `task_routing` config for the existing `a2a` filter
  - In-process `LocalTaskRouteStore` with TTL and terminal-task TTL support
  - Response-body task route capture for successful non-SSE `SendMessage` responses
  - Follow-up task route lookup by task ID
  - Reserved internal route header injection on lookup hit
  - Route-miss behavior that continues to normal router fallback
  - Spoofing protection by requiring route headers to use the reserved `x-praxis-a2a-*` namespace
  - Bounded byte-safe response accumulation using hex scratch storage in `filter_metadata`
  - Oversized response handling that skips capture and passes the response through unchanged
  - Lazy expiry cleanup for stale task routes
  - Example config for A2A task routing

  ## Behavior

  With task routing enabled:

  1. A client sends `SendMessage`.
  2. Praxis routes the initial request normally, typically by method or path.
  3. The selected backend returns a JSON-RPC response containing a task ID.
  4. The `a2a` filter captures `task_id -> cluster` locally.
  5. A later `GetTask` or `CancelTask` request for that task injects `x-praxis-a2a-route-cluster`.
  6. The `router` can match that internal header and send the request back to the task-owning backend.

  ### Streaming Scope

  SSE/streaming responses pass through unchanged. That behavior is already supported by the existing A2A classifier path and is not changed by this PR.

  This PR intentionally captures task IDs only from non-streaming `SendMessage` JSON responses. It does not capture task ownership from `SendStreamingMessage` yet, because that requires incrementally parsing SSE frames across chunked response bodies while preserving the response bytes exactly. Streaming task-route capture is planned as a follow-up PR stack mapped out in the [agentic stack protocol epic](https://github.com/praxis-proxy/ai/issues/148#issuecomment-4368239729).

Until that follow-up lands, a streaming `SendStreamingMessage` can create a task on the backend, but Praxis will not learn task ownership from the SSE stream. A later `GetTask` for that task will therefore follow the router’s static fallback route unless some other route rule matches it.

  ## Manual Validation

  A manual curl-based demo for reviewers  is available [here](https://github.com/nerdalert/praxis-research-spikes/blob/main/demo/a2a-task-routing/demo-output.md)

  The demo runs Praxis in front of two A2A demo agents and verifies:

  - `SendMessage` routes to `agent-a`
  - Praxis captures the returned task ID and owning cluster
  - follow-up `GetTask` for that task routes back to `agent-a`
  - unknown `GetTask` falls through to `agent-b`
  - client spoofing of `x-praxis-a2a-route-cluster` is rejected
  - streaming/SSE pass-through remains unchanged, with streaming task capture deferred to the follow-up PR

  ## Safety

  - Client-supplied reserved internal headers are rejected before routing.
  - `task_routing.route_cluster_header` must use the `x-praxis-a2a-` prefix.
  - Response capture is bounded by `max_response_body_bytes`.
  - Oversized responses continue through the proxy unchanged and do not create task routes.
  - Response body accumulation is byte-safe across arbitrary HTTP chunk boundaries.
  - Invalid JSON or message-only responses do not create task routes.

  ## Tests

  Added unit coverage for:

  - Task routing config defaults and validation
  - Reserved route header validation
  - Route lookup hit/miss behavior
  - Route metadata on hit
  - Task route store TTL, lazy expiry, terminal removal, replacement, and invalid IDs
  - Task route extraction from A2A task response shapes
  - Routable vs non-routable A2A methods
  - Mixed-case SSE content type handling
  - Oversized response pass-through
  - Multibyte UTF-8 split across chunks

  Added integration coverage for:

  - Capture from `SendMessage`, then route `GetTask` back to the creating backend
  - Message-only responses not creating task routes
  - Lookup miss falling through to router fallback
  - Client spoofing of the internal route header being rejected
  - Chunked JSON response capture
  - SSE pass-through with task routing enabled
  - Example config validation and routing behavior

  ## References

  Refs praxis-proxy/ai#148
  Refs praxis-proxy/ai#213