### PR TITLE
docs(filter): add Anthropic Messages API documentation and demo

### DIFF
--- a/docs/anthropic-messages.md
+++ b/docs/anthropic-messages.md
@@ -1,0 +1,285 @@
+# Anthropic Messages API
+
+Praxis supports the Anthropic Messages API
+(`/v1/messages`) through five composable filters.
+Operators can route, validate JSON envelopes, and transform
+Anthropic requests to reach any backend.
+
+## Filters
+
+| Filter | Purpose |
+| ------ | ------- |
+| `anthropic_messages_format` | Classify requests and promote routing facts to headers |
+| `anthropic_validate` | Validate the JSON request envelope before forwarding |
+| `anthropic_messages_protocol` | Header management for native `/v1/messages` backends |
+| `anthropic_to_openai` | Bidirectional body transformation to `OpenAI` Chat Completions |
+| `anthropic_stream_events` | SSE event transformation (per-chunk streaming, conformant with Inference Proxy Conformance Guidelines) |
+
+## Passthrough to vLLM
+
+Route Anthropic requests directly to a backend that
+supports `/v1/messages` natively (e.g. vLLM with
+Anthropic endpoint enabled).
+
+```yaml
+listeners:
+  - name: gateway
+    address: "0.0.0.0:8080"
+    filter_chains: [anthropic]
+
+filter_chains:
+  - name: anthropic
+    filters:
+      - filter: anthropic_messages_format
+        on_invalid: continue
+
+      - filter: anthropic_validate
+
+      - filter: anthropic_messages_protocol
+        default_version: "2023-06-01"
+
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: vllm
+
+      - filter: load_balancer
+        clusters:
+          - name: vllm
+            endpoints:
+              - "127.0.0.1:8000"
+```
+
+Test:
+
+```console
+curl http://localhost:8080/v1/messages \
+  -H "content-type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "openai/gpt-oss-20b",
+    "max_tokens": 100,
+    "system": "Reply concisely.",
+    "messages": [{"role": "user", "content": "Hi"}]
+  }'
+```
+
+## Passthrough to Anthropic API
+
+Route to `api.anthropic.com` with credential
+injection for the `x-api-key` header.
+
+```yaml
+listeners:
+  - name: gateway
+    address: "0.0.0.0:8080"
+    filter_chains: [anthropic]
+
+filter_chains:
+  - name: anthropic
+    filters:
+      - filter: anthropic_messages_format
+        on_invalid: continue
+
+      - filter: anthropic_validate
+
+      - filter: anthropic_messages_protocol
+        default_version: "2023-06-01"
+
+      - filter: headers
+        request_set:
+          - name: Host
+            value: "api.anthropic.com"
+
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: anthropic
+
+      - filter: credential_injection
+        clusters:
+          - name: anthropic
+            header: x-api-key
+            env_var: ANTHROPIC_API_KEY
+            strip_client_credential: true
+
+      - filter: load_balancer
+        clusters:
+          - name: anthropic
+            tls:
+              sni: "api.anthropic.com"
+            endpoints:
+              - "api.anthropic.com:443"
+```
+
+Test:
+
+```console
+curl http://localhost:8080/v1/messages \
+  -H "content-type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "claude-haiku-4-5",
+    "max_tokens": 100,
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+## Transformation to OpenAI Backend
+
+Transform Anthropic requests to OpenAI Chat
+Completions format for backends that only speak
+OpenAI (e.g. llm-d with disaggregation, KServe
+without Anthropic support).
+
+```yaml
+listeners:
+  - name: gateway
+    address: "0.0.0.0:8080"
+    filter_chains: [transform]
+
+filter_chains:
+  - name: transform
+    filters:
+      - filter: anthropic_messages_format
+        on_invalid: continue
+
+      - filter: anthropic_validate
+
+      - filter: anthropic_to_openai
+        max_body_bytes: 1048576
+
+      - filter: anthropic_stream_events
+        response_conditions:
+          - when:
+              headers:
+                content-type: "text/event-stream"
+
+      - filter: path_rewrite
+        replace:
+          pattern: "^/v1/messages$"
+          replacement: "/v1/chat/completions"
+        conditions:
+          - when:
+              path_prefix: "/v1/messages"
+
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: vllm
+
+      - filter: load_balancer
+        clusters:
+          - name: vllm
+            endpoints:
+              - "127.0.0.1:8000"
+```
+
+The `anthropic_to_openai` filter:
+- Hoists `system` to an OpenAI system message
+- Flattens content blocks (text, image, tool_use,
+  tool_result)
+- Maps `stop_sequences` to `stop`,
+  `tool_choice` semantics, tool definitions
+- Preserves `top_k` as an extra body parameter
+- Drops `thinking` blocks with a log warning
+- Transforms the response back to Anthropic format
+- Preserves original `finish_reason` in filter
+  metadata as `openai.finish_reason`
+
+Add `anthropic_stream_events` with a `text/event-stream`
+response condition when the backend may return streaming
+Chat Completions SSE. Keep it response-gated so normal
+JSON responses stay on the buffered `anthropic_to_openai`
+path.
+
+## Filter Configuration Reference
+
+### `anthropic_messages_format`
+
+Classifies requests by body structure, then promotes
+ambiguous `/v1/messages` or `anthropic-version`
+requests to Anthropic Messages when the body otherwise
+looks like Chat Completions.
+
+```yaml
+filter: anthropic_messages_format
+on_invalid: continue      # continue | reject
+max_body_bytes: 1048576    # 1 MiB
+headers:
+  format: x-praxis-ai-format
+  model: x-praxis-ai-model
+  stream: x-praxis-ai-stream
+```
+
+Body classification precedence:
+1. `input` or object-valued `prompt` → OpenAI Responses
+2. `messages` + `max_tokens` + Anthropic structural
+   signals → Anthropic Messages
+3. `messages` alone → OpenAI Chat Completions
+
+`anthropic-version` and `/v1/messages` upgrade only the
+ambiguous Chat Completions result to Anthropic Messages;
+they do not override Responses-shaped bodies.
+
+### `anthropic_validate`
+
+Validates the proxy-owned JSON envelope before forwarding.
+Backend-owned Anthropic semantics such as model availability,
+message shape, role ordering, and token limits are deferred
+to the backend.
+
+```yaml
+filter: anthropic_validate
+max_body_bytes: 1048576    # 1 MiB
+```
+
+Checks: request body is present, valid JSON, and a JSON object.
+
+### `anthropic_messages_protocol`
+
+Injects `anthropic-version` header if absent.
+No body transformation.
+
+```yaml
+filter: anthropic_messages_protocol
+default_version: "2023-06-01"
+```
+
+### `anthropic_to_openai`
+
+Bidirectional request/response transformation.
+Non-streaming only; use `anthropic_stream_events`
+for SSE responses.
+
+```yaml
+filter: anthropic_to_openai
+max_body_bytes: 1048576    # 1 MiB
+```
+
+### `anthropic_stream_events`
+
+Transforms OpenAI SSE chunks to Anthropic SSE
+events. Processes SSE chunks incrementally as they arrive.
+
+```yaml
+filter: anthropic_stream_events
+response_conditions:
+  - when:
+      headers:
+        content-type: "text/event-stream"
+```
+
+## Running with Debug Logging
+
+See filter activity in real time:
+
+```console
+RUST_LOG=debug cargo run -p praxis -- -c config.yaml
+```
+
+Filter-specific logging:
+
+```console
+RUST_LOG=praxis_filter::builtins::http::ai=debug cargo run -p praxis -- -c config.yaml
+```

--- a/examples/demo/anthropic-messages/README.md
+++ b/examples/demo/anthropic-messages/README.md
@@ -1,0 +1,31 @@
+# Anthropic Messages API Demo
+
+Demonstrates routing Anthropic `/v1/messages` requests through Praxis
+to different backends with optional format transformation.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `goals.md` | One-page summary of what this demo covers |
+| `demo.md` | Step-by-step walkthrough with curl commands |
+| `passthrough.yaml` | Config: classify, validate JSON envelopes, route by model to Anthropic API or vLLM |
+| `transform.yaml` | Config: transform Anthropic Messages to OpenAI Chat Completions |
+
+## Quick Start
+
+```bash
+# Passthrough (demos 1-3)
+export ANTHROPIC_API_KEY=sk-ant-...
+RUST_LOG=praxis_filter=debug cargo run -p praxis -- \
+  -c examples/demo/anthropic-messages/passthrough.yaml
+
+# Transform (demo 4)
+RUST_LOG=praxis_filter=debug cargo run -p praxis -- \
+  -c examples/demo/anthropic-messages/transform.yaml
+```
+
+## Prerequisites
+
+- `ANTHROPIC_API_KEY` env var set (for Anthropic API passthrough)
+- vLLM endpoint at `10.0.0.99:8000` (update `passthrough.yaml` / `transform.yaml` for your setup)

--- a/examples/demo/anthropic-messages/demo.md
+++ b/examples/demo/anthropic-messages/demo.md
@@ -1,0 +1,117 @@
+# Anthropic Messages API Filters — Demo
+
+---
+
+## Setup
+
+```
+# Terminal 1 (Praxis logs)
+RUST_LOG=praxis_filter=debug cargo run -p praxis -- -c examples/demo/anthropic-messages/passthrough.yaml 2>&1 \
+  | grep -E 'classified|validation|route matched|upstream selected|credential|transformed|streaming'
+
+# Terminal 2 (curl)
+```
+
+---
+
+## Intro
+
+This is a light demo of the Anthropic Messages API filters in Praxis.
+
+Major caveats that this is still a work in progress and needs more validation,
+but the goal is to show how far we can get with composable filters.
+
+## Goal
+
+Accept Anthropic `/v1/messages` requests and route them to any backend —
+Anthropic API, vLLM, or OpenAI-compatible — with optional format transformation.
+
+There are five composable filters (classify, validate JSON, set protocol headers, transform, stream)
+wired via Praxis' YAML config. And there are no code changes to swap backends.
+
+## 1. Direct to Anthropic (no proxy)
+
+> First, let's hit Anthropic directly to confirm the API works. No proxy involved.
+
+```bash
+curl -s https://api.anthropic.com/v1/messages \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "content-type: application/json" \
+  -d '{
+    "model": "claude-haiku-4-5",
+    "max_tokens": 128,
+    "messages": [{"role": "user", "content": "Why is Red Hat awesome?"}]
+  }' | jq .
+```
+
+---
+
+## 2. Praxis → Anthropic API (/v1/messages passthrough)
+
+> Now the same request goes through Praxis. It classifies the format, validates the JSON envelope, injects credentials, and proxies to Anthropic. Same response, zero changes to the request.
+
+```bash
+curl -s http://127.0.0.1:8080/v1/messages \
+  -H "Host: api.anthropic.com" \
+  -H "content-type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "claude-haiku-4-5",
+    "max_tokens": 128,
+    "messages": [{"role": "user", "content": "Why is Red Hat awesome?"}]
+  }' | jq .
+```
+
+---
+
+## 3. Praxis → vLLM (/v1/messages passthrough)
+
+> Same Anthropic-format request, but now routed to vLLM with gpt-oss 20b. The backend speaks Messages natively — Praxis just forwards it. Different backend, zero code change.
+
+```bash
+curl -s http://127.0.0.1:8080/v1/messages \
+  -H "content-type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "openai/gpt-oss-20b",
+    "max_tokens": 128,
+    "system": "Reply concisely.",
+    "messages": [{"role": "user", "content": "Why is Red Hat awesome?"}]
+  }' | jq .
+```
+
+---
+
+## 4. Praxis → vLLM (/v1/chat/completions transform)
+
+> Now the interesting part. We restart Praxis with a transform config — the transform filter needs body hooks to rewrite request and response payloads, and body hooks don't run inside branch chains, so we swap the config rather than routing conditionally. Same Anthropic request goes in, Praxis transforms it to OpenAI, sends to /v1/chat/completions, and transforms the response back. The client never knows.
+
+```
+# Restart Praxis with the transform config
+RUST_LOG=praxis_filter=debug cargo run -p praxis -- -c examples/demo/anthropic-messages/transform.yaml
+```
+
+```bash
+curl -s http://127.0.0.1:8080/v1/messages \
+  -H "content-type: application/json" \
+  -H "anthropic-version: 2023-06-01" \
+  -d '{
+    "model": "openai/gpt-oss-20b",
+    "max_tokens": 128,
+    "system": "Reply concisely.",
+    "messages": [{"role": "user", "content": "Why is Red Hat awesome?"}]
+  }' | jq .
+```
+
+---
+
+## Filters
+
+| Filter | What it does |
+|--------|-------------|
+| `anthropic_messages_format` | Classify request format |
+| `anthropic_validate` | Validate the JSON request envelope |
+| `anthropic_messages_protocol` | Inject anthropic-version header |
+| `anthropic_to_openai` | Transform request/response body |
+| `anthropic_stream_events` | Per-chunk SSE transformation |

--- a/examples/demo/anthropic-messages/goals.md
+++ b/examples/demo/anthropic-messages/goals.md
@@ -1,0 +1,26 @@
+# Anthropic Messages API in Praxis
+
+## Goal
+
+Accept Anthropic `/v1/messages` requests and route them to any backend —
+Anthropic API, vLLM, or OpenAI-compatible — with optional format transformation.
+
+## Demo
+1. **Direct** — curl → Anthropic API
+2. **Passthrough** — curl → Praxis → Anthropic API (`/v1/messages`)
+3. **vLLM native** — curl → Praxis → vLLM (`/v1/messages`)
+4. **Transform** — curl → Praxis → vLLM (`/v1/chat/completions`, auto-converted)
+
+## How
+Five composable filters — classify, validate JSON, set protocol headers, transform, stream —
+wired via YAML config. No code changes to swap backends.
+
+## Filters
+
+| Filter | What it does |
+|--------|-------------|
+| `anthropic_messages_format` | Classify request format |
+| `anthropic_validate` | Validate the JSON request envelope |
+| `anthropic_messages_protocol` | Inject anthropic-version header |
+| `anthropic_to_openai` | Transform request/response body |
+| `anthropic_stream_events` | Per-chunk SSE transformation |

--- a/examples/demo/anthropic-messages/passthrough.yaml
+++ b/examples/demo/anthropic-messages/passthrough.yaml
@@ -1,0 +1,42 @@
+listeners:
+  - name: gateway
+    address: "127.0.0.1:8080"
+    filter_chains: [anthropic]
+
+filter_chains:
+  - name: anthropic
+    filters:
+      - filter: anthropic_messages_format
+        on_invalid: continue
+
+      - filter: anthropic_validate
+
+      - filter: anthropic_messages_protocol
+        default_version: "2023-06-01"
+
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            headers:
+              x-praxis-ai-model: "claude-haiku-4-5"
+            cluster: anthropic
+          - path_prefix: "/"
+            cluster: vllm
+
+      - filter: credential_injection
+        clusters:
+          - name: anthropic
+            header: x-api-key
+            env_var: ANTHROPIC_API_KEY
+            strip_client_credential: true
+
+      - filter: load_balancer
+        clusters:
+          - name: anthropic
+            endpoints:
+              - "api.anthropic.com:443"
+            tls:
+              sni: "api.anthropic.com"
+          - name: vllm
+            endpoints:
+              - "10.0.0.99:8000"

--- a/examples/demo/anthropic-messages/transform.yaml
+++ b/examples/demo/anthropic-messages/transform.yaml
@@ -1,0 +1,39 @@
+listeners:
+  - name: gateway
+    address: "127.0.0.1:8080"
+    filter_chains: [transform]
+
+filter_chains:
+  - name: transform
+    filters:
+      - filter: anthropic_messages_format
+        on_invalid: continue
+
+      - filter: anthropic_validate
+
+      - filter: anthropic_to_openai
+
+      - filter: anthropic_stream_events
+        response_conditions:
+          - when:
+              headers:
+                content-type: "text/event-stream"
+
+      - filter: path_rewrite
+        replace:
+          pattern: "^/v1/messages$"
+          replacement: "/v1/chat/completions"
+        conditions:
+          - when:
+              path_prefix: "/v1/messages"
+
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: vllm
+
+      - filter: load_balancer
+        clusters:
+          - name: vllm
+            endpoints:
+              - "10.0.0.99:8000"


### PR DESCRIPTION
## Summary

- Adds Anthropic Messages API documentation for native protocol-header and Chat Completions-compatible transform deployments.
- Adds demo walkthrough material and local curl examples for exercising the filters.
- Keeps docs and demo content separate from the functional filter PRs.

Part 7 of the Anthropic Messages API filter stack for epic praxis-proxy/ai#103. Earlier stack layers (#588-#592) are merged; this PR is now a single docs/demo commit over current `main`.

## Review notes

- Scope is documentation and demo guidance only.
- Demo config uses `anthropic_messages_protocol`, and the docs describe `anthropic_validate` as JSON-envelope validation with backend-owned Anthropic semantics deferred to the backend.
- Per-filter example configs and functional example tests live with the corresponding filter PRs.
- The broader OGX-inspired integration coverage is merged in praxis-proxy/praxis#592; functional filter changes are in praxis-proxy/praxis#588-#591.

## Test plan

- [x] Rebased onto current `main`; duplicate stack commits dropped.
- [x] `cargo xtask sync-example-readme`
- [x] `cargo xtask lint-example-tests`
- [x] `make lint`
- [x] `cargo run -p praxis -- -t -c examples/demo/anthropic-messages/passthrough.yaml`
- [x] `cargo run -p praxis -- -t -c examples/demo/anthropic-messages/transform.yaml`
- [x] `cargo test -p praxis-tests-integration --test suite anthropic_messages -- --nocapture`
