### PR TITLE
feat: add shared IdGenerator with per-instance entropy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2505,6 +2505,7 @@ dependencies = [
  "dashmap",
  "pingora-core",
  "praxis-proxy-tls",
+ "rand 0.9.4",
  "regex",
  "serde",
  "thiserror 2.0.18",

--- a/benchmarks/microbenchmarks/common.rs
+++ b/benchmarks/microbenchmarks/common.rs
@@ -10,8 +10,14 @@
     reason = "benchmarks"
 )]
 
+use std::sync::LazyLock;
+
 use http::{HeaderMap, Method, Uri};
+use praxis_core::id::IdGenerator;
 use praxis_filter::{HttpFilterContext, Request};
+
+/// Deterministic ID generator for benchmarks.
+static BENCH_ID_GENERATOR: LazyLock<IdGenerator> = LazyLock::new(|| IdGenerator::with_seed(0));
 
 // -----------------------------------------------------------------------------
 // Tokio Runtime
@@ -45,6 +51,7 @@ pub(crate) fn make_ctx(req: &Request) -> HttpFilterContext<'_> {
         filter_metadata: std::collections::HashMap::new(),
         filter_results: std::collections::HashMap::new(),
         health_registry: None,
+        id_generator: &BENCH_ID_GENERATOR,
         kv_stores: None,
         request: req,
         request_body_bytes: 0,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 dashmap = { workspace = true }
 pingora-core = { workspace = true }
 praxis-tls = { workspace = true }
+rand = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }

