### PR TITLE
chore: update CODEOWNERS for AI filter paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,10 +2,9 @@
 * @shaneutt @twghu
 
 # Experimental AI Filters
-/filter/src/builtins/http/ai/openai/ @leseb @franciscojavierarceo
-/filter/src/builtins/http/ai/anthropic/ @leseb @franciscojavierarceo
-/filter/src/builtins/http/ai/mod.rs @leseb @franciscojavierarceo
+/filter/src/builtins/http/ai/ @leseb @franciscojavierarceo
 /filter/src/registry.rs @leseb @franciscojavierarceo
+/docs/filters/http/ai/ @leseb @franciscojavierarceo
 /examples/configs/ai/ @leseb @franciscojavierarceo
 /examples/README.md @leseb @franciscojavierarceo
 /tests/integration/tests/suite/examples/ @leseb @franciscojavierarceo


### PR DESCRIPTION
## Summary

- Consolidate three specific AI filter source entries (`openai/`, `anthropic/`, `mod.rs`) into a single `/filter/src/builtins/http/ai/` pattern covering the entire AI directory including shared store types
- Add `/docs/filters/http/ai/` for AI filter documentation ownership

Follows up on #604 which added the rehydrate filter and touched paths not previously covered in CODEOWNERS.