### PR TITLE
build(container): use UBI 10 minimal runtime

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -7,6 +7,12 @@ name: Container
 on:
   push:
     branches: [main]
+  pull_request:
+    paths:
+      - Containerfile
+      - Cargo.toml
+      - Cargo.lock
+      - '**/Cargo.toml'
 
 permissions: {}
 
@@ -42,6 +48,22 @@ jobs:
           docker inspect --format='{{json .State.Health}}' praxis
           docker logs praxis
           exit 1
+
+      - name: Verify non-root user
+        run: |
+          user=$(docker exec praxis whoami)
+          if [ "${user}" != "praxis" ]; then
+            echo "Expected user 'praxis', got '${user}'"
+            exit 1
+          fi
+
+      - name: Verify health endpoint
+        run: |
+          response=$(docker exec praxis curl -fsS http://127.0.0.1:9901/healthy)
+          if [ "${response}" != '{"status":"ok"}' ]; then
+            echo "Unexpected health response: ${response}"
+            exit 1
+          fi
 
       - name: Stop container
         if: always()

--- a/Containerfile
+++ b/Containerfile
@@ -84,15 +84,24 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # Stage 2: Runtime
 # ------------------------------------------------------------------------------
 
-FROM alpine:3.23
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
 
 LABEL org.opencontainers.image.source="https://github.com/praxis-proxy/praxis" \
     org.opencontainers.image.description="Praxis proxy server" \
     org.opencontainers.image.licenses="MIT"
 
-RUN apk add --no-cache ca-certificates \
-    && addgroup -S praxis \
-    && adduser -S -G praxis -h /nonexistent -s /sbin/nologin praxis \
+RUN microdnf install -y \
+        --setopt install_weak_deps=0 \
+        ca-certificates curl shadow-utils \
+    && groupadd --system praxis \
+    && useradd --system \
+        --gid praxis \
+        --no-create-home \
+        --home-dir /nonexistent \
+        --shell /sbin/nologin \
+        praxis \
+    && microdnf remove -y shadow-utils \
+    && microdnf clean all \
     && mkdir -p /etc/praxis
 
 COPY --from=builder --chown=root:root --chmod=0555 \
@@ -109,6 +118,7 @@ WORKDIR /etc/praxis
 EXPOSE 8080 9901
 
 HEALTHCHECK --interval=5s --timeout=3s --start-period=2s \
-    CMD wget -qO- http://127.0.0.1:9901/healthy || exit 1
+    CMD curl --fail --silent --show-error \
+        http://127.0.0.1:9901/healthy || exit 1
 
 ENTRYPOINT ["praxis", "-c", "/etc/praxis/config.yaml"]

--- a/docs/release.md
+++ b/docs/release.md
@@ -39,7 +39,7 @@ Container images are published to [GitHub Container Registry][ghcr] (GHCR).
 After pushing a tag, manually trigger the **Publish**
 workflow via the GitHub Actions UI
 (`workflow_dispatch`). The workflow builds a multi-stage
-Alpine image from the `Containerfile` and pushes it to
+image from the `Containerfile` and pushes it to
 `ghcr.io/praxis-proxy/praxis`.
 
 [ghcr]: https://ghcr.io/praxis-proxy/praxis
@@ -80,12 +80,14 @@ triggered as usual.
 
 ## Container Details
 
-The production image is a minimal Alpine container:
+The production image uses Red Hat UBI 10 Minimal as the
+runtime base. The binary is a static musl build produced
+in a separate `rust:1.96-alpine` builder stage (UBI 10
+Rust Toolset ships 1.92, below the project's MSRV).
 
-- Static musl build with LTO, single codegen unit, and stripped symbols
-- Runs as non-root user (`praxis`)
+- Static musl binary with LTO, single codegen unit, and stripped symbols
+- Runtime: `registry.access.redhat.com/ubi10/ubi-minimal:latest`
+- Runs as non-root user `praxis`
 - Exposes ports `8080` (proxy) and `9901` (admin)
-- Built-in health check at `http://127.0.0.1:9901/healthy`
+- Built-in health check via `curl` at `http://127.0.0.1:9901/healthy`
 - Config directory: `/etc/praxis`
-
-> **Note**: This is subject to change.


### PR DESCRIPTION
## Summary

- Replace the Alpine 3.23 runtime stage with Red Hat UBI 10 Minimal (`registry.access.redhat.com/ubi10/ubi-minimal:latest`). The builder stage remains `rust:1.96-alpine` since UBI 10 Rust Toolset ships 1.92, below the project's MSRV.
- Install `shadow-utils` to create the `praxis` user/group, then remove it to keep the image lean. Replace BusyBox `wget` in `HEALTHCHECK` with `curl`.
- Enhance the container CI workflow to trigger on PRs (path-filtered on `Containerfile` and Cargo manifests) and verify the non-root user and health endpoint response.
- Update `docs/release.md` to describe the UBI 10 runtime and Alpine builder arrangement.

## Test plan

- [x] `podman build --format docker -t praxis-ai:ubi10 -f Containerfile .` succeeds
- [x] Container reaches `healthy` status
- [x] `/healthy` returns `{"status":"ok"}`
- [x] Process runs as `praxis` (uid=999), not root
- [x] `cat /etc/redhat-release` reports RHEL 10
- [x] Binary is statically linked (`not a dynamic executable`)
- [x] `ca-certificates` and `curl` packages present
- [x] `git diff --check` passes
- [x] `make lint` passes