--- a/core/src/id.rs
+++ b/core/src/id.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis contributors
+
+//! Per-instance request ID generation.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::time::TimeSource;
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// Mask for the lower 48 bits of the counter.
+const COUNTER_MASK: u64 = 0xFFFF_FFFF_FFFF; // 2^48 - 1
+
+// -----------------------------------------------------------------------------
+// IdGenerator
+// -----------------------------------------------------------------------------
+
+/// Generates 32-character hex request IDs with per-instance entropy.
+///
+/// Combines a wall-clock timestamp (microseconds since epoch), a
+/// random 16-bit seed (set once at construction), and a 48-bit
+/// monotone counter to produce IDs that are probabilistically
+/// unique across instances.
+///
+/// ```
+/// use std::time::Duration;
+///
+/// use praxis_core::{id::IdGenerator, time::FixedTimeSource};
+///
+/// let generator = IdGenerator::with_seed(0x1234);
+/// let ts = FixedTimeSource::new(Duration::from_micros(1));
+/// let id = generator.generate(&ts);
+/// assert_eq!(id.len(), 32);
+/// ```
+pub struct IdGenerator {
+    /// Monotone counter for the sequential component.
+    counter: AtomicU64,
+
+    /// Random per-instance seed for cross-instance uniqueness.
+    seed: u16,
+}
+
+impl Default for IdGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IdGenerator {
+    /// Create a generator with a random seed.
+    ///
+    /// The seed is drawn from the OS random number generator
+    /// via [`rand::random`]. Panics only if the OS entropy
+    /// source is unavailable, which indicates a fundamentally
+    /// broken environment.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            counter: AtomicU64::new(0),
+            seed: rand::random(),
+        }
+    }
+
+    /// Create a generator with a fixed seed for deterministic tests.
+    #[must_use]
+    pub fn with_seed(seed: u16) -> Self {
+        Self {
+            counter: AtomicU64::new(0),
+            seed,
+        }
+    }
+
+    /// Generate a 32-character hex request ID.
+    ///
+    /// Format: `{micros:016x}{seed:04x}{counter:012x}`
+    ///
+    /// - Bits 127-64: microseconds since epoch
+    /// - Bits 63-48: per-instance seed
+    /// - Bits 47-0: monotone counter (masked to 48 bits)
+    #[must_use]
+    pub fn generate(&self, time_source: &dyn TimeSource) -> String {
+        #[allow(clippy::cast_possible_truncation, reason = "clamped to u64::MAX before cast")]
+        let micros = time_source.now().as_micros().min(u128::from(u64::MAX)) as u64;
+
+        let seq = self.counter.fetch_add(1, Ordering::Relaxed) & COUNTER_MASK;
+
+        format!("{micros:016x}{:04x}{seq:012x}", self.seed)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use crate::time::FixedTimeSource;
+
+    #[test]
+    fn deterministic_output_with_fixed_seed() {
+        let generator = IdGenerator::with_seed(0xABCD);
+        let ts = FixedTimeSource::new(Duration::from_micros(0x0011_2233_4455_6677));
+        let id = generator.generate(&ts);
+        assert_eq!(
+            id, "0011223344556677abcd000000000000",
+            "fixed seed + fixed time should produce a known ID"
+        );
+    }
+
+    #[test]
+    fn consecutive_ids_differ() {
+        let generator = IdGenerator::with_seed(0);
+        let ts = FixedTimeSource::new(Duration::from_secs(1_700_000_000));
+        let id1 = generator.generate(&ts);
+        let id2 = generator.generate(&ts);
+        assert_ne!(id1, id2, "consecutive IDs must differ");
+    }
+
+    #[test]
+    fn ids_are_32_chars() {
+        let generator = IdGenerator::with_seed(0);
+        let ts = FixedTimeSource::new(Duration::from_secs(1_700_000_000));
+        let id = generator.generate(&ts);
+        assert_eq!(id.len(), 32, "ID must be 32 hex characters");
+    }
+
+    #[test]
+    fn different_seeds_produce_different_ids() {
+        let ts = FixedTimeSource::new(Duration::from_secs(1_700_000_000));
+        let generator_a = IdGenerator::with_seed(1);
+        let generator_b = IdGenerator::with_seed(2);
+        let id_a = generator_a.generate(&ts);
+        let id_b = generator_b.generate(&ts);
+        assert_ne!(
+            id_a, id_b,
+            "same timestamp + same counter but different seeds must differ"
+        );
+    }
+
+    #[test]
+    fn counter_masks_to_48_bits() {
+        let generator = IdGenerator::with_seed(0);
+        let ts = FixedTimeSource::new(Duration::from_secs(0));
+
+        // Advance counter past 48-bit boundary
+        generator.counter.store(COUNTER_MASK, Ordering::Relaxed);
+        let id = generator.generate(&ts);
+
+        // Counter should be COUNTER_MASK (all 1s in 48 bits)
+        assert!(
+            id.ends_with("ffffffffffff"),
+            "counter at 48-bit max should show 12 hex f's, got: {id}"
+        );
+
+        // Next generate wraps to 0
+        let id_next = generator.generate(&ts);
+        assert!(
+            id_next.ends_with("000000000000"),
+            "counter past 48-bit max should wrap to zero, got: {id_next}"
+        );
+    }
+
+    #[test]
+    fn new_creates_with_random_seed() {
+        let generator = IdGenerator::new();
+        let ts = FixedTimeSource::new(Duration::from_secs(1_700_000_000));
+        let id = generator.generate(&ts);
+        assert_eq!(id.len(), 32, "new() generator should produce 32-char IDs");
+    }
+}

