### PR TITLE
feat(ext-proc): add response-header lifecycle processing

### DIFF
--- a/filter/ext-proc/src/callout.rs
+++ b/filter/ext-proc/src/callout.rs
@@ -54,6 +54,10 @@ pub(crate) enum CalloutError {
 /// Opens a `Process` stream, sends a `RequestHeaders` message, and
 /// waits for one response within `timeout`. Returns [`FilterAction`]
 /// indicating whether the pipeline should continue or reject.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "kept for focused request-header callout tests")
+)]
 pub(crate) async fn process_request_headers(
     channel: Channel,
     target: &str,
@@ -75,6 +79,10 @@ pub(crate) async fn process_request_headers(
 ///
 /// Same pattern as [`process_request_headers`] but wraps
 /// `ResponseHeaders` and operates during the response phase.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "kept for focused response-header callout tests")
+)]
 pub(crate) async fn process_response_headers(
     channel: Channel,
     target: &str,

--- a/filter/ext-proc/src/duplex.rs
+++ b/filter/ext-proc/src/duplex.rs
@@ -158,7 +158,6 @@ pub(crate) enum ExchangeEvent {
         metadata: Option<prost_wkt_types::Struct>,
     },
     /// Response headers response.
-    #[expect(dead_code, reason = "classified by receive; consumed in response-phase processing")]
     ResponseHeaders {
         /// Processor response payload.
         response: HeadersResponse,
@@ -438,7 +437,6 @@ impl ExtProcExchange {
     /// [`send`]: Self::send
     /// [`receive`]: Self::receive
     /// [`open_with_request_headers`]: Self::open_with_request_headers
-    #[cfg_attr(not(test), expect(dead_code, reason = "standard no-preload path used by tests"))]
     pub(crate) fn open(channel: Channel, config: &ExchangeConfig) -> Self {
         let (tx, rx) = mpsc::channel(REQUEST_CHANNEL_CAPACITY);
         let protocol_config = ProtocolConfiguration {
@@ -902,10 +900,17 @@ impl ExtProcExchange {
 
     /// Ensure the bootstrap has resolved to a ready response
     /// stream. Awaits the pending Process future if necessary.
-    async fn ensure_response_stream(&mut self) -> Result<(), ExchangeError> {
+    async fn ensure_response_stream(&mut self, deadline: Option<tokio::time::Instant>) -> Result<(), ExchangeError> {
         if let BootstrapState::Pending(ref mut wrapper) = self.bootstrap {
             let future = wrapper.get_mut();
-            let response = future.await.map_err(|status| {
+            let response_result = if let Some(dl) = deadline {
+                tokio::time::timeout_at(dl, future)
+                    .await
+                    .map_err(|_elapsed| ExchangeError::Timeout)?
+            } else {
+                future.await
+            };
+            let response = response_result.map_err(|status| {
                 self.bootstrap = BootstrapState::Closed;
                 self.terminal = true;
                 ExchangeError::Grpc(status)
@@ -918,7 +923,8 @@ impl ExtProcExchange {
     /// Internal receive with deferred stream resolution, override
     /// loop, and classification.
     ///
-    /// 1. Ensures the response stream has been resolved from the pending bootstrap future.
+    /// 1. Ensures the response stream has been resolved from the pending bootstrap future, using the active processing
+    ///    deadline when present.
     /// 2. Reads a response with optional deadline from active processing.
     /// 3. Runs the override loop: if `override_message_timeout` is present on the envelope, it is an override envelope.
     ///    Valid overrides replace the deadline and continue reading. Invalid overrides are silently ignored. The entire
@@ -928,7 +934,8 @@ impl ExtProcExchange {
     ///
     /// [`classify_and_validate`]: Self::classify_and_validate
     async fn receive_inner(&mut self) -> Result<ExchangeEvent, ExchangeError> {
-        self.ensure_response_stream().await?;
+        let initial_deadline = self.active_processing.as_ref().map(|ap| ap.deadline);
+        self.ensure_response_stream(initial_deadline).await?;
         loop {
             let deadline = self.active_processing.as_ref().map(|ap| ap.deadline);
             let stream = match self.bootstrap {

--- a/filter/ext-proc/src/lib.rs
+++ b/filter/ext-proc/src/lib.rs
@@ -85,7 +85,8 @@ const DEFAULT_MESSAGE_TIMEOUT_MS: u64 = 200;
 /// Default HTTP status code returned on processor errors.
 const DEFAULT_STATUS_ON_ERROR: u16 = 500;
 
-/// Default deferred close timeout in milliseconds (observability mode).
+/// Default deferred close timeout in milliseconds for best-effort
+/// trailing stream cleanup.
 const DEFAULT_DEFERRED_CLOSE_TIMEOUT_MS: u64 = 5000;
 
 /// Default lifecycle timeout in milliseconds for coalesced drain.
@@ -187,8 +188,9 @@ struct ExtProcConfig {
     #[serde(default)]
     allowed_override_modes: Vec<ProcessingModeConfig>,
 
-    /// Timeout in milliseconds for deferred gRPC stream closure in
-    /// observability mode. Default: 5000.
+    /// Best-effort timeout in milliseconds for trailing gRPC stream
+    /// cleanup after the expected processor response is consumed.
+    /// Zero skips cleanup entirely. Default: 5000.
     #[serde(default = "default_deferred_close_timeout_ms")]
     deferred_close_timeout_ms: u64,
 
@@ -518,13 +520,6 @@ fn validate_core_fields(cfg: &ExtProcConfig) -> Result<(), FilterError> {
         let msg = cfg.message_timeout_ms;
         return Err(format!("ext_proc: lifecycle_timeout_ms ({lc}) must be >= message_timeout_ms ({msg})").into());
     }
-    if cfg.deferred_close_timeout_ms > 0 && cfg.deferred_close_timeout_ms < cfg.message_timeout_ms {
-        let close = cfg.deferred_close_timeout_ms;
-        let msg = cfg.message_timeout_ms;
-        return Err(
-            format!("ext_proc: deferred_close_timeout_ms ({close}) must be >= message_timeout_ms ({msg})").into(),
-        );
-    }
     if let Some(max) = cfg.max_message_timeout_ms {
         if max == 0 {
             return Err("ext_proc: max_message_timeout_ms must be greater than 0".into());
@@ -545,26 +540,11 @@ fn validate_core_fields(cfg: &ExtProcConfig) -> Result<(), FilterError> {
 /// existing `none` default. Other body modes (`streamed`, `buffered`,
 /// `buffered_partial`) remain unsupported.
 ///
-/// For the partial request-routing milestone, full-duplex mode
-/// requires `response_header_mode: skip` and rejects
-/// `request_trailer_mode: send` because Pingora has no
-/// request-trailer hooks.
-#[expect(
-    clippy::too_many_lines,
-    reason = "sequential mode validation with full-duplex contract"
-)]
+/// Request and response trailers remain unsupported because Pingora
+/// has no request-trailer hooks in this integration path.
 fn validate_processing_mode(pm: ProcessingModeConfig) -> Result<(), FilterError> {
     if pm.request_header_mode == HeaderSendMode::Skip {
         return Err("ext_proc: request_header_mode 'skip' is not yet supported".into());
-    }
-    if pm.request_body_mode.is_full_duplex() {
-        if pm.response_header_mode == HeaderSendMode::Send {
-            return Err(
-                "ext_proc: full-duplex request mode requires response_header_mode 'skip' until response lifecycle is implemented".into()
-            );
-        }
-    } else if pm.response_header_mode == HeaderSendMode::Skip {
-        return Err("ext_proc: response_header_mode 'skip' is not yet supported".into());
     }
     if !matches!(
         pm.request_body_mode,
@@ -636,6 +616,11 @@ pub struct ExtProcFilter {
     /// Upper bound for processor-requested timeout overrides.
     max_message_timeout: Option<Duration>,
 
+    /// Best-effort timeout for trailing stream cleanup after the
+    /// expected processor response has been consumed. Zero skips
+    /// the drain entirely.
+    deferred_close_timeout: Duration,
+
     /// Bounded lifecycle timeout for coalesced drain at request
     /// body EOS. Separate from per-message timeout.
     lifecycle_timeout: Duration,
@@ -645,6 +630,9 @@ pub struct ExtProcFilter {
 
     /// How the response body is forwarded to the processor.
     response_body_mode: BodySendMode,
+
+    /// Whether response headers are forwarded to the processor.
+    response_header_mode: HeaderSendMode,
 
     /// HTTP status code returned on processor errors.
     status_on_error: u16,
@@ -659,6 +647,7 @@ impl std::fmt::Debug for ExtProcFilter {
             .field("target", &self.target)
             .field("message_timeout", &self.message_timeout)
             .field("request_body_mode", &self.request_body_mode)
+            .field("response_header_mode", &self.response_header_mode)
             .field("status_on_error", &self.status_on_error)
             .finish_non_exhaustive()
     }
@@ -688,6 +677,7 @@ impl ExtProcFilter {
         let message_timeout = Duration::from_millis(cfg.message_timeout_ms);
 
         Ok(Box::new(Self {
+            deferred_close_timeout: Duration::from_millis(cfg.deferred_close_timeout_ms),
             endpoint,
             lazy_channel: std::sync::OnceLock::new(),
             lifecycle_timeout: Duration::from_millis(cfg.lifecycle_timeout_ms),
@@ -695,6 +685,7 @@ impl ExtProcFilter {
             message_timeout,
             request_body_mode: cfg.processing_mode.request_body_mode,
             response_body_mode: cfg.processing_mode.response_body_mode,
+            response_header_mode: cfg.processing_mode.response_header_mode,
             status_on_error: cfg.status_on_error,
             target: cfg.target,
         }))
@@ -752,6 +743,27 @@ impl ExtProcFilter {
         }
     }
 
+    /// Best-effort trailing cleanup for non-lifecycle exchange paths.
+    ///
+    /// Calls `finish_sending()` then drains remaining server data
+    /// within `deferred_close_timeout`. If the timeout is zero or
+    /// the drain times out, the exchange is dropped without waiting.
+    async fn bounded_cleanup(&self, exchange: &mut ExtProcExchange) {
+        exchange.finish_sending();
+        if self.deferred_close_timeout.is_zero() {
+            return;
+        }
+        if tokio::time::timeout(self.deferred_close_timeout, exchange.drain_trailing())
+            .await
+            .is_err()
+        {
+            tracing::debug!(
+                target = %self.target,
+                "ext_proc: deferred close timeout during trailing drain"
+            );
+        }
+    }
+
     /// Ensure the per-request exchange is open and request headers
     /// have been sent. Idempotent — returns immediately if headers
     /// were already sent.
@@ -774,10 +786,70 @@ impl ExtProcFilter {
         let state = ExtProcState {
             exchange,
             headers_sent: true,
+            request_phase_complete: false,
         };
 
         ctx.insert_filter_state(state);
         Ok(())
+    }
+
+    /// Send request headers and wait for the matching processor response.
+    async fn process_request_headers_on_exchange(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+    ) -> Result<FilterAction, FilterError> {
+        let mut state = self.open_and_send_request_headers(ctx).await?;
+        let result = Self::drain_header_response(&mut state, ctx).await;
+
+        self.complete_request_header_processing(state, ctx, result).await
+    }
+
+    /// Open an exchange and send request headers as the first message.
+    async fn open_and_send_request_headers(&self, ctx: &HttpFilterContext<'_>) -> Result<ExtProcState, FilterError> {
+        let headers = mutations::request_to_proto_headers(ctx);
+        let headers_request = processing_request::Request::RequestHeaders(headers);
+
+        let mut state = ExtProcState {
+            exchange: ExtProcExchange::open(self.channel(), &self.exchange_config()),
+            headers_sent: false,
+            request_phase_complete: false,
+        };
+        tokio::time::timeout(self.message_timeout, state.exchange.send(headers_request))
+            .await
+            .map_err(|_elapsed| -> FilterError { "ext_proc: message timeout during request headers".into() })?
+            .map_err(Self::exchange_err)?;
+        state.headers_sent = true;
+
+        Ok(state)
+    }
+
+    /// Store, close, or fail the exchange after request-header processing.
+    async fn complete_request_header_processing(
+        &self,
+        mut state: ExtProcState,
+        ctx: &mut HttpFilterContext<'_>,
+        result: Result<Option<FilterAction>, FilterError>,
+    ) -> Result<FilterAction, FilterError> {
+        match result {
+            Ok(Some(action)) => {
+                self.bounded_cleanup(&mut state.exchange).await;
+                Ok(action)
+            },
+            Ok(None) if self.response_header_mode == HeaderSendMode::Send => {
+                state.request_phase_complete = true;
+                ctx.insert_filter_state(state);
+                Ok(FilterAction::Continue)
+            },
+            Ok(None) => {
+                state.request_phase_complete = true;
+                self.bounded_cleanup(&mut state.exchange).await;
+                Ok(FilterAction::Continue)
+            },
+            Err(e) => {
+                state.exchange.finish_sending();
+                Err(e)
+            },
+        }
     }
 
     /// Drain the exchange after request body EOS: receive the
@@ -807,10 +879,12 @@ impl ExtProcFilter {
             .remove_filter_state::<ExtProcState>()
             .ok_or_else(|| -> FilterError { "ext_proc: missing exchange state during drain".into() })?;
 
-        let result = Self::drain_exchange_inner(&mut state, ctx, body).await;
+        let finish_after_request = self.response_header_mode == HeaderSendMode::Skip;
+        let result = Self::drain_exchange_inner(&mut state, ctx, body, finish_after_request).await;
 
-        // Reinsert the exchange for potential later phases.
-        ctx.insert_filter_state(state);
+        if !finish_after_request && matches!(result, Ok(FilterAction::Continue)) {
+            ctx.insert_filter_state(state);
+        }
 
         result
     }
@@ -820,6 +894,7 @@ impl ExtProcFilter {
         state: &mut ExtProcState,
         ctx: &mut HttpFilterContext<'_>,
         body: &mut Option<Bytes>,
+        finish_after_request: bool,
     ) -> Result<FilterAction, FilterError> {
         if let Some(action) = Self::drain_header_response(state, ctx).await? {
             state.exchange.finish_sending();
@@ -828,8 +903,12 @@ impl ExtProcFilter {
         }
 
         let result = Self::drain_body_responses(state, ctx, body).await;
-        state.exchange.finish_sending();
-        state.exchange.drain_trailing().await;
+        if finish_after_request || !matches!(result, Ok(FilterAction::Continue)) {
+            state.exchange.finish_sending();
+            state.exchange.drain_trailing().await;
+        } else {
+            state.request_phase_complete = true;
+        }
         result
     }
 
@@ -921,6 +1000,68 @@ impl ExtProcFilter {
         }
         Ok(FilterAction::Continue)
     }
+
+    /// Send response headers on the existing exchange and apply the response.
+    async fn process_response_headers_on_exchange(
+        &self,
+        ctx: &mut HttpFilterContext<'_>,
+    ) -> Result<FilterAction, FilterError> {
+        let mut state = ctx
+            .remove_filter_state::<ExtProcState>()
+            .ok_or_else(|| -> FilterError { "ext_proc: missing exchange state during response headers".into() })?;
+
+        let result = self.process_response_headers_inner(&mut state, ctx).await;
+        if result.is_ok() {
+            self.bounded_cleanup(&mut state.exchange).await;
+        } else {
+            state.exchange.finish_sending();
+        }
+        result
+    }
+
+    /// Inner response-header processing using an owned [`ExtProcState`].
+    ///
+    /// Send is bounded by `message_timeout`. Receive uses the
+    /// exchange's active-processing deadline, which supports
+    /// `override_message_timeout` from the processor.
+    #[expect(clippy::too_many_lines, reason = "send + receive + classification match")]
+    async fn process_response_headers_inner(
+        &self,
+        state: &mut ExtProcState,
+        ctx: &mut HttpFilterContext<'_>,
+    ) -> Result<FilterAction, FilterError> {
+        if !state.request_phase_complete {
+            return Err("ext_proc: response headers reached before request phase completed".into());
+        }
+
+        let headers = mutations::response_to_proto_headers(ctx);
+        let timeout = self.message_timeout;
+        tokio::time::timeout(
+            timeout,
+            state
+                .exchange
+                .send(processing_request::Request::ResponseHeaders(headers)),
+        )
+        .await
+        .map_err(|_elapsed| -> FilterError { "ext_proc: message timeout sending response headers".into() })?
+        .map_err(Self::exchange_err)?;
+
+        let event = state.exchange.receive().await.map_err(Self::exchange_err)?;
+        match event {
+            ExchangeEvent::ResponseHeaders { response, metadata } => {
+                apply_dynamic_metadata(metadata, ctx);
+                mutations::apply_headers_response(&response, ctx, Phase::Response);
+                Ok(FilterAction::Continue)
+            },
+            ExchangeEvent::Immediate { response, metadata } => {
+                apply_dynamic_metadata(metadata, ctx);
+                Ok(mutations::immediate_to_rejection(&response))
+            },
+            other => {
+                Err(format!("ext_proc: expected ResponseHeaders or Immediate during response, got {other:?}").into())
+            },
+        }
+    }
 }
 
 /// Resolve the maximum bytes allowed for coalesced processor body
@@ -947,6 +1088,9 @@ struct ExtProcState {
 
     /// Whether request headers have been committed to the exchange.
     headers_sent: bool,
+
+    /// Whether request-phase processor responses have been consumed.
+    request_phase_complete: bool,
 }
 
 // -----------------------------------------------------------------------------
@@ -1042,17 +1186,7 @@ impl HttpFilter for ExtProcFilter {
             return Ok(self.call_or_reject(result.map(|()| FilterAction::Continue)));
         }
 
-        // Header-only mode: use the existing one-shot callout.
-        Ok(self.call_or_reject(
-            callout::process_request_headers(
-                self.channel(),
-                &self.target,
-                self.message_timeout,
-                self.max_message_timeout,
-                ctx,
-            )
-            .await,
-        ))
+        Ok(self.call_or_reject(self.process_request_headers_on_exchange(ctx).await))
     }
 
     async fn on_request_body(
@@ -1145,19 +1279,20 @@ impl HttpFilter for ExtProcFilter {
     }
 
     async fn on_response(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
-        if self.request_body_mode.is_full_duplex() {
+        if self.response_header_mode == HeaderSendMode::Skip {
             return Ok(FilterAction::Continue);
         }
-        Ok(self.call_or_reject(
-            callout::process_response_headers(
-                self.channel(),
-                &self.target,
-                self.message_timeout,
-                self.max_message_timeout,
-                ctx,
-            )
-            .await,
-        ))
+
+        if ctx.get_filter_state::<ExtProcState>().is_some() {
+            return Ok(self.call_or_reject(self.process_response_headers_on_exchange(ctx).await));
+        }
+
+        // Fail closed: response_header_mode is send but no exchange
+        // survived the request phase. This indicates a lifecycle bug
+        // or request-phase error that consumed the exchange.
+        Ok(self.call_or_reject(Err(
+            "ext_proc: response_header_mode is send but no exchange state from request phase".into(),
+        )))
     }
 }
 

--- a/filter/ext-proc/src/tests.rs
+++ b/filter/ext-proc/src/tests.rs
@@ -85,6 +85,28 @@ processing_mode:
     assert_eq!(filter.name(), "ext_proc");
 }
 
+#[tokio::test]
+async fn parse_full_duplex_request_with_response_headers_send() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+target: "http://127.0.0.1:50051"
+message_timeout_ms: 500
+lifecycle_timeout_ms: 5000
+processing_mode:
+  request_header_mode: send
+  response_header_mode: send
+  request_body_mode: full_duplex_streamed
+  response_body_mode: none
+  request_trailer_mode: skip
+  response_trailer_mode: skip
+"#,
+    )
+    .unwrap();
+
+    let filter = ExtProcFilter::from_config(&yaml).unwrap();
+    assert_eq!(filter.name(), "ext_proc");
+}
+
 #[test]
 fn defaults_core_fields() {
     let cfg = minimal_config();
@@ -226,7 +248,7 @@ processing_mode:
 }
 
 #[tokio::test]
-async fn rejects_response_header_mode_skip() {
+async fn accepts_response_header_mode_skip() {
     let yaml: serde_yaml::Value = serde_yaml::from_str(
         r#"
 target: "http://127.0.0.1:50051"
@@ -236,11 +258,8 @@ processing_mode:
     )
     .unwrap();
 
-    let err = ExtProcFilter::from_config(&yaml).err().expect("should error");
-    assert!(
-        err.to_string().contains("response_header_mode"),
-        "error should mention response_header_mode: {err}"
-    );
+    let filter = ExtProcFilter::from_config(&yaml).expect("response_header_mode skip should be supported");
+    assert_eq!(filter.name(), "ext_proc");
 }
 
 #[tokio::test]
@@ -567,7 +586,7 @@ max_message_timeout_ms: 100
 }
 
 #[tokio::test]
-async fn rejects_deferred_close_timeout_less_than_message_timeout() {
+async fn accepts_deferred_close_timeout_shorter_than_message_timeout() {
     let yaml: serde_yaml::Value = serde_yaml::from_str(
         r#"
 target: "http://127.0.0.1:50051"
@@ -577,11 +596,22 @@ deferred_close_timeout_ms: 100
     )
     .unwrap();
 
-    let err = ExtProcFilter::from_config(&yaml).err().expect("should error");
-    assert!(
-        err.to_string().contains("deferred_close_timeout_ms"),
-        "error should reject deferred_close_timeout_ms < message_timeout_ms: {err}"
-    );
+    let filter = ExtProcFilter::from_config(&yaml).expect("shorter deferred close should be accepted");
+    assert_eq!(filter.name(), "ext_proc");
+}
+
+#[tokio::test]
+async fn accepts_zero_deferred_close_timeout() {
+    let yaml: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+target: "http://127.0.0.1:50051"
+deferred_close_timeout_ms: 0
+"#,
+    )
+    .unwrap();
+
+    let filter = ExtProcFilter::from_config(&yaml).expect("zero deferred close should be accepted");
+    assert_eq!(filter.name(), "ext_proc");
 }
 
 #[tokio::test]
@@ -1824,6 +1854,221 @@ async fn grpc_response_headers_round_trip_applies_mutation() {
         resp.headers.get("x-resp-injected").unwrap(),
         "from-processor",
         "response header should be mutated"
+    );
+}
+
+#[tokio::test]
+async fn filter_sends_response_headers_on_existing_exchange() {
+    struct TwoPhaseProcessor {
+        streams: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ExternalProcessor for TwoPhaseProcessor {
+        type ProcessStream = Pin<Box<dyn Stream<Item = Result<ProcessingResponse, tonic::Status>> + Send>>;
+
+        async fn process(
+            &self,
+            request: tonic::Request<tonic::Streaming<ProcessingRequest>>,
+        ) -> Result<tonic::Response<Self::ProcessStream>, tonic::Status> {
+            self.streams.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+            let mut stream = request.into_inner();
+            let (tx, rx) = tokio::sync::mpsc::channel(4);
+
+            tokio::spawn(async move {
+                let first = stream.message().await.unwrap().unwrap();
+                assert!(
+                    matches!(first.request, Some(processing_request::Request::RequestHeaders(_))),
+                    "first ext_proc message should be RequestHeaders"
+                );
+                let request_response = ProcessingResponse {
+                    response: Some(processing_response::Response::RequestHeaders(HeadersResponse {
+                        response: Some(CommonResponse {
+                            header_mutation: Some(HeaderMutation {
+                                set_headers: vec![make_hvo("x-request-phase", "seen")],
+                                remove_headers: vec![],
+                            }),
+                            ..Default::default()
+                        }),
+                    })),
+                    ..Default::default()
+                };
+                drop(tx.send(Ok(request_response)).await);
+
+                let second = stream.message().await.unwrap().unwrap();
+                assert!(
+                    matches!(second.request, Some(processing_request::Request::ResponseHeaders(_))),
+                    "second ext_proc message should be ResponseHeaders"
+                );
+                let response_response = ProcessingResponse {
+                    response: Some(processing_response::Response::ResponseHeaders(HeadersResponse {
+                        response: Some(CommonResponse {
+                            header_mutation: Some(HeaderMutation {
+                                set_headers: vec![make_hvo("x-response-phase", "mutated")],
+                                remove_headers: vec![],
+                            }),
+                            ..Default::default()
+                        }),
+                    })),
+                    ..Default::default()
+                };
+                drop(tx.send(Ok(response_response)).await);
+            });
+
+            Ok(tonic::Response::new(Box::pin(
+                tokio_stream::wrappers::ReceiverStream::new(rx),
+            )))
+        }
+    }
+
+    let streams = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let svc = ExternalProcessorServer::new(TwoPhaseProcessor {
+        streams: std::sync::Arc::clone(&streams),
+    });
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(svc)
+            .serve_with_incoming_shutdown(tokio_stream::wrappers::TcpListenerStream::new(listener), async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+    wait_for_server(addr).await;
+    let _guard = MockServerGuard {
+        shutdown: Some(shutdown_tx),
+    };
+
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&format!(
+        r#"
+target: "http://{addr}"
+message_timeout_ms: 5000
+processing_mode:
+  request_header_mode: send
+  response_header_mode: send
+  request_body_mode: none
+  response_body_mode: none
+"#,
+    ))
+    .unwrap();
+    let filter = ExtProcFilter::from_config(&yaml).unwrap();
+
+    let req = make_request(Method::GET, "/same-stream");
+    let mut ctx = make_ctx(&req);
+    ctx.current_filter_id = Some(42);
+
+    let request_action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(request_action, FilterAction::Continue),
+        "request header processing should continue, got {request_action:?}"
+    );
+    assert_eq!(
+        streams.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "request phase should open exactly one Process stream"
+    );
+    assert!(
+        ctx.get_filter_state::<ExtProcState>()
+            .is_some_and(|state| state.request_phase_complete),
+        "request phase should leave the exchange open for response headers"
+    );
+    assert!(
+        ctx.extra_request_headers
+            .iter()
+            .any(|(name, value)| name == "x-request-phase" && value == "seen"),
+        "request header mutation should be applied before response phase"
+    );
+
+    let mut resp = make_response();
+    ctx.response_header = Some(&mut resp);
+
+    let response_action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(
+        matches!(response_action, FilterAction::Continue),
+        "response header processing should continue"
+    );
+    assert_eq!(
+        streams.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "response phase should reuse the existing Process stream"
+    );
+    assert!(
+        ctx.get_filter_state::<ExtProcState>().is_none(),
+        "response phase should close and remove the exchange after response headers"
+    );
+    assert!(
+        ctx.response_headers_modified,
+        "response header mutation should mark headers modified"
+    );
+    assert_eq!(
+        ctx.response_header
+            .as_ref()
+            .unwrap()
+            .headers
+            .get("x-response-phase")
+            .unwrap(),
+        "mutated",
+        "response header mutation should be applied"
+    );
+}
+
+#[tokio::test]
+async fn response_header_mode_skip_does_not_process_response_headers() {
+    let (addr, _guard) = start_mock_processor(MockBehavior::AddHeader {
+        name: "x-request-phase".to_owned(),
+        value: "seen".to_owned(),
+    })
+    .await;
+
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&format!(
+        r#"
+target: "http://{addr}"
+message_timeout_ms: 5000
+processing_mode:
+  request_header_mode: send
+  response_header_mode: skip
+  request_body_mode: none
+  response_body_mode: none
+"#,
+    ))
+    .unwrap();
+    let filter = ExtProcFilter::from_config(&yaml).unwrap();
+
+    let req = make_request(Method::GET, "/skip-response-headers");
+    let mut ctx = make_ctx(&req);
+    ctx.current_filter_id = Some(42);
+
+    let request_action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(request_action, FilterAction::Continue),
+        "request header processing should continue, got {request_action:?}"
+    );
+    assert!(
+        ctx.extra_request_headers
+            .iter()
+            .any(|(name, value)| name == "x-request-phase" && value == "seen"),
+        "request header mutation should still be applied"
+    );
+    assert!(
+        ctx.get_filter_state::<ExtProcState>().is_none(),
+        "response_header_mode skip should close the exchange after request headers"
+    );
+
+    let mut resp = make_response();
+    ctx.response_header = Some(&mut resp);
+
+    let response_action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(
+        matches!(response_action, FilterAction::Continue),
+        "response_header_mode skip should pass response headers through"
+    );
+    assert!(
+        !ctx.response_headers_modified,
+        "response_header_mode skip should not mutate response headers"
     );
 }
 
@@ -6579,6 +6824,8 @@ async fn header_only_mode_unchanged() {
         r#"
 target: "http://{addr}"
 message_timeout_ms: 5000
+processing_mode:
+  response_header_mode: skip
 "#,
     ))
     .unwrap();
@@ -6603,12 +6850,12 @@ message_timeout_ms: 5000
     let action = filter.on_request(&mut ctx).await.unwrap();
     assert!(
         matches!(action, FilterAction::Continue),
-        "header-only on_request should succeed via one-shot callout"
+        "header-only on_request should succeed via request-header exchange"
     );
     let injected = ctx.extra_request_headers.iter().find(|(k, _)| k == "x-header-only");
     assert!(
         injected.is_some(),
-        "header mutation from one-shot callout should be applied"
+        "header mutation from request-header exchange should be applied"
     );
 }
 
@@ -7452,6 +7699,900 @@ processing_mode:
     assert!(
         matches!(action, FilterAction::Reject(Rejection { status: 503, .. })),
         "oversized coalesced body mutation should use status_on_error, got {action:?}"
+    );
+}
+
+#[tokio::test]
+async fn full_duplex_request_then_response_headers_reuses_exchange() {
+    struct FullDuplexResponseHeaderProcessor {
+        streams: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ExternalProcessor for FullDuplexResponseHeaderProcessor {
+        type ProcessStream = Pin<Box<dyn Stream<Item = Result<ProcessingResponse, tonic::Status>> + Send>>;
+
+        async fn process(
+            &self,
+            request: tonic::Request<tonic::Streaming<ProcessingRequest>>,
+        ) -> Result<tonic::Response<Self::ProcessStream>, tonic::Status> {
+            self.streams.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+            let mut stream = request.into_inner();
+            let (tx, rx) = tokio::sync::mpsc::channel(8);
+
+            tokio::spawn(async move {
+                let first = stream.message().await.unwrap().unwrap();
+                assert!(
+                    matches!(first.request, Some(processing_request::Request::RequestHeaders(_))),
+                    "first ext_proc message should be RequestHeaders"
+                );
+
+                loop {
+                    let msg = stream.message().await.unwrap().unwrap();
+                    if let Some(processing_request::Request::RequestBody(body)) = msg.request
+                        && body.end_of_stream
+                    {
+                        break;
+                    }
+                }
+
+                let header_resp = ProcessingResponse {
+                    response: Some(processing_response::Response::RequestHeaders(HeadersResponse {
+                        response: None,
+                    })),
+                    ..Default::default()
+                };
+                drop(tx.send(Ok(header_resp)).await);
+
+                use crate::proto::envoy::service::ext_proc::v3::{
+                    BodyMutation, CommonResponse, StreamedBodyResponse, body_mutation,
+                };
+                let body_resp = ProcessingResponse {
+                    response: Some(processing_response::Response::RequestBody(BodyResponse {
+                        response: Some(CommonResponse {
+                            body_mutation: Some(BodyMutation {
+                                mutation: Some(body_mutation::Mutation::StreamedResponse(StreamedBodyResponse {
+                                    body: Vec::new(),
+                                    end_of_stream: true,
+                                })),
+                            }),
+                            ..Default::default()
+                        }),
+                    })),
+                    ..Default::default()
+                };
+                drop(tx.send(Ok(body_resp)).await);
+
+                let response_headers = stream.message().await.unwrap().unwrap();
+                assert!(
+                    matches!(
+                        response_headers.request,
+                        Some(processing_request::Request::ResponseHeaders(_))
+                    ),
+                    "response phase should send ResponseHeaders after request body drain"
+                );
+                let response_resp = ProcessingResponse {
+                    response: Some(processing_response::Response::ResponseHeaders(HeadersResponse {
+                        response: Some(CommonResponse {
+                            header_mutation: Some(HeaderMutation {
+                                set_headers: vec![make_hvo("x-full-duplex-response", "ok")],
+                                remove_headers: vec![],
+                            }),
+                            ..Default::default()
+                        }),
+                    })),
+                    ..Default::default()
+                };
+                drop(tx.send(Ok(response_resp)).await);
+            });
+
+            Ok(tonic::Response::new(Box::pin(
+                tokio_stream::wrappers::ReceiverStream::new(rx),
+            )))
+        }
+    }
+
+    let streams = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let svc = ExternalProcessorServer::new(FullDuplexResponseHeaderProcessor {
+        streams: std::sync::Arc::clone(&streams),
+    });
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(svc)
+            .serve_with_incoming_shutdown(tokio_stream::wrappers::TcpListenerStream::new(listener), async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+    wait_for_server(addr).await;
+    let _guard = MockServerGuard {
+        shutdown: Some(shutdown_tx),
+    };
+
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&format!(
+        r#"
+target: "http://{addr}"
+message_timeout_ms: 5000
+lifecycle_timeout_ms: 5000
+processing_mode:
+  request_body_mode: full_duplex_streamed
+  response_header_mode: send
+  response_body_mode: none
+"#,
+    ))
+    .unwrap();
+    let filter = ExtProcFilter::from_config(&yaml).unwrap();
+
+    let req = make_request(Method::POST, "/fd-response-headers");
+    let mut ctx = make_ctx(&req);
+    ctx.current_filter_id = Some(42);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "on_request should bootstrap full-duplex exchange"
+    );
+
+    let mut body = Some(Bytes::from_static(b"request chunk"));
+    let action = filter.on_request_body(&mut ctx, &mut body, false).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "non-terminal request body chunk should be sent"
+    );
+
+    let mut eos_body = None;
+    let action = filter.on_request_body(&mut ctx, &mut eos_body, true).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "request body EOS should drain request responses and keep exchange open"
+    );
+    assert!(
+        ctx.get_filter_state::<ExtProcState>()
+            .is_some_and(|state| state.request_phase_complete),
+        "request drain should leave exchange state ready for response headers"
+    );
+
+    let mut resp = make_response();
+    ctx.response_header = Some(&mut resp);
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "response headers should be processed on the existing exchange"
+    );
+    assert_eq!(
+        streams.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "full-duplex request and response headers should use one Process stream"
+    );
+    assert_eq!(
+        ctx.response_header
+            .as_ref()
+            .unwrap()
+            .headers
+            .get("x-full-duplex-response")
+            .unwrap(),
+        "ok",
+        "response header mutation from processor should be applied"
+    );
+}
+
+#[tokio::test]
+async fn response_header_timeout_rejects_with_status_on_error() {
+    struct HangOnResponseHeaders;
+
+    #[async_trait]
+    impl ExternalProcessor for HangOnResponseHeaders {
+        type ProcessStream = Pin<Box<dyn Stream<Item = Result<ProcessingResponse, tonic::Status>> + Send>>;
+
+        async fn process(
+            &self,
+            request: tonic::Request<tonic::Streaming<ProcessingRequest>>,
+        ) -> Result<tonic::Response<Self::ProcessStream>, tonic::Status> {
+            let mut stream = request.into_inner();
+            let (tx, rx) = tokio::sync::mpsc::channel(4);
+
+            tokio::spawn(async move {
+                let _headers = stream.message().await;
+                let resp = ProcessingResponse {
+                    response: Some(processing_response::Response::RequestHeaders(HeadersResponse {
+                        response: None,
+                    })),
+                    ..Default::default()
+                };
+                drop(tx.send(Ok(resp)).await);
+                let _response_headers = stream.message().await;
+                // Never respond to ResponseHeaders — simulate timeout
+                futures::future::pending::<()>().await;
+            });
+
+            Ok(tonic::Response::new(Box::pin(
+                tokio_stream::wrappers::ReceiverStream::new(rx),
+            )))
+        }
+    }
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let svc = ExternalProcessorServer::new(HangOnResponseHeaders);
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(svc)
+            .serve_with_incoming_shutdown(tokio_stream::wrappers::TcpListenerStream::new(listener), async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+    wait_for_server(addr).await;
+    let _guard = MockServerGuard {
+        shutdown: Some(shutdown_tx),
+    };
+
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&format!(
+        r#"
+target: "http://{addr}"
+message_timeout_ms: 100
+status_on_error: 504
+processing_mode:
+  response_header_mode: send
+"#,
+    ))
+    .unwrap();
+    let filter = ExtProcFilter::from_config(&yaml).unwrap();
+
+    let req = make_request(Method::GET, "/timeout-response");
+    let mut ctx = make_ctx(&req);
+    ctx.current_filter_id = Some(42);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+
+    let mut resp = make_response();
+    ctx.response_header = Some(&mut resp);
+
+    let start = Instant::now();
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    let elapsed = start.elapsed();
+
+    match &action {
+        FilterAction::Reject(r) if r.status == 504 => {},
+        other => panic!("response-header timeout should reject with 504, got {other:?}"),
+    }
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "timeout should fire near configured 100ms, not hang (took {elapsed:?})"
+    );
+}
+
+#[tokio::test]
+async fn response_header_immediate_response_on_existing_exchange() {
+    struct ImmediateOnResponseHeaders {
+        streams: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ExternalProcessor for ImmediateOnResponseHeaders {
+        type ProcessStream = Pin<Box<dyn Stream<Item = Result<ProcessingResponse, tonic::Status>> + Send>>;
+
+        async fn process(
+            &self,
+            request: tonic::Request<tonic::Streaming<ProcessingRequest>>,
+        ) -> Result<tonic::Response<Self::ProcessStream>, tonic::Status> {
+            self.streams.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let mut stream = request.into_inner();
+            let (tx, rx) = tokio::sync::mpsc::channel(4);
+
+            tokio::spawn(async move {
+                let _headers = stream.message().await;
+                let resp = ProcessingResponse {
+                    response: Some(processing_response::Response::RequestHeaders(HeadersResponse {
+                        response: None,
+                    })),
+                    ..Default::default()
+                };
+                drop(tx.send(Ok(resp)).await);
+
+                let _response_headers = stream.message().await;
+                use crate::proto::envoy::service::common::v3::HttpStatus;
+                let resp = ProcessingResponse {
+                    response: Some(processing_response::Response::ImmediateResponse(ImmediateResponse {
+                        status: Some(HttpStatus { code: 429 }),
+                        body: "rate limited by processor".to_owned(),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                };
+                drop(tx.send(Ok(resp)).await);
+            });
+
+            Ok(tonic::Response::new(Box::pin(
+                tokio_stream::wrappers::ReceiverStream::new(rx),
+            )))
+        }
+    }
+
+    let streams = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let svc = ExternalProcessorServer::new(ImmediateOnResponseHeaders {
+        streams: std::sync::Arc::clone(&streams),
+    });
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(svc)
+            .serve_with_incoming_shutdown(tokio_stream::wrappers::TcpListenerStream::new(listener), async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+    wait_for_server(addr).await;
+    let _guard = MockServerGuard {
+        shutdown: Some(shutdown_tx),
+    };
+
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&format!(
+        r#"
+target: "http://{addr}"
+message_timeout_ms: 5000
+processing_mode:
+  response_header_mode: send
+"#,
+    ))
+    .unwrap();
+    let filter = ExtProcFilter::from_config(&yaml).unwrap();
+
+    let req = make_request(Method::GET, "/immediate-response-phase");
+    let mut ctx = make_ctx(&req);
+    ctx.current_filter_id = Some(42);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+
+    let mut resp = make_response();
+    ctx.response_header = Some(&mut resp);
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    match &action {
+        FilterAction::Reject(r) if r.status == 429 => {},
+        other => panic!("response-header ImmediateResponse should produce 429 rejection, got {other:?}"),
+    }
+    assert_eq!(
+        streams.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "ImmediateResponse during response headers should use the same Process stream"
+    );
+}
+
+#[tokio::test]
+async fn response_header_dynamic_metadata_persisted() {
+    struct MetadataOnResponseHeaders;
+
+    #[async_trait]
+    impl ExternalProcessor for MetadataOnResponseHeaders {
+        type ProcessStream = Pin<Box<dyn Stream<Item = Result<ProcessingResponse, tonic::Status>> + Send>>;
+
+        async fn process(
+            &self,
+            request: tonic::Request<tonic::Streaming<ProcessingRequest>>,
+        ) -> Result<tonic::Response<Self::ProcessStream>, tonic::Status> {
+            let mut stream = request.into_inner();
+            let (tx, rx) = tokio::sync::mpsc::channel(4);
+
+            tokio::spawn(async move {
+                let _headers = stream.message().await;
+                let resp = ProcessingResponse {
+                    response: Some(processing_response::Response::RequestHeaders(HeadersResponse {
+                        response: None,
+                    })),
+                    ..Default::default()
+                };
+                drop(tx.send(Ok(resp)).await);
+
+                let _response_headers = stream.message().await;
+                let mut fields = HashMap::new();
+                fields.insert(
+                    "response_model".to_owned(),
+                    prost_wkt_types::Value {
+                        kind: Some(prost_wkt_types::value::Kind::StringValue("gpt-4o".to_owned())),
+                    },
+                );
+                let resp = ProcessingResponse {
+                    response: Some(processing_response::Response::ResponseHeaders(HeadersResponse {
+                        response: None,
+                    })),
+                    dynamic_metadata: Some(prost_wkt_types::Struct { fields }),
+                    ..Default::default()
+                };
+                drop(tx.send(Ok(resp)).await);
+            });
+
+            Ok(tonic::Response::new(Box::pin(
+                tokio_stream::wrappers::ReceiverStream::new(rx),
+            )))
+        }
+    }
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let svc = ExternalProcessorServer::new(MetadataOnResponseHeaders);
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(svc)
+            .serve_with_incoming_shutdown(tokio_stream::wrappers::TcpListenerStream::new(listener), async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+    wait_for_server(addr).await;
+    let _guard = MockServerGuard {
+        shutdown: Some(shutdown_tx),
+    };
+
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&format!(
+        r#"
+target: "http://{addr}"
+message_timeout_ms: 5000
+processing_mode:
+  response_header_mode: send
+"#,
+    ))
+    .unwrap();
+    let filter = ExtProcFilter::from_config(&yaml).unwrap();
+
+    let req = make_request(Method::GET, "/metadata-response");
+    let mut ctx = make_ctx(&req);
+    ctx.current_filter_id = Some(42);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+
+    let mut resp = make_response();
+    ctx.response_header = Some(&mut resp);
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "response header processing should continue, got {action:?}"
+    );
+    assert_eq!(
+        ctx.get_structured_metadata("ext_proc", "response_model"),
+        Some(&serde_json::json!("gpt-4o")),
+        "response-phase dynamic metadata should be persisted to structured_metadata"
+    );
+}
+
+#[tokio::test]
+async fn header_only_request_trailing_drain_does_not_hang() {
+    struct RespondThenHang;
+
+    #[async_trait]
+    impl ExternalProcessor for RespondThenHang {
+        type ProcessStream = Pin<Box<dyn Stream<Item = Result<ProcessingResponse, tonic::Status>> + Send>>;
+
+        async fn process(
+            &self,
+            request: tonic::Request<tonic::Streaming<ProcessingRequest>>,
+        ) -> Result<tonic::Response<Self::ProcessStream>, tonic::Status> {
+            let mut stream = request.into_inner();
+            let (tx, rx) = tokio::sync::mpsc::channel(4);
+            tokio::spawn(async move {
+                let _headers = stream.message().await;
+                let resp = ProcessingResponse {
+                    response: Some(processing_response::Response::RequestHeaders(HeadersResponse {
+                        response: Some(CommonResponse {
+                            header_mutation: Some(HeaderMutation {
+                                set_headers: vec![make_hvo("x-trailing-drain", "applied")],
+                                remove_headers: vec![],
+                            }),
+                            ..Default::default()
+                        }),
+                    })),
+                    ..Default::default()
+                };
+                drop(tx.send(Ok(resp)).await);
+                futures::future::pending::<()>().await;
+            });
+            Ok(tonic::Response::new(Box::pin(
+                tokio_stream::wrappers::ReceiverStream::new(rx),
+            )))
+        }
+    }
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(ExternalProcessorServer::new(RespondThenHang))
+            .serve_with_incoming_shutdown(tokio_stream::wrappers::TcpListenerStream::new(listener), async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+    wait_for_server(addr).await;
+    let _guard = MockServerGuard {
+        shutdown: Some(shutdown_tx),
+    };
+
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&format!(
+        r#"
+target: "http://{addr}"
+message_timeout_ms: 100
+deferred_close_timeout_ms: 100
+processing_mode:
+  response_header_mode: skip
+"#,
+    ))
+    .unwrap();
+    let filter = ExtProcFilter::from_config(&yaml).unwrap();
+
+    let req = make_request(Method::GET, "/trailing-drain");
+    let mut ctx = make_ctx(&req);
+    ctx.current_filter_id = Some(42);
+
+    let start = Instant::now();
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    let elapsed = start.elapsed();
+
+    assert!(matches!(action, FilterAction::Continue));
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "header-only request must not hang on trailing drain (took {elapsed:?})"
+    );
+    assert!(
+        ctx.extra_request_headers.iter().any(|(n, _)| n == "x-trailing-drain"),
+        "mutation from the response should still be applied"
+    );
+}
+
+#[tokio::test]
+async fn response_header_continue_trailing_drain_does_not_hang() {
+    struct RespondBothThenHang;
+
+    #[async_trait]
+    impl ExternalProcessor for RespondBothThenHang {
+        type ProcessStream = Pin<Box<dyn Stream<Item = Result<ProcessingResponse, tonic::Status>> + Send>>;
+
+        async fn process(
+            &self,
+            request: tonic::Request<tonic::Streaming<ProcessingRequest>>,
+        ) -> Result<tonic::Response<Self::ProcessStream>, tonic::Status> {
+            let mut stream = request.into_inner();
+            let (tx, rx) = tokio::sync::mpsc::channel(4);
+            tokio::spawn(async move {
+                let _headers = stream.message().await;
+                let resp = ProcessingResponse {
+                    response: Some(processing_response::Response::RequestHeaders(HeadersResponse {
+                        response: None,
+                    })),
+                    ..Default::default()
+                };
+                drop(tx.send(Ok(resp)).await);
+
+                let _response_headers = stream.message().await;
+                let resp = ProcessingResponse {
+                    response: Some(processing_response::Response::ResponseHeaders(HeadersResponse {
+                        response: Some(CommonResponse {
+                            header_mutation: Some(HeaderMutation {
+                                set_headers: vec![make_hvo("x-resp-drain", "applied")],
+                                remove_headers: vec![],
+                            }),
+                            ..Default::default()
+                        }),
+                    })),
+                    ..Default::default()
+                };
+                drop(tx.send(Ok(resp)).await);
+                futures::future::pending::<()>().await;
+            });
+            Ok(tonic::Response::new(Box::pin(
+                tokio_stream::wrappers::ReceiverStream::new(rx),
+            )))
+        }
+    }
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(ExternalProcessorServer::new(RespondBothThenHang))
+            .serve_with_incoming_shutdown(tokio_stream::wrappers::TcpListenerStream::new(listener), async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+    wait_for_server(addr).await;
+    let _guard = MockServerGuard {
+        shutdown: Some(shutdown_tx),
+    };
+
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&format!(
+        r#"
+target: "http://{addr}"
+message_timeout_ms: 200
+deferred_close_timeout_ms: 200
+processing_mode:
+  response_header_mode: send
+"#,
+    ))
+    .unwrap();
+    let filter = ExtProcFilter::from_config(&yaml).unwrap();
+
+    let req = make_request(Method::GET, "/resp-trailing-drain");
+    let mut ctx = make_ctx(&req);
+    ctx.current_filter_id = Some(42);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+
+    let mut resp = make_response();
+    ctx.response_header = Some(&mut resp);
+
+    let start = Instant::now();
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    let elapsed = start.elapsed();
+
+    assert!(matches!(action, FilterAction::Continue));
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "response-header Continue must not hang on trailing drain (took {elapsed:?})"
+    );
+    assert!(ctx.response_headers_modified, "response mutation should be applied");
+}
+
+#[tokio::test]
+async fn response_header_immediate_does_not_hang_on_trailing_drain() {
+    struct ImmediateThenHang;
+
+    #[async_trait]
+    impl ExternalProcessor for ImmediateThenHang {
+        type ProcessStream = Pin<Box<dyn Stream<Item = Result<ProcessingResponse, tonic::Status>> + Send>>;
+
+        async fn process(
+            &self,
+            request: tonic::Request<tonic::Streaming<ProcessingRequest>>,
+        ) -> Result<tonic::Response<Self::ProcessStream>, tonic::Status> {
+            let mut stream = request.into_inner();
+            let (tx, rx) = tokio::sync::mpsc::channel(4);
+            tokio::spawn(async move {
+                let _headers = stream.message().await;
+                let resp = ProcessingResponse {
+                    response: Some(processing_response::Response::RequestHeaders(HeadersResponse {
+                        response: None,
+                    })),
+                    ..Default::default()
+                };
+                drop(tx.send(Ok(resp)).await);
+
+                let _response_headers = stream.message().await;
+                use crate::proto::envoy::service::common::v3::HttpStatus;
+                let resp = ProcessingResponse {
+                    response: Some(processing_response::Response::ImmediateResponse(ImmediateResponse {
+                        status: Some(HttpStatus { code: 503 }),
+                        body: "rejected during response".to_owned(),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                };
+                drop(tx.send(Ok(resp)).await);
+                futures::future::pending::<()>().await;
+            });
+            Ok(tonic::Response::new(Box::pin(
+                tokio_stream::wrappers::ReceiverStream::new(rx),
+            )))
+        }
+    }
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(ExternalProcessorServer::new(ImmediateThenHang))
+            .serve_with_incoming_shutdown(tokio_stream::wrappers::TcpListenerStream::new(listener), async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+    wait_for_server(addr).await;
+    let _guard = MockServerGuard {
+        shutdown: Some(shutdown_tx),
+    };
+
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&format!(
+        r#"
+target: "http://{addr}"
+message_timeout_ms: 200
+deferred_close_timeout_ms: 200
+processing_mode:
+  response_header_mode: send
+"#,
+    ))
+    .unwrap();
+    let filter = ExtProcFilter::from_config(&yaml).unwrap();
+
+    let req = make_request(Method::GET, "/imm-trailing-drain");
+    let mut ctx = make_ctx(&req);
+    ctx.current_filter_id = Some(42);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+
+    let mut resp = make_response();
+    ctx.response_header = Some(&mut resp);
+
+    let start = Instant::now();
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    let elapsed = start.elapsed();
+
+    match &action {
+        FilterAction::Reject(r) if r.status == 503 => {},
+        other => panic!("response-header ImmediateResponse should produce 503, got {other:?}"),
+    }
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "ImmediateResponse must not hang on trailing drain (took {elapsed:?})"
+    );
+}
+
+#[tokio::test]
+async fn response_header_mode_send_without_state_rejects() {
+    let (addr, _guard) = start_mock_processor(MockBehavior::AddHeader {
+        name: "x-req".to_owned(),
+        value: "ok".to_owned(),
+    })
+    .await;
+
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&format!(
+        r#"
+target: "http://{addr}"
+message_timeout_ms: 200
+status_on_error: 502
+processing_mode:
+  response_header_mode: send
+"#,
+    ))
+    .unwrap();
+    let filter = ExtProcFilter::from_config(&yaml).unwrap();
+
+    let req = make_request(Method::GET, "/missing-state");
+    let mut ctx = make_ctx(&req);
+    ctx.current_filter_id = Some(42);
+
+    // Skip on_request so no ExtProcState is stored
+    let mut resp = make_response();
+    ctx.response_header = Some(&mut resp);
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    match &action {
+        FilterAction::Reject(r) if r.status == 502 => {},
+        other => panic!("missing state should reject with status_on_error 502, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn response_header_override_timeout_respected() {
+    struct OverrideThenDelayedResponse;
+
+    #[async_trait]
+    impl ExternalProcessor for OverrideThenDelayedResponse {
+        type ProcessStream = Pin<Box<dyn Stream<Item = Result<ProcessingResponse, tonic::Status>> + Send>>;
+
+        async fn process(
+            &self,
+            request: tonic::Request<tonic::Streaming<ProcessingRequest>>,
+        ) -> Result<tonic::Response<Self::ProcessStream>, tonic::Status> {
+            let mut stream = request.into_inner();
+            let (tx, rx) = tokio::sync::mpsc::channel(4);
+            tokio::spawn(async move {
+                let _headers = stream.message().await;
+                let resp = ProcessingResponse {
+                    response: Some(processing_response::Response::RequestHeaders(HeadersResponse {
+                        response: None,
+                    })),
+                    ..Default::default()
+                };
+                drop(tx.send(Ok(resp)).await);
+
+                let _response_headers = stream.message().await;
+                // Send override extending timeout to 2s
+                let override_resp = ProcessingResponse {
+                    override_message_timeout: Some(prost_types::Duration { seconds: 2, nanos: 0 }),
+                    ..Default::default()
+                };
+                drop(tx.send(Ok(override_resp)).await);
+
+                // Delay past original message_timeout (200ms) but within override (2s)
+                tokio::time::sleep(Duration::from_millis(400)).await;
+
+                let resp = ProcessingResponse {
+                    response: Some(processing_response::Response::ResponseHeaders(HeadersResponse {
+                        response: Some(CommonResponse {
+                            header_mutation: Some(HeaderMutation {
+                                set_headers: vec![make_hvo("x-override-worked", "yes")],
+                                remove_headers: vec![],
+                            }),
+                            ..Default::default()
+                        }),
+                    })),
+                    ..Default::default()
+                };
+                drop(tx.send(Ok(resp)).await);
+            });
+            Ok(tonic::Response::new(Box::pin(
+                tokio_stream::wrappers::ReceiverStream::new(rx),
+            )))
+        }
+    }
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(ExternalProcessorServer::new(OverrideThenDelayedResponse))
+            .serve_with_incoming_shutdown(tokio_stream::wrappers::TcpListenerStream::new(listener), async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+    wait_for_server(addr).await;
+    let _guard = MockServerGuard {
+        shutdown: Some(shutdown_tx),
+    };
+
+    let yaml: serde_yaml::Value = serde_yaml::from_str(&format!(
+        r#"
+target: "http://{addr}"
+message_timeout_ms: 200
+max_message_timeout_ms: 5000
+deferred_close_timeout_ms: 200
+processing_mode:
+  response_header_mode: send
+"#,
+    ))
+    .unwrap();
+    let filter = ExtProcFilter::from_config(&yaml).unwrap();
+
+    let req = make_request(Method::GET, "/override-timeout");
+    let mut ctx = make_ctx(&req);
+    ctx.current_filter_id = Some(42);
+
+    let action = filter.on_request(&mut ctx).await.unwrap();
+    assert!(matches!(action, FilterAction::Continue));
+
+    let mut resp = make_response();
+    ctx.response_header = Some(&mut resp);
+
+    let action = filter.on_response(&mut ctx).await.unwrap();
+    assert!(
+        matches!(action, FilterAction::Continue),
+        "response headers should succeed via timeout override, got {action:?}"
+    );
+    assert_eq!(
+        ctx.response_header
+            .as_ref()
+            .unwrap()
+            .headers
+            .get("x-override-worked")
+            .unwrap(),
+        "yes",
+        "response mutation from delayed-but-overridden response should be applied"
     );
 }
 


### PR DESCRIPTION
 ## Summary

  Adds response-header lifecycle support to the `ext_proc` filter.

  The request-routing path from #707 and the integration coverage from #747 established the request-side full-duplex exchange. This PR extends that same exchange through the response-header phase so Praxis can send backend response headers to an external processor, apply response-header mutations, persist dynamic metadata, and handle response-phase `ImmediateResponse`.

  ## What Changed

  - Allows `response_header_mode: send`.
  - Keeps `response_header_mode: skip` as a real no-op.
  - Reuses the existing request-phase `ExternalProcessor.Process` stream for response-header processing.
  - Sends `ResponseHeaders` during `on_response`.
  - Applies response-header mutations returned by the processor.
  - Persists response-phase `dynamic_metadata` into `ctx.structured_metadata`.
  - Handles `ImmediateResponse` during response-header processing.
  - Fails closed with `status_on_error` if response-header processing is requested but request-phase exchange state is missing.
  - Adds bounded best-effort trailing cleanup via `deferred_close_timeout_ms`.
  - Preserves request-routing behavior from the merged full-duplex work.

  ## Timeout Behavior

  Response-header send is bounded by `message_timeout_ms`.

  Response-header receive uses the exchange’s active-processing deadline, including `override_message_timeout` support. This preserves Envoy-style timeout override behavior while avoiding an outer timeout that would mask valid processor overrides.

  Trailing cleanup is best-effort and bounded by `deferred_close_timeout_ms`; setting it to `0` skips trailing drain cleanup.

  ## Why This Matters for llm-d

  The current llm-d routing path only requires request-side processing: Praxis sends request headers/body to the EPP, waits for an endpoint decision, and routes the request.

  This PR extends Praxis toward the full Envoy `ext_proc` lifecycle by keeping the same processor stream alive through response headers. That matters for llm-d because environment-backed integrations need a feedback path after routing: backend identity, model/pool metadata, cache or scheduler signals, failure status, and future token/accounting data may be visible only once the selected backend responds.

  This remains generic `ext_proc` behavior. It does not add llm-d-specific routing logic to Praxis; it gives standard external processors the lifecycle surface they expect.

  ## Tests

  Adds coverage for:

  - `response_header_mode: send` config acceptance
  - `response_header_mode: skip` no-op behavior
  - response headers sent on the existing exchange
  - full-duplex request body drain followed by response headers on the same stream
  - response-header mutation application
  - response-phase `ImmediateResponse`
  - response-phase dynamic metadata persistence
  - response-header timeout handling
  - response-header `override_message_timeout`
  - missing exchange state fail-closed behavior
  - bounded trailing cleanup paths
  - shorter and zero `deferred_close_timeout_ms`

  ## Deferred

  This PR is one step in the planned full Envoy `ext_proc` compatibility work. The following generic `ext_proc` parity items are intentionally deferred to follow-up PRs:

  - response body processing
  - request and response trailers
  - full processing-mode override matrix
  - mutation and forwarding rules
  - metadata options and attributes
  - per-route and processor-target overrides
  - observability mode
  - stats, examples, and conformance coverage

These are protocol/gateway features, not llm-d-specific behavior. AI-specific policy will remain outside Praxis core, in `praxis-proxy/ai`.

  ## Validation

  - `git diff --check`
  - `cargo +nightly-2026-03-28 fmt --all -- --check`
  - `make lint`
  - `cargo clippy --workspace --all-targets -- -D warnings`
  - `cargo test -p praxis-proxy-ext-proc`
  - `cargo test -p praxis-proxy-ext-proc -- --test-threads=1`
  - `cargo test -p praxis-proxy-filter`
  - `cargo test -p praxis-proxy-protocol`
  - `cargo test -p praxis-tests-integration --test suite ext_proc`
  - `cargo doc --workspace --no-deps --document-private-items`
