### PR TITLE
fix: nightly rustfmt formatting and should_stop_early test

### DIFF
--- a/filter/src/builtins/http/traffic_management/router/tests.rs
+++ b/filter/src/builtins/http/traffic_management/router/tests.rs
@@ -693,7 +693,8 @@ fn update_best_match_keeps_current_when_dominated() {
 fn should_stop_early_true_when_prefix_shorter_than_best() {
     let best_route = prefix_route("/api/v2/", "best");
     let shorter = prefix_route("/api/", "shorter");
-    let best = Some(((false, best_route.path_match.len(), 0), &best_route));
+    let best_specificity = crate::path_match::path_prefix_specificity("/api/v2/");
+    let best = Some(((false, best_specificity, 0), &best_route));
     assert!(
         should_stop_early(best, &shorter),
         "should stop when current route prefix is shorter than best"
@@ -704,7 +705,8 @@ fn should_stop_early_true_when_prefix_shorter_than_best() {
 fn should_stop_early_false_when_prefix_equal_to_best() {
     let best_route = prefix_route("/api/", "best");
     let same = prefix_route("/api/", "same");
-    let best = Some(((false, best_route.path_match.len(), 0), &best_route));
+    let best_specificity = crate::path_match::path_prefix_specificity("/api/");
+    let best = Some(((false, best_specificity, 0), &best_route));
     assert!(
         !should_stop_early(best, &same),
         "should not stop when prefix lengths are equal"

--- a/filter/src/builtins/http/traffic_management/router/tests.rs
+++ b/filter/src/builtins/http/traffic_management/router/tests.rs
@@ -724,7 +724,10 @@ fn should_stop_early_false_when_no_best() {
 fn prefix_without_trailing_slash_accepted() {
     let router = make_router(vec![prefix_route("/api", "api"), prefix_route("/", "default")]);
     let route = router.match_route("/api/v1", None, &HeaderMap::new()).unwrap();
-    assert_eq!(&*route.cluster, "api", "/api/v1 should match /api prefix without trailing slash");
+    assert_eq!(
+        &*route.cluster, "api",
+        "/api/v1 should match /api prefix without trailing slash"
+    );
 }
 
 #[test]

--- a/filter/src/path_match.rs
+++ b/filter/src/path_match.rs
@@ -97,13 +97,7 @@ mod tests {
     /// matches paths whose second byte is `/`.
     #[test]
     fn double_slash_prefix() {
-        assert!(
-            !path_prefix_matches("/foo", "//"),
-            "/foo must not match // prefix"
-        );
-        assert!(
-            path_prefix_matches("//bar", "//"),
-            "//bar should match // prefix"
-        );
+        assert!(!path_prefix_matches("/foo", "//"), "/foo must not match // prefix");
+        assert!(path_prefix_matches("//bar", "//"), "//bar should match // prefix");
     }
 }


### PR DESCRIPTION
## Summary

Two fixes for main CI:

1. **Nightly rustfmt formatting** — `assert!`/`assert_eq!` macros reformatted by updated nightly `rustfmt`
2. **`should_stop_early` test regression from #382** — tests constructed best-match specificity using `path_match.len()` but #382 changed `should_stop_early` to use `path_prefix_specificity()` which strips trailing slashes. `/api/` had length 5 in the test but specificity 4 in the implementation, causing the equal-length assertion to fail.

## Test plan

- [x] `make fmt && make lint` pass
- [x] All 1489 filter unit tests pass
- [x] `should_stop_early` tests pass with corrected specificity values