### PR TITLE
fix(xtask): resolve shared enums in filter doc generation

### DIFF
--- a/docs/filters/http/ai/a2a.md
+++ b/docs/filters/http/ai/a2a.md
@@ -18,7 +18,7 @@ Extracts A2A protocol metadata from JSON-RPC request bodies and promotes method,
 | `headers.version` | string | no | Header name for A2A version (e.g. `x-praxis-a2a-version`). |
 | `max_body_bytes` | usize | no | Maximum body size in bytes for `StreamBuffer`. |
 | `method_aliases` | object<string, string> | no | Method aliases for compatibility (slash-delimited → `PascalCase`). |
-| `on_invalid` | `reject` \| `continue` | no | Invalid input handling behavior. |
+| `on_invalid` | `continue` \| `reject` \| `error` | no | Invalid input handling behavior. |
 | `task_routing` | TaskRoutingConfig | no | Task-ownership routing configuration. |
 | `task_routing.enabled` | bool | no | Whether task routing is enabled. |
 | `task_routing.max_response_body_bytes` | usize | no | Maximum response body bytes to buffer for task route capture. |

--- a/docs/filters/http/ai/anthropic_messages_format.md
+++ b/docs/filters/http/ai/anthropic_messages_format.md
@@ -11,7 +11,7 @@ Requires Cargo feature: `ai-inference`.
 
 | Field | Type | Required | Description |
 |-------|------|---------|-------------|
-| `on_invalid` | `continue` \| `reject` | no | Behavior when the body cannot be classified. |
+| `on_invalid` | `continue` \| `reject` \| `error` | no | Behavior when the body cannot be classified. |
 | `max_body_bytes` | usize | no | Maximum body size in bytes for `StreamBuffer` mode. |
 | `headers` | AnthropicMessagesFormatHeaders | no | Header names for promoted classification facts. |
 | `headers.format` | string | no | Header name for the detected format. |

--- a/docs/filters/http/ai/mcp.md
+++ b/docs/filters/http/ai/mcp.md
@@ -31,7 +31,7 @@ This first MCP static catalog change short-circuits all methods: no request is f
 | `headers.protocol_version` | string | no | Header name for the MCP protocol version (e.g. `x-praxis-mcp-protocol-version`). |
 | `headers.session_present` | string | no | Header name for MCP session presence (e.g. `x-praxis-mcp-session-present`). |
 | `max_body_bytes` | usize | no | Maximum body size in bytes for `StreamBuffer`. |
-| `on_invalid` | `reject` \| `continue` | no | Invalid input handling behavior. |
+| `on_invalid` | `continue` \| `reject` \| `error` | no | Invalid input handling behavior. |
 | `default_version` | string | no | Fallback MCP protocol version returned in broker `initialize` responses when the client's requested version is not supported. Must be present in `supported_versions` and implemented by this build. Defaults to [`protocol::DEFAULT_VERSION`]. |
 | `invalid_tool_policy` | `reject_server` \| `filter_out` | no | Behavior when a tool has an invalid schema. |
 | `path` | string | no | Public MCP path handled by Praxis. |

--- a/docs/filters/http/ai/openai_responses_format.md
+++ b/docs/filters/http/ai/openai_responses_format.md
@@ -19,7 +19,7 @@ Use with branch chains to route stateful and stateless requests to different clu
 
 | Field | Type | Required | Description |
 |-------|------|---------|-------------|
-| `on_invalid` | `continue` \| `reject` | no | Behavior when the body cannot be classified. |
+| `on_invalid` | `continue` \| `reject` \| `error` | no | Behavior when the body cannot be classified. |
 | `max_body_bytes` | usize | no | Maximum body size in bytes for `StreamBuffer` mode. |
 | `headers` | ResponsesFormatHeaders | no | Header names for promoted classification facts. |
 | `headers.format` | string | no | Header name for the detected format (e.g. `openai_responses`, `openai_chat_completions`). |

--- a/xtask/src/filter_docs.rs
+++ b/xtask/src/filter_docs.rs
@@ -373,11 +373,15 @@ fn discover_all_filters(root: &Path, shared_items: &ModuleItems) -> Vec<FilterEn
 /// Extract all filters from a category directory using anchor-based discovery.
 fn extract_filters(category_dir: &Path, shared_items: &ModuleItems) -> Vec<FilterInfo> {
     let anchors = discover_filter_anchors(category_dir);
+
+    let mut category_shared = shared_items.clone_for_filter();
+    parse_category_shared_types(category_dir, &anchors, &mut category_shared);
+
     let filters: Vec<FilterInfo> = anchors
         .iter()
         .map(|anchor| {
             let files = scope_files_for_anchor(anchor, category_dir, &anchors);
-            let mut items = shared_items.clone_for_filter();
+            let mut items = category_shared.clone_for_filter();
             for path in &files {
                 let Ok(source) = fs::read_to_string(path) else {
                     continue;
@@ -391,6 +395,39 @@ fn extract_filters(category_dir: &Path, shared_items: &ModuleItems) -> Vec<Filte
         })
         .collect();
     merge_filter_variants(filters)
+}
+
+/// Parse non-anchor `.rs` files directly in the category root for shared
+/// enum/struct types (e.g. `on_invalid.rs` in the AI category).  Only
+/// struct field info and enums survive `clone_for_filter`, so module docs
+/// and config structs from these files do not leak into individual filter
+/// docs.
+fn parse_category_shared_types(category_dir: &Path, anchors: &[FilterAnchor], out: &mut ModuleItems) {
+    let Ok(entries) = fs::read_dir(category_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_none_or(|e| e != "rs") {
+            continue;
+        }
+        if path.file_name().is_some_and(|n| n == "mod.rs" || n == "tests.rs") {
+            continue;
+        }
+        if anchors.iter().any(|a| a.file == path) {
+            continue;
+        }
+        let Ok(source) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(file) = syn::parse_file(&source) else {
+            continue;
+        };
+        parse_file_items(&file, out);
+    }
+    out.configs.clear();
+    out.module_docs.clear();
+    out.struct_docs.clear();
 }
 
 /// Discover filter anchor files under a directory tree.


### PR DESCRIPTION
## Summary

Commit 910bcbae consolidated per-filter `OnInvalidBehavior` enums into a shared
`filter/src/builtins/http/ai/on_invalid.rs` file. The doc generator's file scoping
excluded category-root support files from nested filter scans, so `OnInvalidBehavior`
rendered as a raw type name instead of inline variants. This broke `make lint` via
the `lint-filter-docs` check.

This PR adds `parse_category_shared_types` to scan non-anchor `.rs` files in
category root directories, making their enum/struct definitions available to all
filters in the category while clearing docs/configs to prevent description leakage.

## Changes

- **`xtask/src/filter_docs.rs`**: add `parse_category_shared_types()` that scans
  category-root non-anchor `.rs` files for shared `Deserialize` enums/structs
- **`docs/filters/http/ai/{a2a,anthropic_messages_format,mcp,openai_responses_format}.md`**:
  regenerated — `on_invalid` now renders `` `continue` \| `reject` \| `error` ``
  instead of `OnInvalidBehavior`

## Test plan

- [x] `make lint` passes (including `lint-filter-docs`)
- [x] `make build` passes
- [x] `cargo test -p xtask` — all 91 tests pass
- [x] `json_body_field` docs unaffected (no description leakage from `compression_config.rs`)