### PR TITLE
fix(classifier): recognize previous_response_id and conversation as Responses signals

### DIFF
--- a/filter/src/builtins/http/ai/classifier/mod.rs
+++ b/filter/src/builtins/http/ai/classifier/mod.rs
@@ -151,9 +151,10 @@ pub(crate) fn classify_request_body(body: &[u8]) -> ClassifiedRequest {
 
 /// Determine format from top-level keys.
 ///
-/// Precedence: `input` or `prompt` object → Responses, then
-/// `messages` with Anthropic signals → Anthropic Messages, then
-/// `messages` alone → Chat Completions.
+/// Precedence: `input`, `prompt` object, `previous_response_id`,
+/// or `conversation` → Responses, then `messages` with Anthropic
+/// signals → Anthropic Messages, then `messages` alone → Chat
+/// Completions.
 ///
 /// Anthropic signals: `max_tokens` is required AND at least one of
 /// top-level `system` field or typed content blocks (arrays of
@@ -161,7 +162,11 @@ pub(crate) fn classify_request_body(body: &[u8]) -> ClassifiedRequest {
 /// positives when `OpenAI` Chat Completions requests include the
 /// optional `max_tokens` field.
 fn classify_format(obj: &serde_json::Map<String, serde_json::Value>) -> AiRequestFormat {
-    if obj.contains_key("input") || obj.get("prompt").is_some_and(serde_json::Value::is_object) {
+    if obj.contains_key("input")
+        || obj.get("prompt").is_some_and(serde_json::Value::is_object)
+        || obj.contains_key("previous_response_id")
+        || obj.contains_key("conversation")
+    {
         return AiRequestFormat::Responses;
     }
 
@@ -797,6 +802,79 @@ mod tests {
         assert!(
             !is_responses_path(&http::Method::GET, "/v1/responses//input_items"),
             "GET /v1/responses//input_items should not collapse empty id segment"
+        );
+    }
+
+    #[test]
+    fn previous_response_id_only_classifies_as_responses() {
+        let body = br#"{"model":"gpt-4.1","previous_response_id":"resp_abc"}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::Responses,
+            "previous_response_id without input should classify as responses"
+        );
+        assert!(
+            result.has_previous_response_id,
+            "previous_response_id should be detected"
+        );
+    }
+
+    #[test]
+    fn previous_response_id_with_input_classifies_as_responses() {
+        let body = br#"{"model":"gpt-4.1","previous_response_id":"resp_abc","input":"hello"}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::Responses,
+            "previous_response_id with input should still classify as responses"
+        );
+    }
+
+    #[test]
+    fn conversation_only_classifies_as_responses() {
+        let body = br#"{"model":"gpt-4.1","conversation":{"id":"conv_123"}}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::Responses,
+            "conversation without input should classify as responses"
+        );
+        assert!(result.has_conversation, "conversation should be detected");
+    }
+
+    #[test]
+    fn null_previous_response_id_still_classifies_as_responses() {
+        let body = br#"{"model":"gpt-4.1","previous_response_id":null}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::Responses,
+            "previous_response_id key present (even null) should classify as responses"
+        );
+        assert!(
+            !result.has_previous_response_id,
+            "null value should not set the has_previous_response_id flag"
+        );
+    }
+
+    #[test]
+    fn null_conversation_still_classifies_as_responses() {
+        let body = br#"{"model":"gpt-4.1","conversation":null}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::Responses,
+            "conversation key present (even null) should classify as responses"
+        );
+        assert!(
+            !result.has_conversation,
+            "null value should not set the has_conversation flag"
         );
     }
 

--- a/filter/src/builtins/http/ai/classifier/mod.rs
+++ b/filter/src/builtins/http/ai/classifier/mod.rs
@@ -681,6 +681,31 @@ mod tests {
         );
     }
 
+    #[test]
+    fn previous_response_id_with_messages_classifies_as_responses() {
+        let body =
+            br#"{"model":"gpt-4.1","previous_response_id":"resp_abc","messages":[{"role":"user","content":"Hi"}]}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::Responses,
+            "previous_response_id should take precedence over messages"
+        );
+    }
+
+    #[test]
+    fn conversation_with_messages_classifies_as_responses() {
+        let body = br#"{"model":"gpt-4.1","conversation":{"id":"conv_123"},"messages":[{"role":"user","content":"Hi"}],"max_tokens":1024,"system":"Be helpful."}"#;
+        let result = classify_request_body(body);
+
+        assert_eq!(
+            result.format,
+            AiRequestFormat::Responses,
+            "conversation should take precedence over Anthropic signals"
+        );
+    }
+
     // -------------------------------------------------------------------------
     // Path Classification
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `previous_response_id` and `conversation` as Responses API discriminators in `classify_format`, so bodies without `input` (e.g. `{"model":"gpt-4.1","previous_response_id":"resp_..."}`) are no longer misclassified as `UnknownJson` and rejected with a 400 when `on_invalid: reject` is configured.
- Adds 5 test cases covering the new classification paths, including null-value edge cases and regression guards.

## Test plan

- [x] `cargo test -p praxis-proxy-filter --features ai-inference -- classifier` — all 61 tests pass
- [x] `make lint` — clippy and fmt clean (pre-existing `lint-filter-docs` failure unrelated)
- [x] `make build` — workspace builds successfully