### PR TITLE
feat(filter): add RequestExtensions type-map for request-scoped state

### DIFF
--- a/benchmarks/microbenchmarks/common.rs
+++ b/benchmarks/microbenchmarks/common.rs
@@ -45,6 +45,7 @@ pub(crate) fn make_ctx(req: &Request) -> HttpFilterContext<'_> {
         cluster: None,
         current_filter_id: None,
         downstream_tls: false,
+        extensions: praxis_filter::RequestExtensions::default(),
         executed_filter_indices: Vec::new(),
         extra_request_headers: Vec::new(),
         request_headers_to_remove: Vec::new(),

--- a/filter/ext-proc/src/tests.rs
+++ b/filter/ext-proc/src/tests.rs
@@ -2053,6 +2053,7 @@ fn make_ctx(req: &praxis_filter::Request) -> HttpFilterContext<'_> {
         cluster: None,
         current_filter_id: None,
         downstream_tls: false,
+        extensions: praxis_filter::RequestExtensions::default(),
         executed_filter_indices: Vec::new(),
         extra_request_headers: Vec::new(),
         request_headers_to_remove: Vec::new(),

--- a/filter/src/context.rs
+++ b/filter/src/context.rs
@@ -10,7 +10,7 @@ use praxis_core::{
     connectivity::Upstream, health::HealthRegistry, id::IdGenerator, kv::KvStoreRegistry, time::TimeSource,
 };
 
-use crate::{body::BodyMode, pipeline::body::merge_body_mode, results::FilterResultSet};
+use crate::{body::BodyMode, extensions::RequestExtensions, pipeline::body::merge_body_mode, results::FilterResultSet};
 
 // -----------------------------------------------------------------------------
 // HttpFilterContext
@@ -55,6 +55,18 @@ pub struct HttpFilterContext<'a> {
     /// rather than the request URI scheme (which is absent
     /// in HTTP/1.1).
     pub downstream_tls: bool,
+
+    /// Type-safe request-scoped extension container.
+    ///
+    /// Filters store and retrieve arbitrary typed values that
+    /// persist across all Pingora lifecycle phases (request,
+    /// request body, response, response body, logging). Keyed
+    /// by [`TypeId`], so only one value per concrete type. Use
+    /// private newtypes to avoid collisions between independent
+    /// filters.
+    ///
+    /// [`TypeId`]: std::any::TypeId
+    pub extensions: RequestExtensions,
 
     /// Tracks which pipeline filter indices actually executed
     /// during the request phase. The response phase skips

