### PR TITLE
docs: add linting guidance to contribution guide

### DIFF
--- a/docs/developing/getting-started.md
+++ b/docs/developing/getting-started.md
@@ -17,6 +17,15 @@ that do not follow these conventions will be rejected.
 
 [conventions.md]:./conventions.md
 
+## Lint
+
+```console
+make fmt
+make lint
+```
+
+It is recommended you run `make setup-hooks` to setup pre-commit hooks that ensure linting is always done before commiting code.
+
 ## Build
 
 ```console
@@ -29,9 +38,6 @@ make check
 
 ```console
 make test
-```
-
-```console
 make test-integration
 ```
 

--- a/docs/developing/getting-started.md
+++ b/docs/developing/getting-started.md
@@ -24,7 +24,9 @@ make fmt
 make lint
 ```
 
-It is recommended you run `make setup-hooks` to setup pre-commit hooks that ensure linting is always done before commiting code.
+It is recommended you run `make setup-hooks` to set
+up pre-commit hooks that ensure linting is always
+done before committing code.
 
 ## Build
 


### PR DESCRIPTION
there is no mention of several linting makefile commands in the contribution guide - this led to me pushing lint errors on a different that would have been better to have caught locally 

add small section documenting `make fmt`, `make lint`, and `make setup-hooks`

also cleanup test command formatting a smidge