### PR TITLE
chore(docs): expand CODEOWNERS for AI filter paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,7 @@
 # Experimental AI Filters
 /filter/src/builtins/http/ai/openai/ @leseb @franciscojavierarceo
 /filter/src/builtins/http/ai/anthropic/ @leseb @franciscojavierarceo
+/filter/src/registry.rs @leseb @franciscojavierarceo
+/examples/configs/ai/ @leseb @franciscojavierarceo
+/examples/README.md @leseb @franciscojavierarceo
+/tests/integration/tests/suite/examples/ @leseb @franciscojavierarceo

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 # Experimental AI Filters
 /filter/src/builtins/http/ai/openai/ @leseb @franciscojavierarceo
 /filter/src/builtins/http/ai/anthropic/ @leseb @franciscojavierarceo
+/filter/src/builtins/http/ai/mod.rs @leseb @franciscojavierarceo
 /filter/src/registry.rs @leseb @franciscojavierarceo
 /examples/configs/ai/ @leseb @franciscojavierarceo
 /examples/README.md @leseb @franciscojavierarceo


### PR DESCRIPTION
## Summary
- Add CODEOWNERS entries for AI filter module and registry files, AI example configs, the examples README, and example integration tests under the experimental AI owners.

## Validation
- `pre-commit run --all-files` (not run: repository has no `.pre-commit-config.yaml`)
- `make build lint`
- `git diff --check`