### PR TITLE
Bootstrap praxis init with messages and responses starters

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,6 +23,29 @@ curl http://127.0.0.1:8080/
 {"status": "ok", "server": "praxis"}
 ```
 
+## Bootstrap a starter config
+
+Generate a starter config:
+
+```console
+praxis init responses passthrough
+```
+
+For Anthropic Messages traffic, use:
+
+```console
+praxis init messages protocol
+```
+
+This writes `./praxis.yaml` with a curated starter recipe and prints
+the next validation and run commands.
+
+Start Praxis with the generated config:
+
+```console
+./target/release/praxis -c praxis.yaml
+```
+
 ## Proxy to a backend
 
 Create `praxis.yaml`:

--- a/server/src/init.rs
+++ b/server/src/init.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+use std::{fs, path::Path};
+
+use crate::{InitFamily, InitRecipe};
+
+/// Starter YAML for `praxis init responses passthrough`.
+const RESPONSES_PASSTHROUGH: &str = include_str!("../../examples/configs/ai/openai/responses/responses-routing.yaml");
+/// Starter YAML for `praxis init responses full-flow`.
+const RESPONSES_FULL_FLOW: &str = include_str!("../../examples/configs/ai/openai/responses/full-flow.yaml");
+/// Starter YAML for `praxis init messages protocol`.
+const MESSAGES_PROTOCOL: &str = include_str!("../../examples/configs/ai/anthropic/messages-protocol.yaml");
+/// Starter YAML for `praxis init messages to-openai`.
+const MESSAGES_TO_OPENAI: &str = include_str!("../../examples/configs/ai/anthropic/messages-to-openai.yaml");
+
+/// Write a curated starter `praxis.yaml` for the selected family and recipe.
+pub(crate) fn run_init(
+    output_dir: &Path,
+    family: InitFamily,
+    recipe: InitRecipe,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    let output_path = output_dir.join("praxis.yaml");
+    if output_path.exists() {
+        return Err(format!("{} already exists; refusing to overwrite it", output_path.display()).into());
+    }
+
+    let template = match (family, recipe) {
+        (InitFamily::Messages, InitRecipe::Protocol) => MESSAGES_PROTOCOL,
+        (InitFamily::Messages, InitRecipe::ToOpenai) => MESSAGES_TO_OPENAI,
+        (InitFamily::Responses, InitRecipe::Passthrough) => RESPONSES_PASSTHROUGH,
+        (InitFamily::Responses, InitRecipe::FullFlow) => RESPONSES_FULL_FLOW,
+        (InitFamily::Messages | InitFamily::Responses, _) => {
+            return Err(format!("unsupported recipe `{recipe:?}` for family `{family:?}`").into());
+        },
+    };
+
+    fs::write(&output_path, template)?;
+
+    Ok(format!(
+        "Wrote {}.\nNext steps:\n  1. Review the starter config.\n  2. Run `praxis validate -c {0}`.\n  3. Start Praxis with `praxis -c {0}`.",
+        output_path.display()
+    ))
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, reason = "tests exercise straightforward filesystem helpers")]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::{InitFamily, InitRecipe, run_init};
+
+    #[test]
+    fn run_init_writes_default_praxis_yaml() {
+        let dir = tempdir().unwrap();
+
+        let summary = run_init(dir.path(), InitFamily::Responses, InitRecipe::Passthrough).unwrap();
+        let written = dir.path().join("praxis.yaml");
+
+        assert!(written.exists(), "init should write praxis.yaml");
+        let yaml = fs::read_to_string(&written).unwrap();
+        assert!(
+            yaml.contains("openai_responses_format"),
+            "starter config should include responses routing filters"
+        );
+        assert!(
+            summary.contains("praxis validate"),
+            "summary should tell the user how to validate the config"
+        );
+    }
+
+    #[test]
+    fn run_init_refuses_to_overwrite_existing_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("praxis.yaml");
+        fs::write(&path, "existing: true\n").unwrap();
+
+        let err = run_init(dir.path(), InitFamily::Responses, InitRecipe::Passthrough).unwrap_err();
+        assert!(
+            err.to_string().contains("already exists"),
+            "existing file error should explain overwrite refusal: {err}"
+        );
+    }
+
+    #[test]
+    fn run_init_full_flow_uses_full_flow_template() {
+        let dir = tempdir().unwrap();
+
+        run_init(dir.path(), InitFamily::Responses, InitRecipe::FullFlow).unwrap();
+        let yaml = fs::read_to_string(dir.path().join("praxis.yaml")).unwrap();
+
+        assert!(
+            yaml.contains("openai_response_store"),
+            "full-flow starter should include response storage"
+        );
+    }
+
+    #[test]
+    fn run_init_messages_protocol_uses_messages_protocol_template() {
+        let dir = tempdir().unwrap();
+
+        run_init(dir.path(), InitFamily::Messages, InitRecipe::Protocol).unwrap();
+        let yaml = fs::read_to_string(dir.path().join("praxis.yaml")).unwrap();
+
+        assert!(
+            yaml.contains("anthropic_messages_protocol"),
+            "messages protocol starter should include anthropic protocol filter"
+        );
+    }
+
+    #[test]
+    fn run_init_messages_to_openai_uses_transform_template() {
+        let dir = tempdir().unwrap();
+
+        run_init(dir.path(), InitFamily::Messages, InitRecipe::ToOpenai).unwrap();
+        let yaml = fs::read_to_string(dir.path().join("praxis.yaml")).unwrap();
+
+        assert!(
+            yaml.contains("anthropic_to_openai"),
+            "messages to-openai starter should include transform filter"
+        );
+        assert!(
+            yaml.contains("anthropic_stream_events"),
+            "messages to-openai starter should include streaming transform"
+        );
+    }
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -17,8 +17,12 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 mod commands;
 mod dump;
+/// Starter-config generation helpers for `praxis init`.
+mod init;
 
-use clap::Parser;
+use std::io::Write as _;
+
+use clap::{Parser, Subcommand, ValueEnum};
 use tracing::info;
 
 // -----------------------------------------------------------------------------
@@ -40,6 +44,44 @@ struct Cli {
     /// Validate configuration and exit.
     #[arg(short = 't', long = "validate")]
     validate: bool,
+
+    /// Generate a starter config for a common Praxis workflow.
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+/// Top-level `praxis` subcommands.
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Generate a starter config from a curated recipe.
+    Init {
+        /// Incoming API family or traffic shape.
+        family: InitFamily,
+        /// Starter recipe within the selected family.
+        recipe: InitRecipe,
+    },
+}
+
+/// Supported starter-config families for `praxis init`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum InitFamily {
+    /// Anthropic Messages API starters.
+    Messages,
+    /// OpenAI Responses API starters.
+    Responses,
+}
+
+/// Supported starter recipes for `praxis init`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum InitRecipe {
+    /// Native Messages protocol starter for `/v1/messages` backends.
+    Protocol,
+    /// Transform Messages traffic to a Chat Completions-style backend.
+    ToOpenai,
+    /// Minimal mode-aware routing for Responses traffic.
+    Passthrough,
+    /// End-to-end Responses pipeline with validation and response storage.
+    FullFlow,
 }
 
 // -----------------------------------------------------------------------------
@@ -50,6 +92,11 @@ struct Cli {
 #[expect(clippy::print_stderr, reason = "fatal error output")]
 fn main() {
     let cli = Cli::parse();
+    if let Some(Command::Init { family, recipe }) = cli.command {
+        handle_init_command(family, recipe);
+        return;
+    }
+
     let explicit = cli.config.or_else(|| std::env::var("PRAXIS_CONFIG").ok());
 
     if cli.validate {
@@ -75,6 +122,20 @@ fn main() {
     praxis::run_server(config, config_path)
 }
 
+/// Execute `praxis init` for a selected starter family and recipe.
+fn handle_init_command(family: InitFamily, recipe: InitRecipe) {
+    let cwd = std::env::current_dir().unwrap_or_else(|e| praxis::fatal(&e));
+    match init::run_init(&cwd, family, recipe) {
+        Ok(summary) => {
+            std::io::stdout()
+                .write_all(summary.as_bytes())
+                .and_then(|()| std::io::stdout().write_all(b"\n"))
+                .unwrap_or_else(|e| praxis::fatal(&e));
+        },
+        Err(e) => praxis::fatal(&format!("init failed: {e}")),
+    }
+}
+
 // -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
@@ -85,7 +146,7 @@ fn main() {
 mod tests {
     use clap::Parser as _;
 
-    use super::Cli;
+    use super::{Cli, Command, InitFamily, InitRecipe};
 
     // -------------------------------------------------------------------------
     // --validate CLI parsing
@@ -152,5 +213,55 @@ mod tests {
     fn cli_dump_short_conflicts_with_validate_short() {
         let result = Cli::try_parse_from(["praxis", "-T", "-t"]);
         assert!(result.is_err(), "-T and -t should conflict");
+    }
+
+    // -------------------------------------------------------------------------
+    // init CLI parsing
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn cli_init_responses_passthrough() {
+        let cli = Cli::parse_from(["praxis", "init", "responses", "passthrough"]);
+        let Some(Command::Init { family, recipe }) = cli.command else {
+            unreachable!("expected init command");
+        };
+        assert_eq!(family, InitFamily::Responses);
+        assert_eq!(recipe, InitRecipe::Passthrough);
+    }
+
+    #[test]
+    fn cli_init_responses_full_flow() {
+        let cli = Cli::parse_from(["praxis", "init", "responses", "full-flow"]);
+        let Some(Command::Init { family, recipe }) = cli.command else {
+            unreachable!("expected init command");
+        };
+        assert_eq!(family, InitFamily::Responses);
+        assert_eq!(recipe, InitRecipe::FullFlow);
+    }
+
+    #[test]
+    fn cli_init_unknown_recipe_rejected() {
+        let result = Cli::try_parse_from(["praxis", "init", "responses", "unknown"]);
+        assert!(result.is_err(), "unknown init recipe should fail clap parsing");
+    }
+
+    #[test]
+    fn cli_init_messages_protocol() {
+        let cli = Cli::parse_from(["praxis", "init", "messages", "protocol"]);
+        let Some(Command::Init { family, recipe }) = cli.command else {
+            unreachable!("expected init command");
+        };
+        assert_eq!(family, InitFamily::Messages);
+        assert_eq!(recipe, InitRecipe::Protocol);
+    }
+
+    #[test]
+    fn cli_init_messages_to_openai() {
+        let cli = Cli::parse_from(["praxis", "init", "messages", "to-openai"]);
+        let Some(Command::Init { family, recipe }) = cli.command else {
+            unreachable!("expected init command");
+        };
+        assert_eq!(family, InitFamily::Messages);
+        assert_eq!(recipe, InitRecipe::ToOpenai);
     }
 }


### PR DESCRIPTION
## Summary

Bootstrap `praxis init` with a small, truthful first slice aimed at issue praxis-proxy/praxis#859.

This PR adds:

- a new `praxis init <family> <recipe>` CLI surface
- real starter generation for:
  - `messages protocol`
  - `messages to-openai`
  - `responses passthrough`
  - `responses full-flow`
- friendly next-step output after writing `praxis.yaml`
- quickstart docs for the new bootstrap flow
- unit tests for CLI parsing and file generation behavior

## Why

Issue praxis-proxy/praxis#859 proposes a starter-config CLI that makes Praxis easier to try without starting from a blank YAML file.

This PR establishes the command framework and ships the first recipes from maintained in-repo examples for both Anthropic Messages and OpenAI Responses workflows.

## Scope notes

This is still the first slice of the broader epic:

- the framework is general, but the initial shipped families are `messages` and `responses`
- interactive setup is still out of scope for v1
- the command currently writes `praxis.yaml` in the working directory and refuses to overwrite existing files

## Validation

- `cargo test -p praxis`
- `cargo run -q -p praxis -- init messages --help`
- end-to-end smoke run: `cargo run -q --manifest-path server/Cargo.toml -- init messages protocol` in a temp dir and verified the generated `praxis.yaml`
- end-to-end smoke run: `cargo run -q --manifest-path server/Cargo.toml -- init responses passthrough` in a temp dir and verified the generated `praxis.yaml`

Closes praxis-proxy/praxis#859