--- a/filter/src/extensions.rs
+++ b/filter/src/extensions.rs
@@ -69,7 +69,7 @@ impl RequestExtensions {
     /// the correct type. The `expect` guards against impossible
     /// `TypeId` collisions in the standard library.
     pub fn get_or_insert_with<T: Send + Sync + 'static>(&mut self, f: impl FnOnce() -> T) -> &mut T {
-        #[allow(clippy::expect_used, reason = "downcast cannot fail after typed insert")]
+        #[expect(clippy::expect_used, reason = "downcast cannot fail after typed insert")]
         self.0
             .entry(std::any::TypeId::of::<T>())
             .or_insert_with(|| Box::new(f()))
@@ -91,6 +91,7 @@ impl RequestExtensions {
 // -----------------------------------------------------------------------------
 
 #[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, reason = "tests")]
 mod tests {
     use super::*;

--- a/filter/src/extensions.rs
+++ b/filter/src/extensions.rs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Type-safe, request-scoped extension container.
+//!
+//! [`RequestExtensions`] is a type-map keyed by [`TypeId`]. Filters
+//! store and retrieve arbitrary typed values that persist across all
+//! Pingora lifecycle phases (request, request body, response,
+//! response body, logging).
+//!
+//! The framework has no knowledge of what filters store in it. The
+//! cost when unused is an empty [`HashMap`] (zero allocations, no
+//! overhead on existing filter chains).
+//!
+//! Only one value per concrete type can be stored. Filters must use
+//! private newtypes for their state, not bare types like
+//! [`serde_json::Value`] or `Vec<String>`, to avoid overwriting
+//! each other's data.
+//!
+//! [`TypeId`]: std::any::TypeId
+
+use std::{any::Any, collections::HashMap};
+
+// -----------------------------------------------------------------------------
+// RequestExtensions
+// -----------------------------------------------------------------------------
+
+/// Type-safe, request-scoped extension container.
+///
+/// Keyed by [`TypeId`], so only one value per concrete type is
+/// stored. Use private newtypes to avoid collisions between
+/// independent filters.
+///
+/// [`TypeId`]: std::any::TypeId
+#[derive(Default)]
+pub struct RequestExtensions(HashMap<std::any::TypeId, Box<dyn Any + Send + Sync>>);
+
+impl RequestExtensions {
+    /// Create an empty extension container.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a typed value, replacing any previous value of the same type.
+    pub fn insert<T: Send + Sync + 'static>(&mut self, val: T) {
+        self.0.insert(std::any::TypeId::of::<T>(), Box::new(val));
+    }
+
+    /// Get a shared reference to a stored value by type.
+    pub fn get<T: Send + Sync + 'static>(&self) -> Option<&T> {
+        self.0
+            .get(&std::any::TypeId::of::<T>())
+            .and_then(|boxed| boxed.downcast_ref())
+    }
+
+    /// Get an exclusive reference to a stored value by type.
+    pub fn get_mut<T: Send + Sync + 'static>(&mut self) -> Option<&mut T> {
+        self.0
+            .get_mut(&std::any::TypeId::of::<T>())
+            .and_then(|boxed| boxed.downcast_mut())
+    }
+
+    /// Get an exclusive reference to a stored value, inserting a
+    /// default computed by `f` if absent.
+    ///
+    /// # Panics
+    ///
+    /// Cannot panic in practice: the value was just inserted with
+    /// the correct type. The `expect` guards against impossible
+    /// `TypeId` collisions in the standard library.
+    pub fn get_or_insert_with<T: Send + Sync + 'static>(&mut self, f: impl FnOnce() -> T) -> &mut T {
+        #[allow(clippy::expect_used, reason = "downcast cannot fail after typed insert")]
+        self.0
+            .entry(std::any::TypeId::of::<T>())
+            .or_insert_with(|| Box::new(f()))
+            .downcast_mut()
+            .expect("type mismatch after insert")
+    }
+
+    /// Remove a stored value by type, returning it if present.
+    pub fn remove<T: Send + Sync + 'static>(&mut self) -> Option<T> {
+        self.0
+            .remove(&std::any::TypeId::of::<T>())
+            .and_then(|boxed| boxed.downcast().ok())
+            .map(|boxed| *boxed)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_empty() {
+        let ext = RequestExtensions::default();
+        assert!(ext.get::<String>().is_none(), "default should contain no values");
+    }
+
+    #[test]
+    fn insert_and_get() {
+        let mut ext = RequestExtensions::new();
+        ext.insert(42u32);
+        assert_eq!(ext.get::<u32>(), Some(&42), "should retrieve inserted value");
+    }
+
+    #[test]
+    fn insert_and_get_mut() {
+        let mut ext = RequestExtensions::new();
+        ext.insert("hello".to_owned());
+        if let Some(val) = ext.get_mut::<String>() {
+            val.push_str(" world");
+        }
+        assert_eq!(
+            ext.get::<String>().map(String::as_str),
+            Some("hello world"),
+            "get_mut should allow mutation"
+        );
+    }
+
+    #[test]
+    fn multiple_types_coexist() {
+        let mut ext = RequestExtensions::new();
+        ext.insert(1u32);
+        ext.insert("text".to_owned());
+        ext.insert(1.5f64);
+        assert_eq!(ext.get::<u32>(), Some(&1), "u32 should be present");
+        assert_eq!(
+            ext.get::<String>().map(String::as_str),
+            Some("text"),
+            "String should be present"
+        );
+        assert_eq!(ext.get::<f64>(), Some(&1.5), "f64 should be present");
+    }
+
+    #[test]
+    fn insert_same_type_overwrites() {
+        let mut ext = RequestExtensions::new();
+        ext.insert(1u32);
+        ext.insert(2u32);
+        assert_eq!(ext.get::<u32>(), Some(&2), "second insert should overwrite first");
+    }
+
+    #[test]
+    fn remove_returns_owned_value() {
+        let mut ext = RequestExtensions::new();
+        ext.insert(99u32);
+        let removed = ext.remove::<u32>();
+        assert_eq!(removed, Some(99), "remove should return the stored value");
+        assert!(ext.get::<u32>().is_none(), "value should be gone after remove");
+    }
+
+    #[test]
+    fn remove_absent_returns_none() {
+        let mut ext = RequestExtensions::new();
+        assert!(ext.remove::<u32>().is_none(), "removing absent type should return None");
+    }
+
+    #[test]
+    fn get_or_insert_with_creates_when_absent() {
+        let mut ext = RequestExtensions::new();
+        let val = ext.get_or_insert_with(|| 42u32);
+        assert_eq!(*val, 42, "should create value when absent");
+    }
+
+    #[test]
+    fn get_or_insert_with_returns_existing() {
+        let mut ext = RequestExtensions::new();
+        ext.insert(10u32);
+        let val = ext.get_or_insert_with(|| 42u32);
+        assert_eq!(*val, 10, "should return existing value without calling factory");
+    }
+
+    #[test]
+    fn get_wrong_type_returns_none() {
+        let mut ext = RequestExtensions::new();
+        ext.insert(42u32);
+        assert!(ext.get::<String>().is_none(), "wrong type should return None");
+    }
+
+    #[test]
+    fn newtypes_are_independent() {
+        struct FilterAState(u32);
+        struct FilterBState(u32);
+
+        let mut ext = RequestExtensions::new();
+        ext.insert(FilterAState(1));
+        ext.insert(FilterBState(2));
+
+        assert_eq!(
+            ext.get::<FilterAState>().map(|s| s.0),
+            Some(1),
+            "FilterAState should be 1"
+        );
+        assert_eq!(
+            ext.get::<FilterBState>().map(|s| s.0),
+            Some(2),
+            "FilterBState should be 2"
+        );
+    }
+}

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -12,6 +12,7 @@ mod body;
 mod builtins;
 mod condition;
 mod context;
