### PR TITLE
fix(ci): skip removed files in proposal-check

### DIFF
--- a/.github/workflows/conventions.yaml
+++ b/.github/workflows/conventions.yaml
@@ -366,6 +366,10 @@ jobs:
           while IFS= read -r file; do
             status=$(echo "$proposal_files" | jq -r --arg f "$file" '.[] | select(.filename == $f) | .status')
 
+            if [ "$status" = "removed" ]; then
+              continue
+            fi
+
             content=$(gh api "repos/${{ github.repository }}/contents/${file}?ref=$HEAD_SHA" \
               --jq '.content' | base64 -d)
 


### PR DESCRIPTION
## Summary

Follow-up to #508. The proposal-check workflow iterates all proposal files in the PR diff, including removed files. When a proposal is renamed (delete old + add new), fetching content for the removed file at HEAD SHA returns 404, causing `base64 -d` to fail.

Fix: skip files with `status: "removed"` since there's nothing to validate on a deleted file.

This is what's blocking #425 from passing CI.

## Test plan

- [ ] #425 passes `proposal-check` after this merges