### PR TITLE
feat(ext-proc): make external processor crate publishable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ audit:
 	cargo deny check
 
 PUBLISH_CRATES := praxis-proxy-tls praxis-proxy-core \
-	praxis-proxy-filter praxis-proxy-protocol praxis-proxy
+	praxis-proxy-filter praxis-proxy-ext-proc praxis-proxy-protocol praxis-proxy
 
 publish-dry-run:
 	@for crate in $(PUBLISH_CRATES); do \

--- a/filter/ext-proc/Cargo.toml
+++ b/filter/ext-proc/Cargo.toml
@@ -8,7 +8,7 @@ description = "Envoy-compatible ext_proc filter for Praxis"
 license = "MIT AND Apache-2.0 AND BSD-3-Clause"
 repository.workspace = true
 readme = "../../README.md"
-publish = false
+publish = true
 
 [lib]
 name = "praxis_ext_proc"

--- a/filter/ext-proc/src/lib.rs
+++ b/filter/ext-proc/src/lib.rs
@@ -43,11 +43,14 @@
 //! use praxis_filter::FilterRegistry;
 //!
 //! let mut registry = FilterRegistry::with_builtins();
-//! registry.register(
-//!     "ext_proc",
-//!     praxis_filter::http_builtin(praxis_ext_proc::ExtProcFilter::from_config),
-//! ).unwrap();
+//! praxis_ext_proc::register_filters(&mut registry);
 //! ```
+//!
+//! # Protocol Types
+//!
+//! Generated Envoy protobuf and gRPC types are exposed under [`proto`]
+//! so downstream tests and external processor implementations can use
+//! the same vendored protocol definitions as the filter.
 //!
 //! [`HttpFilter`]: praxis_filter::HttpFilter
 //! [`FilterRegistry::with_builtins`]: praxis_filter::FilterRegistry::with_builtins
@@ -59,7 +62,7 @@
 mod callout;
 pub(crate) mod duplex;
 mod mutations;
-pub(crate) mod proto;
+pub mod proto;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -1159,6 +1162,10 @@ impl HttpFilter for ExtProcFilter {
             .await,
         ))
     }
+}
+
+praxis_filter::export_filters! {
+    http "ext_proc" => ExtProcFilter::from_config,
 }
 
 #[cfg(test)]

--- a/filter/ext-proc/src/proto.rs
+++ b/filter/ext-proc/src/proto.rs
@@ -8,14 +8,17 @@
 //!
 //! Compiled from vendored `.proto` files at build time.
 
+/// Envoy API protobuf modules.
 #[allow(
     clippy::allow_attributes,
     clippy::missing_docs_in_private_items,
     reason = "generated protobuf module tree"
 )]
-pub(crate) mod envoy {
-    pub(crate) mod service {
-        pub(crate) mod common {
+pub mod envoy {
+    /// Envoy service protobuf modules.
+    pub mod service {
+        /// Shared Envoy service protobuf types.
+        pub mod common {
             #[allow(
                 dead_code,
                 missing_docs,
@@ -41,7 +44,8 @@ pub(crate) mod envoy {
             }
         }
 
-        pub(crate) mod ext_proc {
+        /// Envoy external processing protobuf types and gRPC service.
+        pub mod ext_proc {
             #[allow(
                 dead_code,
                 missing_docs,
@@ -57,6 +61,7 @@ pub(crate) mod envoy {
                 clippy::doc_markdown,
                 clippy::enum_variant_names,
                 clippy::missing_docs_in_private_items,
+                clippy::missing_errors_doc,
                 clippy::needless_borrows_for_generic_args,
                 clippy::too_many_lines,
                 clippy::trivially_copy_pass_by_ref,


### PR DESCRIPTION
  ## Summary

This PR makes the generic `praxis-proxy-ext-proc` crate publishable.

  Currently `ext_proc` works inside the Praxis workspace, but downstream repos cannot depend on it through the normal released-crate path. That blocks [llm-d integration](https://github.com/praxis-proxy/ai/issues/166)  test work in `praxis-proxy/ai`, where the AI gateway needs to register the same  generic `ext_proc` filter without local-path or git-dependency workarounds.

  `ext_proc` is not full Envoy parity yet, but publishing the crate unblocks the llm-d integration-testing epic.

  ## What Changed

  - Marks `praxis-proxy-ext-proc` as publishable.
  - Exports `register_filters()` so downstream binaries can explicitly register the filter.
  - Exposes `praxis_ext_proc::proto` so downstream code can use the generated Envoy `ext_proc` protobuf and gRPC types.
  - Adds `praxis-proxy-ext-proc` to the `Makefile` publish dry-run crate list.

## Generated Proto Lint Suppression

  This PR exposes `praxis_ext_proc::proto` so downstream crates can use the same generated Envoy `ext_proc` protobuf and gRPC types as Praxis. That is needed for downstream integration tests and external processor implementations that need `ExternalProcessor`, `ExternalProcessorServer`, `ProcessingRequest`, and `ProcessingResponse`.

  This is a new public API shape for Praxis filter crates: most published filters expose handwritten Rust filters/config types, while `praxis-proxy-ext-proc` also exposes generated tonic/prost code.

  Because the tonic-generated gRPC client/server methods are generated code, they do not include Praxis-style rustdoc sections such as `# Errors` on every public `Result` returning method. The PR keeps Praxis lint standards for handwritten code and suppresses generated-code-only Clippy lints only at the `include_proto!` module boundary.

  ## Validation

  - `git diff --check`
  - `cargo +nightly-2026-03-28 fmt --all -- --check`
  - `make lint`
  - `cargo clippy --workspace --all-targets -- -D warnings`
  - `cargo test -p praxis-proxy-ext-proc`
  - `cargo test -p praxis-proxy-ext-proc -- --test-threads=1`
  - `cargo deny check`
  - `cargo doc --workspace --no-deps --document-private-items`
  - `cargo package -p praxis-proxy-ext-proc --allow-dirty --no-verify`

  Note: full `cargo package` verification depends on release ordering and will pass after the next `praxis-proxy-filter` crate version is published first.