+mod extensions;
 mod factory;
 mod filter;
 pub(crate) mod load_balancing;
@@ -43,6 +44,7 @@ pub use builtins::{
 pub use builtins::{TokenUsage, TokenUsageProvider, extract_token_usage};
 pub use condition::{should_execute, should_execute_response, should_execute_response_ref};
 pub use context::{HttpFilterContext, Request, Response};
+pub use extensions::RequestExtensions;
 pub use factory::{FilterFactory, HttpFilterFactory, TcpFilterFactory, http_builtin, parse_filter_config, tcp_builtin};
 pub use filter::{Filter, FilterContext, FilterError, HttpFilter};
 pub use pipeline::FilterPipeline;
@@ -280,6 +282,7 @@ pub(crate) mod test_utils {
             cluster: None,
             current_filter_id: None,
             downstream_tls: false,
+            extensions: crate::extensions::RequestExtensions::default(),
             executed_filter_indices: Vec::new(),
             extra_request_headers: Vec::new(),
             request_headers_to_remove: Vec::new(),

--- a/protocol/src/http/pingora/context.rs
+++ b/protocol/src/http/pingora/context.rs
@@ -66,6 +66,14 @@ pub struct PingoraRequestCtx {
     /// bytes are raw protocol frames (e.g. `WebSocket`), not HTTP bodies.
     pub connection_upgraded: bool,
 
+    /// Type-safe request-scoped extension container. Swapped into each
+    /// [`HttpFilterContext`] and written back after filter execution,
+    /// following the same lifecycle as [`filter_metadata`].
+    ///
+    /// [`HttpFilterContext`]: praxis_filter::HttpFilterContext
+    /// [`filter_metadata`]: PingoraRequestCtx::filter_metadata
+    pub extensions: praxis_filter::RequestExtensions,
+
     /// Durable per-request metadata that persists across all lifecycle
     /// phases. Swapped into each [`HttpFilterContext`] and written back
     /// after filter execution.
@@ -223,6 +231,7 @@ macro_rules! filter_context {
             cluster: $ctx.cluster.take(),
             current_filter_id: None,
             downstream_tls: $ctx.downstream_tls,
+            extensions: std::mem::take(&mut $ctx.extensions),
             executed_filter_indices: Vec::new(),
             extra_request_headers: Vec::new(),
             request_headers_to_remove: Vec::new(),
@@ -373,6 +382,7 @@ impl Default for PingoraRequestCtx {
             cluster: None,
             connection_upgraded: false,
             downstream_tls: false,
+            extensions: praxis_filter::RequestExtensions::new(),
             filter_metadata: std::collections::HashMap::new(),
             mutated_request_body_len: None,
             pinned_pipeline: None,

--- a/protocol/src/http/pingora/handler/mod.rs
+++ b/protocol/src/http/pingora/handler/mod.rs
@@ -549,6 +549,26 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn logging_cleanup_preserves_extensions() {
+        let registry = praxis_filter::FilterRegistry::with_builtins();
+        let pipeline = FilterPipeline::build(&mut [], &registry).unwrap();
+        let mut ctx = PingoraRequestCtx::default();
+        ctx.response_phase_done = false;
+        ctx.extensions.insert(42u32);
+        ctx.request_snapshot = Some(praxis_filter::Request {
+            method: http::Method::POST,
+            uri: "/test".parse().unwrap(),
+            headers: http::HeaderMap::new(),
+        });
+        logging_cleanup(&pipeline, &mut ctx).await;
+        assert_eq!(
+            ctx.extensions.get::<u32>(),
+            Some(&42),
+            "extensions should survive logging_cleanup"
+        );
+    }
+
     #[test]
     fn passive_health_error_is_failure() {
         let (pipeline, ctx) = make_passive_scenario(Some(3), Some(2));

--- a/protocol/src/http/pingora/handler/mod.rs
+++ b/protocol/src/http/pingora/handler/mod.rs
@@ -265,8 +265,10 @@ async fn logging_cleanup(pipeline: &FilterPipeline, ctx: &mut PingoraRequestCtx)
         && let Some(mut filter_ctx) = ctx.filter_context_for(pipeline, None)
     {
         let _result = pipeline.execute_http_response(&mut filter_ctx).await;
+        let extensions = filter_ctx.extensions;
         let metadata = filter_ctx.filter_metadata;
         let state = filter_ctx.filter_state;
+        ctx.extensions = extensions;
         ctx.filter_metadata = metadata;
         ctx.filter_state = state;
     }

--- a/protocol/src/http/pingora/handler/request_body_filter.rs
+++ b/protocol/src/http/pingora/handler/request_body_filter.rs
@@ -106,7 +106,7 @@ pub(super) async fn execute(
         _ => tracing::warn!("unhandled BodyMode variant in request body filter"),
     }
 
-    let (result, body_bytes, cluster, upstream, filter_metadata, filter_state) = {
+    let (result, body_bytes, cluster, upstream, extensions, filter_metadata, filter_state) = {
         let mut fctx = ctx.filter_context_for(pipeline, None).ok_or_else(|| {
             pingora_core::Error::explain(
                 pingora_core::ErrorType::InternalError,
@@ -119,6 +119,7 @@ pub(super) async fn execute(
             fctx.request_body_bytes,
             fctx.cluster,
             fctx.upstream,
+            fctx.extensions,
             fctx.filter_metadata,
             fctx.filter_state,
         )
@@ -126,6 +127,7 @@ pub(super) async fn execute(
     ctx.request_body_bytes = body_bytes;
     ctx.cluster = cluster;
     ctx.upstream = upstream;
+    ctx.extensions = extensions;
     ctx.filter_metadata = filter_metadata;
     ctx.filter_state = filter_state;
 

--- a/protocol/src/http/pingora/handler/request_filter/mod.rs
+++ b/protocol/src/http/pingora/handler/request_filter/mod.rs
@@ -185,6 +185,7 @@ async fn run_pipeline(
         rewritten_path,
         request_body_mode,
         selected_endpoint_index,
+        extensions,
         filter_metadata,
         filter_state,
     ) = {
@@ -201,12 +202,14 @@ async fn run_pipeline(
             filter_ctx.rewritten_path,
             filter_ctx.request_body_mode,
             filter_ctx.selected_endpoint_index,
+            filter_ctx.extensions,
             filter_ctx.filter_metadata,
             filter_ctx.filter_state,
         )
     };
 
     ctx.request_snapshot = Some(request);
+    ctx.extensions = extensions;
     ctx.filter_metadata = filter_metadata;
     ctx.filter_state = filter_state;
     ctx.metrics_cluster_shared = cluster.as_ref().map(|c| ::metrics::SharedString::from(Arc::clone(c)));

--- a/protocol/src/http/pingora/handler/request_filter/stream_buffer.rs
+++ b/protocol/src/http/pingora/handler/request_filter/stream_buffer.rs
@@ -162,6 +162,7 @@ pub(super) async fn pre_read_body(
         ctx.cluster = filter_ctx.cluster;
         ctx.rewritten_path = filter_ctx.rewritten_path;
         ctx.upstream = filter_ctx.upstream;
+        ctx.extensions = filter_ctx.extensions;
         ctx.filter_metadata = filter_ctx.filter_metadata;
         ctx.filter_state = filter_ctx.filter_state;
         ctx.filter_results = filter_ctx.filter_results;

--- a/protocol/src/http/pingora/handler/response_body_filter.rs
+++ b/protocol/src/http/pingora/handler/response_body_filter.rs
@@ -94,7 +94,7 @@ pub(super) fn execute(
         _ => tracing::warn!("unhandled BodyMode variant in response body filter"),
     }
 
-    let (result, body_bytes, cluster, upstream, filter_metadata, filter_state) = {
+    let (result, body_bytes, cluster, upstream, extensions, filter_metadata, filter_state) = {
         let mut fctx = ctx.filter_context_for(pipeline, None).ok_or_else(|| {
             pingora_core::Error::explain(
                 pingora_core::ErrorType::InternalError,
@@ -107,6 +107,7 @@ pub(super) fn execute(
             fctx.response_body_bytes,
             fctx.cluster,
             fctx.upstream,
+            fctx.extensions,
             fctx.filter_metadata,
             fctx.filter_state,
         )
@@ -114,6 +115,7 @@ pub(super) fn execute(
     ctx.response_body_bytes = body_bytes;
     ctx.cluster = cluster;
     ctx.upstream = upstream;
+    ctx.extensions = extensions;
     ctx.filter_metadata = filter_metadata;
     ctx.filter_state = filter_state;
 

--- a/protocol/src/http/pingora/handler/response_filter.rs
+++ b/protocol/src/http/pingora/handler/response_filter.rs
@@ -48,7 +48,7 @@ async fn run_response_pipeline(
     resp: &mut praxis_filter::Response,
 ) -> Result<(std::result::Result<FilterAction, praxis_filter::FilterError>, bool)> {
     let baseline_response_body_mode = ctx.response_body_mode;
-    let (r, headers_modified, response_body_mode, cluster, filter_metadata, filter_state) = {
+    let (r, headers_modified, response_body_mode, cluster, extensions, filter_metadata, filter_state) = {
         let mut fctx = ctx.filter_context_for(pipeline, Some(resp)).ok_or_else(|| {
             pingora_core::Error::explain(
                 pingora_core::ErrorType::InternalError,
@@ -61,12 +61,14 @@ async fn run_response_pipeline(
             fctx.response_headers_modified,
             fctx.response_body_mode,
             fctx.cluster,
+            fctx.extensions,
             fctx.filter_metadata,
             fctx.filter_state,
         )
     };
     ctx.cluster = cluster;
     ctx.response_body_mode = super::clamp_body_mode_to_ceiling(response_body_mode, baseline_response_body_mode);
+    ctx.extensions = extensions;
     ctx.filter_metadata = filter_metadata;
     ctx.filter_state = filter_state;
     Ok((r, headers_modified))


### PR DESCRIPTION
## Summary

- Add a generic, type-safe `RequestExtensions` container (`TypeMap` pattern) to `HttpFilterContext`, allowing filters to store and retrieve arbitrary typed values that persist across all Pingora lifecycle phases
- Wire extensions through the full lifecycle: swap into `HttpFilterContext` via `filter_context!` macro, write back at all 6 handler sites (request, request body, stream buffer pre-read, response, response body, logging) — identical pattern to `filter_metadata`
- First consumer will be the Responses API filter set (#354), which needs to share heavy request-scoped state (conversation history, tool definitions, usage) across phases

## Test plan

- [x] Unit tests for all `RequestExtensions` API methods (insert, get, get_mut, get_or_insert_with, remove, newtype independence)
- [x] `make build` passes
- [x] `make lint` passes (clippy, fmt, lint-deps, example coverage)
- [x] All existing tests continue to pass — construction sites in benchmarks, ext-proc tests, and fuzz targets updated