### PR TITLE
chore: add `praxis.yaml` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ docs/**/
 !docs/filters/tcp/*/
 !docs/operating/
 !docs/proposals/
+
+# Praxis config files
+praxis.yaml


### PR DESCRIPTION
this is the example server config file from the quickstart: https://praxis.fast/docs/getting-started/quickstart

since the project can only be run from source currently, typically this will land in this repo, however we would never want a file like this to be tracked