### PR TITLE
fix(ci): skip How? check for renamed proposal files

### DIFF
--- a/.github/workflows/conventions.yaml
+++ b/.github/workflows/conventions.yaml
@@ -388,9 +388,9 @@ jobs:
             fi
 
             if [ "$status" = "added" ]; then
-              basename=$(basename "$file" .md | sed 's/^[0-9]*_//')
-              renamed_from=$(echo "$proposal_files" | jq -r --arg b "$basename" \
-                '[.[] | select(.status == "removed") | select(.filename | test($b))] | length')
+              proposal_name=$(basename "$file" .md | sed 's/^[0-9][0-9]*_//')
+              renamed_from=$(echo "$proposal_files" | jq -r --arg b "$proposal_name" \
+                '[.[] | select(.status == "removed") | select(.filename | endswith($b + ".md"))] | length')
               if [ "$renamed_from" -eq 0 ]; then
                 if echo "$content" | grep -qF '## How?'; then
                   errors="${errors}\n- \`${file}\`: new proposals must not include the \`## How?\` section in the first PR. Submit What? and Why? first; add How? in a follow-up."

--- a/.github/workflows/conventions.yaml
+++ b/.github/workflows/conventions.yaml
@@ -388,8 +388,13 @@ jobs:
             fi
 
             if [ "$status" = "added" ]; then
-              if echo "$content" | grep -qF '## How?'; then
-                errors="${errors}\n- \`${file}\`: new proposals must not include the \`## How?\` section in the first PR. Submit What? and Why? first; add How? in a follow-up."
+              basename=$(basename "$file" .md | sed 's/^[0-9]*_//')
+              renamed_from=$(echo "$proposal_files" | jq -r --arg b "$basename" \
+                '[.[] | select(.status == "removed") | select(.filename | test($b))] | length')
+              if [ "$renamed_from" -eq 0 ]; then
+                if echo "$content" | grep -qF '## How?'; then
+                  errors="${errors}\n- \`${file}\`: new proposals must not include the \`## How?\` section in the first PR. Submit What? and Why? first; add How? in a follow-up."
+                fi
               fi
             fi
           done < <(echo "$proposal_files" | jq -r '.[].filename')


### PR DESCRIPTION
## Summary

When a proposal file is renamed (e.g. `xxxxx_` → `00484_` after an issue is created), git reports the new filename as `added` and the old as `removed`. The `proposal-check` CI job treated this as a brand-new proposal and rejected it for containing `## How?`.

Now checks if a file with the same basename was removed in the same PR before flagging — a rename is not a new proposal.

Triggered by praxis-proxy/praxis#425 which renames the Anthropic Messages API proposal after creating praxis-proxy/ai#103.

## Test plan

- [x] praxis-proxy/praxis#425 currently fails `proposal-check` due to this bug
- [ ] After merge, re-run praxis-proxy/praxis#425 CI to confirm it passes