### PR TITLE
refactor(core): move SubRequest and SubResponse to core crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,7 @@ dependencies = [
  "base64",
  "chrono",
  "cpex-core",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -2971,7 +2971,9 @@ dependencies = [
 name = "praxis-proxy-core"
 version = "0.4.1"
 dependencies = [
+ "bytes",
  "dashmap 6.2.1",
+ "http",
  "praxis-proxy-tls",
  "quixotic-plecostomus-core",
  "rand 0.10.2",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,9 @@ name = "praxis_core"
 workspace = true
 
 [dependencies]
+bytes = { workspace = true }
 dashmap = { workspace = true }
+http = { workspace = true }
 pingora-core = { workspace = true }
 praxis-tls = { workspace = true }
 rand = { workspace = true }

--- a/core/src/subrequest.rs
+++ b/core/src/subrequest.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 Praxis Contributors
 
-//! Shared HTTP connector for sub-request execution.
+//! Sub-request types and shared HTTP connector.
 //!
-//! Wraps a Pingora [`Connector`] in an [`Arc`] so it can be cloned
-//! cheaply and shared across filter pipelines and config reloads.
-//! The connector provides connection pooling, HTTP/2 ALPN
-//! negotiation, and TLS — the same transport layer that Pingora
-//! uses for normal upstream exchanges.
+//! Defines the `SubRequest` and `SubResponse` data types used by
+//! sub-request exchanges, plus the `SubRequestConnector` that wraps
+//! a Pingora `Connector` for connection pooling, HTTP/2 ALPN
+//! negotiation, and TLS.
 //!
 //! ```
 //! use praxis_core::subrequest::SubRequestConnector;
@@ -16,13 +15,47 @@
 //! let clone = connector.clone(); // Arc bump, same pool
 //! ```
 //!
-//! [`Arc`]: std::sync::Arc
 //! [`Connector`]: pingora_core::connectors::http::Connector
 
 use std::sync::Arc;
 
+use bytes::Bytes;
+use http::HeaderMap;
 use pingora_core::connectors::{ConnectorOptions, http::Connector};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+// ---------------------------------------------------------------------------
+// SubRequest / SubResponse
+// ---------------------------------------------------------------------------
+
+/// An outbound HTTP request for a sub-request exchange.
+#[derive(Clone, Debug)]
+pub struct SubRequest {
+    /// HTTP method.
+    pub method: http::Method,
+
+    /// Request URI (path + query).
+    pub uri: http::Uri,
+
+    /// Request headers.
+    pub headers: HeaderMap,
+
+    /// Request body.
+    pub body: Bytes,
+}
+
+/// The response from a sub-request exchange.
+#[derive(Clone, Debug)]
+pub struct SubResponse {
+    /// HTTP status code.
+    pub status: u16,
+
+    /// Response headers.
+    pub headers: HeaderMap,
+
+    /// Buffered response body.
+    pub body: Bytes,
+}
 
 // ---------------------------------------------------------------------------
 // SubRequestConnector
@@ -204,5 +237,30 @@ mod tests {
             Arc::ptr_eq(a.admission.as_ref().unwrap(), b.admission.as_ref().unwrap()),
             "cloned connectors should share the semaphore"
         );
+    }
+
+    #[test]
+    fn subrequest_clone_preserves_fields() {
+        let req = SubRequest {
+            method: http::Method::POST,
+            uri: "/v1/chat".parse().unwrap(),
+            headers: HeaderMap::new(),
+            body: Bytes::from_static(b"hello"),
+        };
+        let cloned = req.clone();
+        assert_eq!(cloned.method, http::Method::POST);
+        assert_eq!(cloned.body, Bytes::from_static(b"hello"));
+    }
+
+    #[test]
+    fn subresponse_clone_preserves_fields() {
+        let resp = SubResponse {
+            status: 200,
+            headers: HeaderMap::new(),
+            body: Bytes::from_static(b"world"),
+        };
+        let cloned = resp.clone();
+        assert_eq!(cloned.status, 200);
+        assert_eq!(cloned.body, Bytes::from_static(b"world"));
     }
 }

--- a/filter/src/builtins/http/traffic_management/iterative_request_router/tests.rs
+++ b/filter/src/builtins/http/traffic_management/iterative_request_router/tests.rs
@@ -684,7 +684,7 @@ fn local_rejection_becomes_transition_response() {
 
 #[test]
 fn build_terminal_preserves_body() {
-    use crate::pipeline::subrequest::SubResponse;
+    use crate::SubResponse;
 
     let response = SubResponse {
         status: 200,
@@ -706,7 +706,7 @@ fn build_terminal_preserves_body() {
 
 #[test]
 fn build_terminal_preserves_headers() {
-    use crate::pipeline::subrequest::SubResponse;
+    use crate::SubResponse;
 
     let mut headers = HeaderMap::new();
     headers.insert("content-type", "application/json".parse().unwrap());
@@ -743,8 +743,8 @@ fn make_default_done() -> config::StepTransition {
 }
 
 /// Build a minimal `SubResponse` with the given status.
-fn make_response(status: u16) -> crate::pipeline::subrequest::SubResponse {
-    crate::pipeline::subrequest::SubResponse {
+fn make_response(status: u16) -> crate::SubResponse {
+    crate::SubResponse {
         status,
         headers: HeaderMap::new(),
         body: bytes::Bytes::new(),
@@ -1791,7 +1791,7 @@ fn build_terminal_empty_body_has_no_body() {
 
 #[test]
 fn build_terminal_multiple_headers() {
-    use crate::pipeline::subrequest::SubResponse;
+    use crate::SubResponse;
 
     let mut headers = HeaderMap::new();
     headers.insert("content-type", "application/json".parse().unwrap());
@@ -1807,7 +1807,7 @@ fn build_terminal_multiple_headers() {
 
 #[test]
 fn build_terminal_reframes_empty_response_for_keepalive() {
-    use crate::pipeline::subrequest::SubResponse;
+    use crate::SubResponse;
 
     let mut headers = HeaderMap::new();
     headers.insert(http::header::CONTENT_LENGTH, "99".parse().unwrap());
@@ -1837,7 +1837,7 @@ fn build_terminal_does_not_frame_bodyless_status() {
 
 #[test]
 fn build_terminal_preserves_head_content_length() {
-    use crate::pipeline::subrequest::SubResponse;
+    use crate::SubResponse;
 
     let mut headers = HeaderMap::new();
     headers.insert(http::header::CONTENT_LENGTH, "123".parse().unwrap());
@@ -1854,7 +1854,7 @@ fn build_terminal_preserves_head_content_length() {
 
 #[test]
 fn build_terminal_preserves_opaque_header_bytes() {
-    use crate::pipeline::subrequest::SubResponse;
+    use crate::SubResponse;
 
     let mut headers = HeaderMap::new();
     headers.insert("x-opaque", http::HeaderValue::from_bytes(&[b'a', 0x80, b'z']).unwrap());

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -43,9 +43,12 @@ pub use factory::{
 pub use filter::{Filter, FilterContext, FilterError, HttpFilter};
 pub use pipeline::{
     FilterPipeline, PipelineExtension,
-    subrequest::{IterationState, NextIterationBody, SubRequest, SubResponse},
+    subrequest::{IterationState, NextIterationBody},
 };
-pub use praxis_core::config::{FailureMode, FilterEntry};
+pub use praxis_core::{
+    config::{FailureMode, FilterEntry},
+    subrequest::{SubRequest, SubResponse},
+};
 pub use praxis_tls::TlsPeerIdentity;
 pub use registry::{FilterRegistry, SecurityClass};
 pub use results::{FilterResultSet, matches_filter_result};

--- a/filter/src/pipeline/subrequest.rs
+++ b/filter/src/pipeline/subrequest.rs
@@ -15,7 +15,7 @@ use std::{collections::HashMap, time::Duration};
 use bytes::Bytes;
 use http::HeaderMap;
 use pingora_core::upstreams::peer::{HttpPeer, Peer as _};
-use praxis_core::subrequest::SubRequestConnector;
+use praxis_core::subrequest::{SubRequest, SubRequestConnector, SubResponse};
 use thiserror::Error;
 use tracing::{debug, warn};
 
@@ -33,35 +33,6 @@ pub(crate) const DEPTH_HEADER: &str = "x-praxis-iterative-depth";
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-/// An outbound HTTP request for a sub-request exchange.
-#[derive(Clone, Debug)]
-pub struct SubRequest {
-    /// HTTP method.
-    pub method: http::Method,
-
-    /// Request URI (path + query).
-    pub uri: http::Uri,
-
-    /// Request headers.
-    pub headers: HeaderMap,
-
-    /// Request body.
-    pub body: Bytes,
-}
-
-/// The response from a sub-request exchange.
-#[derive(Clone, Debug)]
-pub struct SubResponse {
-    /// HTTP status code.
-    pub status: u16,
-
-    /// Response headers.
-    pub headers: HeaderMap,
-
-    /// Buffered response body.
-    pub body: Bytes,
-}
 
 /// Per-request accumulator for state that persists across
 /// iterations of the iterative request router.
@@ -423,31 +394,6 @@ mod tests {
         assert!(empty_body_needs_framing(&http::Method::PATCH));
         assert!(!empty_body_needs_framing(&http::Method::GET));
         assert!(!empty_body_needs_framing(&http::Method::HEAD));
-    }
-
-    #[test]
-    fn subrequest_clone_preserves_fields() {
-        let req = SubRequest {
-            method: http::Method::POST,
-            uri: "/v1/chat".parse().unwrap(),
-            headers: HeaderMap::new(),
-            body: Bytes::from_static(b"hello"),
-        };
-        let cloned = req.clone();
-        assert_eq!(cloned.method, http::Method::POST);
-        assert_eq!(cloned.body, Bytes::from_static(b"hello"));
-    }
-
-    #[test]
-    fn subresponse_clone_preserves_fields() {
-        let resp = SubResponse {
-            status: 200,
-            headers: HeaderMap::new(),
-            body: Bytes::from_static(b"world"),
-        };
-        let cloned = resp.clone();
-        assert_eq!(cloned.status, 200);
-        assert_eq!(cloned.body, Bytes::from_static(b"world"));
     }
 
     #[test]


### PR DESCRIPTION
### What does this PR do?

Moves `SubRequest` and `SubResponse` from `filter/src/pipeline/subrequest.rs` to `core/src/subrequest.rs` alongside `SubRequestConnector`. These are pure data types with no filter-specific dependencies (only `bytes::Bytes` and `http::HeaderMap/Method/Uri`). The filter crate's public API is preserved via re-exports.

### Which issue(s) does this relate to?

Follow-up to #849

### Checklist

- [x] Signed off all commits (`git commit -s`)
- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] `make lint && make test` passes locally

### Does this introduce a breaking change?

No. The filter crate re-exports both types from core, so existing consumers are unaffected.