### PR TITLE
fix(server): add `--version` flag to CLI

### DIFF
--- a/server/build.rs
+++ b/server/build.rs
@@ -27,6 +27,8 @@ struct ActiveFeatures {
 }
 
 fn main() {
+    emit_version_env();
+
     let Some(metadata) = load_metadata() else {
         write_generated_file(&generate_registration_code(&[]));
         return;
@@ -178,6 +180,50 @@ fn write_generated_file(code: &str) {
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
     let dest = std::path::Path::new(&out_dir).join("external_filters.rs");
     std::fs::write(&dest, code).expect("failed to write external_filters.rs");
+}
+
+/// Emit `PRAXIS_VERSION` with the package version, git SHA, and dirty marker.
+///
+/// Produces `X.Y.Z (abc1234)` on a clean checkout or `X.Y.Z (abc1234-dirty)`
+/// when there are uncommitted changes. Falls back to the plain package version
+/// when git is unavailable.
+fn emit_version_env() {
+    let git_dir = std::path::Path::new("../.git");
+    let head_path = git_dir.join("HEAD");
+    println!("cargo:rerun-if-changed={}", head_path.display());
+
+    if let Ok(head) = std::fs::read_to_string(&head_path)
+        && let Some(ref_path) = head.strip_prefix("ref: ")
+    {
+        println!("cargo:rerun-if-changed={}", git_dir.join(ref_path.trim()).display());
+    }
+    println!("cargo:rerun-if-changed={}", git_dir.join("index").display());
+
+    let pkg_version = std::env::var("CARGO_PKG_VERSION").unwrap_or_default();
+    let version = match git_version_suffix() {
+        Some(suffix) => format!("{pkg_version} ({suffix})"),
+        None => pkg_version,
+    };
+    println!("cargo:rustc-env=PRAXIS_VERSION={version}");
+}
+
+/// Return the git short SHA, optionally suffixed with `-dirty`.
+fn git_version_suffix() -> Option<String> {
+    let sha = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())?;
+
+    let dirty = std::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .is_some_and(|o| !o.stdout.is_empty());
+
+    Some(if dirty { format!("{sha}-dirty") } else { sha })
 }
 
 /// Tell Cargo when to re-run this build script.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -27,7 +27,7 @@ use tracing::info;
 
 /// Cloud and AI-native proxy server.
 #[derive(Parser)]
-#[command(name = "praxis")]
+#[command(name = "praxis", version)]
 struct Cli {
     /// Path to the YAML configuration file.
     #[arg(short = 'c', long = "config")]

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -27,7 +27,7 @@ use tracing::info;
 
 /// Cloud and AI-native proxy server.
 #[derive(Parser)]
-#[command(name = "praxis", version)]
+#[command(name = "praxis", version = env!("PRAXIS_VERSION"))]
 struct Cli {
     /// Path to the YAML configuration file.
     #[arg(short = 'c', long = "config")]
@@ -71,7 +71,7 @@ fn main() {
     let config_path = praxis::resolve_config_path(explicit.as_deref());
     let config = praxis::load_config(explicit.as_deref()).unwrap_or_else(|e| praxis::fatal(&e));
     praxis::init_tracing(&config).unwrap_or_else(|e| praxis::fatal(&e));
-    info!("starting server");
+    info!(version = env!("PRAXIS_VERSION"), "starting server");
     praxis::run_server(config, config_path)
 }
 
@@ -164,6 +164,15 @@ mod tests {
         assert!(
             matches!(&result, Err(e) if e.kind() == clap::error::ErrorKind::DisplayVersion),
             "--version should be recognized"
+        );
+    }
+
+    #[test]
+    fn cli_version_short_flag() {
+        let result = Cli::try_parse_from(["praxis", "-V"]);
+        assert!(
+            matches!(&result, Err(e) if e.kind() == clap::error::ErrorKind::DisplayVersion),
+            "-V should be recognized"
         );
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -153,4 +153,17 @@ mod tests {
         let result = Cli::try_parse_from(["praxis", "-T", "-t"]);
         assert!(result.is_err(), "-T and -t should conflict");
     }
+
+    // -------------------------------------------------------------------------
+    // --version CLI parsing
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn cli_version_flag() {
+        let result = Cli::try_parse_from(["praxis", "--version"]);
+        assert!(
+            matches!(&result, Err(e) if e.kind() == clap::error::ErrorKind::DisplayVersion),
+            "--version should be recognized"
+        );
+    }
 }


### PR DESCRIPTION
As noted in https://github.com/praxis-proxy/praxis-proxy.github.io/issues/5, there seems to be an expectation for a `--version` flag to be exposed in Praxis. However, this did not currently exist in the codebase.

This PR adds the version command to the CLI, as well as a regression test to ensure this functionality exists moving forward.