--- a/core/src/id.rs
+++ b/core/src/id.rs
@@ -77,9 +77,9 @@ impl IdGenerator {
     ///
     /// Format: `{micros:016x}{seed:04x}{counter:012x}`
     ///
-    /// - Bits 127-64: microseconds since epoch
-    /// - Bits 63-48: per-instance seed
-    /// - Bits 47-0: monotone counter (masked to 48 bits)
+    /// - Chars 0-15: microseconds since epoch (64-bit)
+    /// - Chars 16-19: per-instance seed (16-bit)
+    /// - Chars 20-31: monotone counter (48-bit, masked)
     #[must_use]
     pub fn generate(&self, time_source: &dyn TimeSource) -> String {
         #[allow(clippy::cast_possible_truncation, reason = "clamped to u64::MAX before cast")]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,6 +13,8 @@ pub mod connectivity;
 pub mod errors;
 /// Shared health state types for active health checking.
 pub mod health;
+/// Per-instance request ID generation.
+pub mod id;
 /// Key-value store trait and registry.
 pub mod kv;
 /// Tracing subscriber setup.

--- a/filter/src/builtins/http/observability/request_id.rs
+++ b/filter/src/builtins/http/observability/request_id.rs
@@ -3,13 +3,7 @@
 
 //! Request correlation ID filter.
 
-use std::{
-    borrow::Cow,
-    sync::{
-        Arc,
-        atomic::{AtomicU64, Ordering},
-    },
-};
+use std::{borrow::Cow, sync::Arc};
 
 use async_trait::async_trait;
 use serde::Deserialize;
@@ -69,9 +63,6 @@ fn default_header_name() -> String {
 /// assert_eq!(filter.name(), "request_id");
 /// ```
 pub struct RequestIdFilter {
-    /// Monotone counter for the sequential component of generated IDs.
-    counter: AtomicU64,
-
     /// Header name used for reading, generating, and forwarding the ID.
     header_name: Arc<str>,
 }
@@ -88,23 +79,8 @@ impl RequestIdFilter {
         let cfg: RequestIdFilterConfig = parse_filter_config("request_id", config)?;
 
         Ok(Box::new(Self {
-            counter: AtomicU64::new(0),
             header_name: Arc::from(cfg.header_name.as_str()),
         }))
-    }
-
-    /// Generate a new request ID.
-    ///
-    /// Combines the current time in microseconds with a per-instance
-    /// monotone counter. Not cryptographically random but unique
-    /// within a filter instance for any realistic request rate.
-    fn generate_id(&self, time_source: &dyn praxis_core::time::TimeSource) -> String {
-        #[allow(clippy::cast_possible_truncation, reason = "micros fit u64")]
-        let micros = time_source.now().as_micros().min(u128::from(u64::MAX)) as u64;
-
-        let seq = self.counter.fetch_add(1, Ordering::Relaxed);
-
-        format!("{micros:016x}{seq:016x}")
     }
 
     /// Resolve the request ID to echo on the response.
@@ -163,7 +139,7 @@ impl HttpFilter for RequestIdFilter {
             .headers
             .get(&*self.header_name)
             .and_then(|v| v.to_str().ok())
-            .map_or_else(|| self.generate_id(ctx.time_source), str::to_owned);
+            .map_or_else(|| ctx.id_generator.generate(ctx.time_source), str::to_owned);
 
         debug!(request_id = %id, header = %self.header_name, "forwarding request ID");
 
@@ -302,27 +278,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn generated_ids_are_unique() {
-        let ts = praxis_core::time::FixedTimeSource::new(std::time::Duration::from_secs(1_700_000_000));
-        let filter = make_filter("");
-        let id1 = filter.generate_id(&ts);
-        let id2 = filter.generate_id(&ts);
-        assert_ne!(id1, id2, "consecutive generated IDs must be unique");
-    }
-
-    #[test]
-    fn generate_id_uses_time_source() {
-        let ts = praxis_core::time::FixedTimeSource::new(std::time::Duration::from_micros(0x0011_2233_4455_6677));
-        let filter = make_filter("");
-        let id = filter.generate_id(&ts);
-        assert!(
-            id.starts_with("00112233"),
-            "ID should start with hex-encoded fixed micros, got: {id}"
-        );
-        assert_eq!(id.len(), 32, "generated ID should be 32 hex chars");
-    }
-
     // -------------------------------------------------------------------------
     // Test Utilities
     // -------------------------------------------------------------------------
@@ -332,7 +287,6 @@ mod tests {
         let config: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
         let cfg: RequestIdFilterConfig = parse_filter_config("request_id", &config).unwrap();
         RequestIdFilter {
-            counter: AtomicU64::new(0),
             header_name: Arc::from(cfg.header_name.as_str()),
         }
     }

--- a/filter/src/context.rs
+++ b/filter/src/context.rs
@@ -6,7 +6,9 @@
 use std::{borrow::Cow, collections::HashMap, net::IpAddr, sync::Arc, time::Instant};
 
 use http::{HeaderMap, Method, StatusCode, Uri};
-use praxis_core::{connectivity::Upstream, health::HealthRegistry, kv::KvStoreRegistry, time::TimeSource};
+use praxis_core::{
+    connectivity::Upstream, health::HealthRegistry, id::IdGenerator, kv::KvStoreRegistry, time::TimeSource,
+};
 
 use crate::{body::BodyMode, pipeline::body::merge_body_mode, results::FilterResultSet};
 
@@ -78,6 +80,9 @@ pub struct HttpFilterContext<'a> {
 
     /// Shared health registry for endpoint health lookups.
     pub health_registry: Option<&'a HealthRegistry>,
+
+    /// Shared request ID generator.
+    pub id_generator: &'a IdGenerator,
 
     /// Named key-value stores for runtime mappings.
     pub kv_stores: Option<&'a KvStoreRegistry>,

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -241,9 +241,15 @@ mod macro_tests {
 #[cfg(test)]
 #[allow(clippy::expect_used, reason = "test utilities")]
 pub(crate) mod test_utils {
+    use std::sync::LazyLock;
+
     use http::{HeaderMap, Method, Uri};
+    use praxis_core::id::IdGenerator;
 
     use crate::{HttpFilterContext, Request};
+
+    /// Deterministic ID generator for tests (seed=0).
+    static TEST_ID_GENERATOR: LazyLock<IdGenerator> = LazyLock::new(|| IdGenerator::with_seed(0));
 
     pub(crate) fn make_request(method: Method, path: &str) -> Request {
         Request {
@@ -267,6 +273,7 @@ pub(crate) mod test_utils {
             filter_metadata: std::collections::HashMap::new(),
             filter_results: std::collections::HashMap::new(),
             health_registry: None,
+            id_generator: &TEST_ID_GENERATOR,
             kv_stores: None,
             request: req,
             request_body_bytes: 0,

--- a/filter/src/pipeline/build.rs
+++ b/filter/src/pipeline/build.rs
@@ -5,7 +5,7 @@
 
 use std::{collections::HashMap, mem, sync::Arc};
 
-use praxis_core::{config::FilterEntry, time::SystemTimeSource};
+use praxis_core::{config::FilterEntry, id::IdGenerator, time::SystemTimeSource};
 use tracing::{debug, warn};
 
 use super::{FilterPipeline, body::compute_body_capabilities, filter::PipelineFilter};
@@ -52,6 +52,7 @@ impl FilterPipeline {
             compression,
             filters,
             health_registry: None,
+            id_generator: Arc::new(IdGenerator::new()),
             kv_stores: None,
             time_source: Arc::new(SystemTimeSource),
         })
@@ -82,6 +83,7 @@ impl FilterPipeline {
             compression,
             filters,
             health_registry: None,
+            id_generator: Arc::new(IdGenerator::new()),
             kv_stores: None,
             time_source: Arc::new(SystemTimeSource),
         })

--- a/filter/src/pipeline/mod.rs
+++ b/filter/src/pipeline/mod.rs
@@ -36,6 +36,7 @@ use std::sync::Arc;
 use praxis_core::{
     config::{ABSOLUTE_MAX_BODY_BYTES, FailureMode, InsecureOptions},
     health::HealthRegistry,
+    id::IdGenerator,
     kv::KvStoreRegistry,
     time::TimeSource,
 };
@@ -73,6 +74,9 @@ pub struct FilterPipeline {
 
     /// Shared health registry for endpoint health lookups.
     health_registry: Option<HealthRegistry>,
+
+    /// Shared ID generator for request correlation IDs.
+    id_generator: Arc<IdGenerator>,
 
     /// Named key-value stores for runtime mappings.
     kv_stores: Option<KvStoreRegistry>,
@@ -168,6 +172,16 @@ impl FilterPipeline {
     /// The shared health registry, if set.
     pub fn health_registry(&self) -> Option<&HealthRegistry> {
         self.health_registry.as_ref()
+    }
+
+    /// The shared request ID generator.
+    pub fn id_generator(&self) -> &IdGenerator {
+        &self.id_generator
+    }
+
+    /// Override the [`IdGenerator`] for this pipeline.
+    pub fn set_id_generator(&mut self, generator: Arc<IdGenerator>) {
+        self.id_generator = generator;
     }
 
     /// The shared KV store registry, if set.

--- a/filter/src/pipeline/tcp.rs
+++ b/filter/src/pipeline/tcp.rs
@@ -444,6 +444,7 @@ mod tests {
             compression: None,
             filters,
             health_registry: None,
+            id_generator: Arc::new(praxis_core::id::IdGenerator::with_seed(0)),
             kv_stores: None,
             time_source: Arc::new(praxis_core::time::SystemTimeSource),
         }

--- a/filter/src/pipeline/tests.rs
+++ b/filter/src/pipeline/tests.rs
@@ -639,6 +639,7 @@ fn apply_body_limits_no_limits_leaves_stream_mode() {
         compression: None,
         filters: vec![],
         health_registry: None,
+        id_generator: Arc::new(praxis_core::id::IdGenerator::with_seed(0)),
         kv_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
@@ -672,6 +673,7 @@ fn apply_body_limits_converts_default_stream_to_size_limit() {
         compression: None,
         filters: vec![],
         health_registry: None,
+        id_generator: Arc::new(praxis_core::id::IdGenerator::with_seed(0)),
         kv_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
@@ -714,6 +716,7 @@ fn apply_body_limits_preserves_filter_declared_stream() {
         compression: None,
         filters: vec![],
         health_registry: None,
+        id_generator: Arc::new(praxis_core::id::IdGenerator::with_seed(0)),
         kv_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
@@ -1287,6 +1290,7 @@ fn apply_body_limits_default_stream_becomes_size_limit() {
         compression: None,
         filters: vec![],
         health_registry: None,
+        id_generator: Arc::new(praxis_core::id::IdGenerator::with_seed(0)),
         kv_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
@@ -1313,6 +1317,7 @@ fn apply_body_limits_filter_stricter_than_config() {
         compression: None,
         filters: vec![],
         health_registry: None,
+        id_generator: Arc::new(praxis_core::id::IdGenerator::with_seed(0)),
         kv_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
@@ -1336,6 +1341,7 @@ fn apply_body_limits_config_stricter_than_filter() {
         compression: None,
         filters: vec![],
         health_registry: None,
+        id_generator: Arc::new(praxis_core::id::IdGenerator::with_seed(0)),
         kv_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
@@ -1359,6 +1365,7 @@ fn apply_body_limits_rejects_unbounded_stream_buffer() {
         compression: None,
         filters: vec![],
         health_registry: None,
+        id_generator: Arc::new(praxis_core::id::IdGenerator::with_seed(0)),
         kv_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
@@ -1381,6 +1388,7 @@ fn apply_body_limits_clamps_unbounded_stream_buffer_with_override() {
         compression: None,
         filters: vec![],
         health_registry: None,
+        id_generator: Arc::new(praxis_core::id::IdGenerator::with_seed(0)),
         kv_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
@@ -1596,6 +1604,7 @@ async fn skip_to_excludes_skipped_filters_from_response() {
         compression: None,
         filters: vec![filter_a, filter_b, filter_c],
         health_registry: None,
+        id_generator: Arc::new(praxis_core::id::IdGenerator::with_seed(0)),
         kv_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
@@ -1640,6 +1649,7 @@ async fn all_executed_filters_run_on_response() {
             ),
         ],
         health_registry: None,
+        id_generator: Arc::new(praxis_core::id::IdGenerator::with_seed(0)),
         kv_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
@@ -1691,6 +1701,7 @@ async fn skipped_filter_skips_its_branches() {
         compression: None,
         filters: vec![parent],
         health_registry: None,
+        id_generator: Arc::new(praxis_core::id::IdGenerator::with_seed(0)),
         kv_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     };
@@ -2740,6 +2751,7 @@ fn make_pipeline(filters: Vec<Box<dyn HttpFilter>>) -> FilterPipeline {
         compression: None,
         filters,
         health_registry: None,
+        id_generator: Arc::new(praxis_core::id::IdGenerator::with_seed(0)),
         kv_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     }
@@ -2760,6 +2772,7 @@ fn make_pipeline_with_conditions(
         compression: None,
         filters,
         health_registry: None,
+        id_generator: Arc::new(praxis_core::id::IdGenerator::with_seed(0)),
         kv_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     }
@@ -2780,6 +2793,7 @@ fn make_pipeline_with_response_conditions(
         compression: None,
         filters,
         health_registry: None,
+        id_generator: Arc::new(praxis_core::id::IdGenerator::with_seed(0)),
         kv_stores: None,
         time_source: Arc::new(praxis_core::time::SystemTimeSource),
     }

--- a/protocol/src/http/pingora/context.rs
+++ b/protocol/src/http/pingora/context.rs
@@ -207,6 +207,7 @@ macro_rules! filter_context {
             filter_metadata: std::mem::take(&mut $ctx.filter_metadata),
             filter_results: std::mem::take(&mut $ctx.filter_results),
             health_registry: $pipeline.health_registry(),
+            id_generator: $pipeline.id_generator(),
             kv_stores: $pipeline.kv_stores(),
             request: $request,
             request_body_bytes: $ctx.request_body_bytes,

--- a/tests/fuzz/fuzz_targets/fuzz_filter_pipeline.rs
+++ b/tests/fuzz/fuzz_targets/fuzz_filter_pipeline.rs
@@ -1,7 +1,13 @@
 #![no_main]
 
+use std::sync::LazyLock;
+
 use libfuzzer_sys::fuzz_target;
+use praxis_core::id::IdGenerator;
 use praxis_filter::{FailureMode, FilterEntry, FilterPipeline, FilterRegistry};
+
+/// Deterministic ID generator for fuzz targets.
+static FUZZ_ID_GENERATOR: LazyLock<IdGenerator> = LazyLock::new(|| IdGenerator::with_seed(0));
 
 fuzz_target!(|data: &str| {
     let registry = FilterRegistry::with_builtins();
@@ -58,6 +64,7 @@ fuzz_target!(|data: &str| {
             filter_metadata: std::collections::HashMap::new(),
             filter_results: std::collections::HashMap::new(),
             health_registry: None,
+            id_generator: &FUZZ_ID_GENERATOR,
             kv_stores: None,
             request: &request,
             request_body_bytes: 0,


### PR DESCRIPTION
## Summary

Introduces an `IdGenerator` in `praxis-core` that combines a wall-clock timestamp, a random 16-bit seed, and a 48-bit atomic counter to produce 32-character hex request IDs that are probabilistically unique across multiple Praxis instances.

- `IdGenerator` struct in `core/src/id.rs` with `new()` (random seed via `rand`), `with_seed()` (deterministic), and `generate()` (32-char hex)
- Injected through `FilterPipeline` → `HttpFilterContext` → `filter_context!` macro, same pattern as `TimeSource`
- `RequestIdFilter` drops its own `AtomicU64` counter and delegates to `ctx.id_generator.generate(ctx.time_source)`
- 6 unit tests covering deterministic output, counter masking, seed uniqueness, and 48-bit wrap

## Test plan

- [x] `cargo test -p praxis-proxy-core -- id` — 6 unit tests + doctest
- [x] `cargo test -p praxis-proxy-filter -- request_id` — 6 remaining filter tests
- [x] `make lint` — clean
- [x] `make doc` — clean
- [x] `cargo check --workspace` — clean

Closes praxis-proxy/ai#219