### PR TITLE
fix(ci): update crossbeam-epoch to resolve RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

  Updates `crossbeam-epoch` from 0.9.18 to 0.9.20 in `Cargo.lock` via `cargo update -p crossbeam-epoch`.

  ## Why

  The Supply Chain workflow is failing during `cargo deny check` because `crossbeam-epoch 0.9.18` is affected by RUSTSEC-2026-0204.

  Example failing workflow:

  https://github.com/praxis-proxy/praxis/actions/runs/28836961723/job/85522675707?pr=762

  Relevant output:

  ```text
  error[vulnerability]: Invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid
  ```

  The advisory recommends upgrading to crossbeam-epoch 0.9.20 or newer.

  ## Scope

  - Lockfile-only dependency update
  - No source code changes
  - No deny.toml changes
  - No workflow changes

  ## Validation

  - cargo deny check — passed
  - cargo deny check bans — passed
  - cargo clippy --workspace --all-targets -- -D warnings — passed
  - cargo test --workspace --all-targets — passed, 87/87
  - git diff --check — passed