### PR TITLE
feat(protocol): structured error responses with pluggable formatting

### DIFF
--- a/filter/src/context.rs
+++ b/filter/src/context.rs
@@ -682,6 +682,28 @@ pub struct Response {
 }
 
 // -----------------------------------------------------------------------------
+// ErrorResponseFormat
+// -----------------------------------------------------------------------------
+
+/// Error response format for proxy error responses.
+///
+/// Stored in [`RequestExtensions`] by AI classifier filters to
+/// control the format of error responses produced by
+/// `fail_to_proxy`. When absent, defaults to [`ProblemDetails`].
+///
+/// [`ProblemDetails`]: Self::ProblemDetails
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ErrorResponseFormat {
+    /// RFC 9457 Problem Details (`application/problem+json`).
+    #[default]
+    ProblemDetails,
+    /// OpenAI-compatible error envelope (`application/json`).
+    OpenAi,
+    /// Anthropic Messages API error envelope (`application/json`).
+    Anthropic,
+}
+
+// -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
 

--- a/filter/src/context.rs
+++ b/filter/src/context.rs
@@ -682,28 +682,6 @@ pub struct Response {
 }
 
 // -----------------------------------------------------------------------------
-// ErrorResponseFormat
-// -----------------------------------------------------------------------------
-
-/// Error response format for proxy error responses.
-///
-/// Stored in [`RequestExtensions`] by AI classifier filters to
-/// control the format of error responses produced by
-/// `fail_to_proxy`. When absent, defaults to [`ProblemDetails`].
-///
-/// [`ProblemDetails`]: Self::ProblemDetails
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum ErrorResponseFormat {
-    /// RFC 9457 Problem Details (`application/problem+json`).
-    #[default]
-    ProblemDetails,
-    /// OpenAI-compatible error envelope (`application/json`).
-    OpenAi,
-    /// Anthropic Messages API error envelope (`application/json`).
-    Anthropic,
-}
-
-// -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
 

--- a/filter/src/error_response.rs
+++ b/filter/src/error_response.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Provider-neutral proxy error response formatting contracts.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use http::HeaderValue;
+
+// -----------------------------------------------------------------------------
+// ErrorResponseContext
+// -----------------------------------------------------------------------------
+
+/// Classified proxy error information supplied to a custom formatter.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ErrorResponseContext<'a> {
+    /// Machine-readable error code.
+    pub code: &'a str,
+
+    /// Human-readable error message.
+    pub message: &'a str,
+
+    /// HTTP status code returned to the downstream client.
+    pub status: u16,
+}
+
+impl<'a> ErrorResponseContext<'a> {
+    /// Create a classified proxy error context.
+    pub const fn new(code: &'a str, message: &'a str, status: u16) -> Self {
+        Self { code, message, status }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// FormattedErrorResponse
+// -----------------------------------------------------------------------------
+
+/// Body and content type produced by an [`ErrorResponseFormatter`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FormattedErrorResponse {
+    /// Serialized downstream response body.
+    pub body: Bytes,
+
+    /// Media type describing [`body`].
+    ///
+    /// [`body`]: Self::body
+    pub content_type: HeaderValue,
+}
+
+impl FormattedErrorResponse {
+    /// Create a formatted proxy error response.
+    pub fn new(body: impl Into<Bytes>, content_type: HeaderValue) -> Self {
+        Self {
+            body: body.into(),
+            content_type,
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// ErrorResponseFormatter
+// -----------------------------------------------------------------------------
+
+/// Formats classified proxy failures for a downstream API protocol.
+///
+/// External filters can install an [`ErrorResponseFormatterHandle`] in
+/// [`HttpFilterContext::extensions`] during request processing. The protocol
+/// layer invokes it only when synthesizing a fatal proxy response. When no
+/// formatter is installed, Praxis emits RFC 9457 Problem Details.
+///
+/// [`HttpFilterContext::extensions`]: crate::HttpFilterContext::extensions
+pub trait ErrorResponseFormatter: Send + Sync {
+    /// Format a classified proxy failure.
+    fn format(&self, context: &ErrorResponseContext<'_>) -> FormattedErrorResponse;
+}
+
+// -----------------------------------------------------------------------------
+// ErrorResponseFormatterHandle
+// -----------------------------------------------------------------------------
+
+/// Cloneable request-extension value wrapping a custom error formatter.
+#[derive(Clone)]
+pub struct ErrorResponseFormatterHandle {
+    /// Shared custom formatter implementation.
+    formatter: Arc<dyn ErrorResponseFormatter>,
+}
+
+impl ErrorResponseFormatterHandle {
+    /// Wrap a custom error formatter for insertion into request extensions.
+    pub fn new(formatter: impl ErrorResponseFormatter + 'static) -> Self {
+        Self {
+            formatter: Arc::new(formatter),
+        }
+    }
+
+    /// Format a classified proxy failure with the wrapped formatter.
+    pub fn format(&self, context: &ErrorResponseContext<'_>) -> FormattedErrorResponse {
+        self.formatter.format(context)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    /// Test formatter proving external implementations receive the context.
+    struct TestFormatter;
+
+    impl ErrorResponseFormatter for TestFormatter {
+        fn format(&self, context: &ErrorResponseContext<'_>) -> FormattedErrorResponse {
+            FormattedErrorResponse::new(
+                format!(r#"{{"code":"{}","status":{}}}"#, context.code, context.status),
+                HeaderValue::from_static("application/vnd.praxis.test+json"),
+            )
+        }
+    }
+
+    #[test]
+    fn context_constructor_sets_fields() {
+        let context = ErrorResponseContext::new("upstream_error", "Upstream error", 502);
+
+        assert_eq!(context.code, "upstream_error");
+        assert_eq!(context.message, "Upstream error");
+        assert_eq!(context.status, 502);
+    }
+
+    #[test]
+    fn formatter_handle_delegates_to_external_formatter() {
+        let formatter = ErrorResponseFormatterHandle::new(TestFormatter);
+        let context = ErrorResponseContext::new("upstream_error", "Upstream error", 502);
+
+        let response = formatter.format(&context);
+
+        assert_eq!(
+            response.body,
+            Bytes::from_static(br#"{"code":"upstream_error","status":502}"#)
+        );
+        assert_eq!(
+            response.content_type,
+            HeaderValue::from_static("application/vnd.praxis.test+json")
+        );
+    }
+}

--- a/filter/src/error_response.rs
+++ b/filter/src/error_response.rs
@@ -110,18 +110,6 @@ impl ErrorResponseFormatterHandle {
 mod tests {
     use super::*;
 
-    /// Test formatter proving external implementations receive the context.
-    struct TestFormatter;
-
-    impl ErrorResponseFormatter for TestFormatter {
-        fn format(&self, context: &ErrorResponseContext<'_>) -> FormattedErrorResponse {
-            FormattedErrorResponse::new(
-                format!(r#"{{"code":"{}","status":{}}}"#, context.code, context.status),
-                HeaderValue::from_static("application/vnd.praxis.test+json"),
-            )
-        }
-    }
-
     #[test]
     fn context_constructor_sets_fields() {
         let context = ErrorResponseContext::new("upstream_error", "Upstream error", 502);
@@ -146,5 +134,20 @@ mod tests {
             response.content_type,
             HeaderValue::from_static("application/vnd.praxis.test+json")
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // Test Utilities
+    // -------------------------------------------------------------------------
+
+    struct TestFormatter;
+
+    impl ErrorResponseFormatter for TestFormatter {
+        fn format(&self, context: &ErrorResponseContext<'_>) -> FormattedErrorResponse {
+            FormattedErrorResponse::new(
+                format!(r#"{{"code":"{}","status":{}}}"#, context.code, context.status),
+                HeaderValue::from_static("application/vnd.praxis.test+json"),
+            )
+        }
     }
 }

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -11,6 +11,7 @@ pub mod body;
 pub mod builtins;
 mod condition;
 mod context;
+mod error_response;
 mod extensions;
 mod factory;
 mod filter;
@@ -36,8 +37,9 @@ pub use builtins::{
     normalize_rewritten_path,
 };
 pub use condition::{should_execute, should_execute_response, should_execute_response_ref};
-pub use context::{
-    ErrorResponseFormat, HttpFilterContext, PendingHeaderResult, Request, Response, TrustedHeaderMutation,
+pub use context::{HttpFilterContext, PendingHeaderResult, Request, Response, TrustedHeaderMutation};
+pub use error_response::{
+    ErrorResponseContext, ErrorResponseFormatter, ErrorResponseFormatterHandle, FormattedErrorResponse,
 };
 pub use extensions::RequestExtensions;
 pub use factory::{

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -36,7 +36,9 @@ pub use builtins::{
     normalize_rewritten_path,
 };
 pub use condition::{should_execute, should_execute_response, should_execute_response_ref};
-pub use context::{ErrorResponseFormat, HttpFilterContext, PendingHeaderResult, Request, Response, TrustedHeaderMutation};
+pub use context::{
+    ErrorResponseFormat, HttpFilterContext, PendingHeaderResult, Request, Response, TrustedHeaderMutation,
+};
 pub use extensions::RequestExtensions;
 pub use factory::{
     EmptyFilterConfig, FilterFactory, HttpFilterFactory, TcpFilterFactory, http_builtin, parse_filter_config,

--- a/filter/src/lib.rs
+++ b/filter/src/lib.rs
@@ -36,7 +36,7 @@ pub use builtins::{
     normalize_rewritten_path,
 };
 pub use condition::{should_execute, should_execute_response, should_execute_response_ref};
-pub use context::{HttpFilterContext, PendingHeaderResult, Request, Response, TrustedHeaderMutation};
+pub use context::{ErrorResponseFormat, HttpFilterContext, PendingHeaderResult, Request, Response, TrustedHeaderMutation};
 pub use extensions::RequestExtensions;
 pub use factory::{
     EmptyFilterConfig, FilterFactory, HttpFilterFactory, TcpFilterFactory, http_builtin, parse_filter_config,

--- a/protocol/src/http/pingora/handler/fail_to_proxy.rs
+++ b/protocol/src/http/pingora/handler/fail_to_proxy.rs
@@ -4,9 +4,10 @@
 //! Structured error responses for fatal proxy errors.
 
 use bytes::Bytes;
+use http::HeaderValue;
 use pingora_core::ErrorType;
 use pingora_proxy::{FailToProxy, Session};
-use praxis_filter::ErrorResponseFormat;
+use praxis_filter::{ErrorResponseContext, ErrorResponseFormatterHandle, FormattedErrorResponse};
 use tracing::{debug, error};
 
 use crate::http::pingora::context::PingoraRequestCtx;
@@ -24,30 +25,25 @@ struct ProxyError {
 /// Handle a fatal proxy error by writing a structured error response
 /// to the downstream client.
 ///
-/// The response format is determined by [`ErrorResponseFormat`] stored
-/// in the request extensions. AI classifier filters set this to
-/// [`OpenAi`] or [`Anthropic`] during request processing; all other
-/// requests get the default [`ProblemDetails`] (RFC 9457) format.
+/// External filters can store an [`ErrorResponseFormatterHandle`] in
+/// the request extensions to control the downstream envelope. Requests
+/// without a custom formatter use RFC 9457 Problem Details.
 ///
 /// Guards against double-writes (filter rejections that already sent a
 /// response), dead downstream connections, and HEAD requests (body
 /// suppressed). Writable downstream failures (e.g. client body read
 /// timeout) receive a structured 400 response.
-///
-/// [`OpenAi`]: ErrorResponseFormat::OpenAi
-/// [`Anthropic`]: ErrorResponseFormat::Anthropic
-/// [`ProblemDetails`]: ErrorResponseFormat::ProblemDetails
 pub(super) async fn execute(session: &mut Session, e: &pingora_core::Error, ctx: &PingoraRequestCtx) -> FailToProxy {
     let etype = e.etype().clone();
-    let format = ctx.extensions.get::<ErrorResponseFormat>().copied().unwrap_or_default();
+    let formatter = ctx.extensions.get::<ErrorResponseFormatterHandle>();
 
     if let ErrorType::HTTPStatus(code) = etype {
-        return handle_http_status(session, code, format).await;
+        return handle_http_status(session, code, formatter).await;
     }
 
     let source = e.esource();
     if matches!(source, pingora_core::ErrorSource::Downstream) {
-        return handle_downstream(session, &etype, format).await;
+        return handle_downstream(session, &etype, formatter).await;
     }
 
     let err = classify_error(&etype, source);
@@ -60,14 +56,18 @@ pub(super) async fn execute(session: &mut Session, e: &pingora_core::Error, ctx:
         return done(err.status);
     }
 
-    write_error_response(session, err, format).await
+    write_error_response(session, err, formatter).await
 }
 
 /// Structured response for explicit HTTP status errors.
 ///
 /// Filter rejections typically write their own response before raising
 /// `HTTPStatus`; the double-write guard returns immediately in that case.
-async fn handle_http_status(session: &mut Session, code: u16, format: ErrorResponseFormat) -> FailToProxy {
+async fn handle_http_status(
+    session: &mut Session,
+    code: u16,
+    formatter: Option<&ErrorResponseFormatterHandle>,
+) -> FailToProxy {
     if final_response_written(session) {
         return done(code);
     }
@@ -76,7 +76,7 @@ async fn handle_http_status(session: &mut Session, code: u16, format: ErrorRespo
         message: status_title(code),
         status: code,
     };
-    write_error_response(session, err, format).await
+    write_error_response(session, err, formatter).await
 }
 
 /// Handle a downstream-origin error.
@@ -84,7 +84,11 @@ async fn handle_http_status(session: &mut Session, code: u16, format: ErrorRespo
 /// Dead connections (write failure, read failure, closed) are silently
 /// abandoned. Writable failures (e.g. body read timeout) receive a
 /// structured 400 response, matching Pingora's default status choice.
-async fn handle_downstream(session: &mut Session, etype: &ErrorType, format: ErrorResponseFormat) -> FailToProxy {
+async fn handle_downstream(
+    session: &mut Session,
+    etype: &ErrorType,
+    formatter: Option<&ErrorResponseFormatterHandle>,
+) -> FailToProxy {
     if is_connection_dead(etype) {
         debug!("downstream connection dead, skipping error response");
         return done(0);
@@ -97,7 +101,7 @@ async fn handle_downstream(session: &mut Session, etype: &ErrorType, format: Err
         message: "Request error",
         status: 400,
     };
-    write_error_response(session, err, format).await
+    write_error_response(session, err, formatter).await
 }
 
 /// Whether the downstream connection is too broken to write a response.
@@ -109,87 +113,66 @@ fn is_connection_dead(etype: &ErrorType) -> bool {
 }
 
 /// Build and write the error response to the downstream session.
-async fn write_error_response(session: &mut Session, err: ProxyError, format: ErrorResponseFormat) -> FailToProxy {
-    let (body, content_type) = format_error_body(&err, format);
-    let body_bytes = Bytes::from(body);
+async fn write_error_response(
+    session: &mut Session,
+    err: ProxyError,
+    formatter: Option<&ErrorResponseFormatterHandle>,
+) -> FailToProxy {
+    let FormattedErrorResponse { body, content_type } = format_error_response(&err, formatter);
 
-    session.set_keepalive(None);
-
-    let Some(header) = build_header(err.status, body_bytes.len(), content_type) else {
+    let Some(header) = build_header(err.status, body.len(), content_type) else {
         return done(err.status);
     };
 
     let is_head = session.req_header().method == http::Method::HEAD;
-    send_error_response(session, header, body_bytes, is_head).await;
+    send_error_response(session, header, body, is_head).await;
     done(err.status)
 }
 
-/// Format the error body and content-type for the given format.
-fn format_error_body(err: &ProxyError, format: ErrorResponseFormat) -> (String, &'static str) {
-    match format {
-        ErrorResponseFormat::OpenAi => (
-            format!(
-                r#"{{"error":{{"message":"{}","type":"proxy_error","code":"{}"}}}}"#,
-                err.message, err.code,
-            ),
-            "application/json",
-        ),
-        ErrorResponseFormat::Anthropic => (
-            format!(
-                r#"{{"type":"error","error":{{"type":"{}","message":"{}"}},"request_id":null}}"#,
-                anthropic_error_type(err.status),
-                err.message,
-            ),
-            "application/json",
-        ),
-        ErrorResponseFormat::ProblemDetails => (
-            format!(
-                r#"{{"type":"about:blank","title":"{}","status":{},"detail":"{}"}}"#,
-                status_title(err.status),
-                err.status,
-                err.message,
-            ),
-            "application/problem+json",
-        ),
+/// Format an error with an installed formatter or the default RFC 9457 envelope.
+fn format_error_response(err: &ProxyError, formatter: Option<&ErrorResponseFormatterHandle>) -> FormattedErrorResponse {
+    if let Some(formatter) = formatter {
+        let context = ErrorResponseContext::new(err.code, err.message, err.status);
+        return formatter.format(&context);
     }
+
+    FormattedErrorResponse::new(
+        format!(
+            r#"{{"type":"about:blank","title":"{}","status":{},"detail":"{}"}}"#,
+            status_title(err.status),
+            err.status,
+            err.message,
+        ),
+        HeaderValue::from_static("application/problem+json"),
+    )
 }
 
-/// RFC 9457 title for common proxy error status codes.
+/// Canonical HTTP reason phrase for RFC 9457 `about:blank` titles.
 fn status_title(status: u16) -> &'static str {
-    match status {
-        400 => "Bad Request",
-        500 => "Internal Server Error",
-        502 => "Bad Gateway",
-        503 => "Service Unavailable",
-        504 => "Gateway Timeout",
-        _ => "Proxy Error",
-    }
+    http::StatusCode::from_u16(status)
+        .ok()
+        .and_then(|s| s.canonical_reason())
+        .unwrap_or("Proxy Error")
 }
 
-/// Anthropic error type for the given HTTP status code.
-fn anthropic_error_type(status: u16) -> &'static str {
-    match status {
-        429 => "rate_limit_error",
-        504 => "timeout_error",
-        529 => "overloaded_error",
-        _ => "api_error",
-    }
-}
-
-/// Write the error response header and optional body to the downstream session.
+/// Write the error response directly to the downstream session.
+///
+/// The raw downstream writer intentionally bypasses response modules. Synthetic
+/// proxy errors must not be transformed by filters such as compression after
+/// their content length and provider envelope have been finalized.
 async fn send_error_response(session: &mut Session, header: pingora_http::ResponseHeader, body: Bytes, is_head: bool) {
-    let end_of_stream = is_head;
-    if let Err(e) = session.write_response_header(Box::new(header), end_of_stream).await {
-        debug!(error = %e, "failed to write error response header");
-        return;
-    }
-    if !is_head && let Err(e) = session.write_response_body(Some(body), true).await {
-        debug!(error = %e, "failed to write error response body");
+    let response_body = if is_head { Bytes::new() } else { body };
+    if let Err(e) = session
+        .as_downstream_mut()
+        .write_error_response(header, response_body)
+        .await
+    {
+        debug!(error = %e, "failed to write error response");
     }
 }
 
 /// Build a response header with content-type and content-length.
-fn build_header(status: u16, content_length: usize, content_type: &str) -> Option<pingora_http::ResponseHeader> {
+fn build_header(status: u16, content_length: usize, content_type: HeaderValue) -> Option<pingora_http::ResponseHeader> {
     let mut header = match pingora_http::ResponseHeader::build(status, Some(3)) {
         Ok(h) => h,
         Err(err) => {
@@ -198,9 +181,8 @@ fn build_header(status: u16, content_length: usize, content_type: &str) -> Optio
         },
     };
 
-    // no-transform: synthetic error bodies bypass Pingora's response
-    // compression pipeline (written directly to the session), so tell
-    // downstream intermediaries not to re-encode them either.
+    // Synthetic error bodies bypass Pingora's response modules. Ask downstream
+    // intermediaries to preserve the finalized representation as well.
     if header.insert_header("content-type", content_type).is_err()
         || header
             .insert_header("content-length", content_length.to_string())
@@ -270,6 +252,18 @@ fn classify_error_tuple(etype: &ErrorType, source: &pingora_core::ErrorSource) -
 mod tests {
     use super::*;
 
+    /// Test formatter proving the protocol delegates classified errors.
+    struct TestFormatter;
+
+    impl praxis_filter::ErrorResponseFormatter for TestFormatter {
+        fn format(&self, context: &ErrorResponseContext<'_>) -> FormattedErrorResponse {
+            FormattedErrorResponse::new(
+                format!(r#"{{"code":"{}","status":{}}}"#, context.code, context.status),
+                HeaderValue::from_static("application/vnd.praxis.test+json"),
+            )
+        }
+    }
+
     fn check(etype: &ErrorType, source: &pingora_core::ErrorSource, expected_status: u16, expected_code: &str) {
         let err = classify_error(etype, source);
         assert_eq!(
@@ -283,19 +277,18 @@ mod tests {
     }
 
     #[test]
-    fn default_format_is_problem_details() {
-        assert_eq!(ErrorResponseFormat::default(), ErrorResponseFormat::ProblemDetails);
-    }
-
-    #[test]
     fn problem_details_body_has_rfc9457_fields() {
         let err = ProxyError {
             code: "upstream_connect_refused",
             message: "Upstream connection refused",
             status: 502,
         };
-        let (body, ct) = format_error_body(&err, ErrorResponseFormat::ProblemDetails);
-        assert_eq!(ct, "application/problem+json");
+        let response = format_error_response(&err, None);
+        let body = String::from_utf8(response.body.to_vec()).unwrap();
+        assert_eq!(
+            response.content_type,
+            HeaderValue::from_static("application/problem+json")
+        );
         assert!(body.contains(r#""type":"about:blank""#), "body: {body}");
         assert!(body.contains(r#""title":"Bad Gateway""#), "body: {body}");
         assert!(body.contains(r#""status":502"#), "body: {body}");
@@ -306,67 +299,42 @@ mod tests {
     }
 
     #[test]
-    fn openai_body_has_error_envelope() {
+    fn custom_formatter_receives_classified_error() {
         let err = ProxyError {
             code: "upstream_connect_refused",
             message: "Upstream connection refused",
             status: 502,
         };
-        let (body, ct) = format_error_body(&err, ErrorResponseFormat::OpenAi);
-        assert_eq!(ct, "application/json");
-        assert!(body.contains(r#""type":"proxy_error""#), "body: {body}");
-        assert!(body.contains(r#""code":"upstream_connect_refused""#), "body: {body}");
-        assert!(
-            body.contains(r#""message":"Upstream connection refused""#),
-            "body: {body}"
+        let formatter = ErrorResponseFormatterHandle::new(TestFormatter);
+
+        let response = format_error_response(&err, Some(&formatter));
+
+        assert_eq!(
+            response.body,
+            Bytes::from_static(br#"{"code":"upstream_connect_refused","status":502}"#)
+        );
+        assert_eq!(
+            response.content_type,
+            HeaderValue::from_static("application/vnd.praxis.test+json")
         );
     }
 
     #[test]
-    fn anthropic_body_has_error_envelope() {
-        let err = ProxyError {
-            code: "upstream_connect_refused",
-            message: "Upstream connection refused",
-            status: 502,
-        };
-        let (body, ct) = format_error_body(&err, ErrorResponseFormat::Anthropic);
-        assert_eq!(ct, "application/json");
-        assert!(body.contains(r#""type":"error""#), "body: {body}");
-        assert!(body.contains(r#""type":"api_error""#), "body: {body}");
-        assert!(body.contains(r#""request_id":null"#), "body: {body}");
-        assert!(
-            body.contains(r#""message":"Upstream connection refused""#),
-            "body: {body}"
-        );
-    }
-
-    #[test]
-    fn anthropic_timeout_uses_timeout_error_type() {
-        let err = ProxyError {
-            code: "upstream_read_timeout",
-            message: "Upstream read timed out",
-            status: 504,
-        };
-        let (body, _) = format_error_body(&err, ErrorResponseFormat::Anthropic);
-        assert!(body.contains(r#""type":"timeout_error""#), "body: {body}");
-    }
-
-    #[test]
-    fn anthropic_error_type_maps_status_codes() {
-        assert_eq!(anthropic_error_type(429), "rate_limit_error");
-        assert_eq!(anthropic_error_type(504), "timeout_error");
-        assert_eq!(anthropic_error_type(529), "overloaded_error");
-        assert_eq!(anthropic_error_type(500), "api_error");
-        assert_eq!(anthropic_error_type(502), "api_error");
-    }
-
-    #[test]
-    fn status_title_maps_common_codes() {
-        assert_eq!(status_title(502), "Bad Gateway");
-        assert_eq!(status_title(504), "Gateway Timeout");
+    fn status_title_uses_canonical_reason_phrase() {
+        assert_eq!(status_title(400), "Bad Request");
+        assert_eq!(status_title(401), "Unauthorized");
+        assert_eq!(status_title(403), "Forbidden");
+        assert_eq!(status_title(413), "Payload Too Large");
+        assert_eq!(status_title(429), "Too Many Requests");
         assert_eq!(status_title(500), "Internal Server Error");
+        assert_eq!(status_title(502), "Bad Gateway");
         assert_eq!(status_title(503), "Service Unavailable");
-        assert_eq!(status_title(418), "Proxy Error");
+        assert_eq!(status_title(504), "Gateway Timeout");
+    }
+
+    #[test]
+    fn status_title_falls_back_for_nonstandard_codes() {
+        assert_eq!(status_title(599), "Proxy Error");
     }
 
     #[test]

--- a/protocol/src/http/pingora/handler/fail_to_proxy.rs
+++ b/protocol/src/http/pingora/handler/fail_to_proxy.rs
@@ -2,14 +2,14 @@
 // Copyright (c) 2026 Praxis Contributors
 
 //! Structured error responses for fatal proxy errors.
-//!
-//! Produces RFC 9457 Problem Details (`application/problem+json`)
-//! responses when the proxy cannot reach the upstream.
 
 use bytes::Bytes;
 use pingora_core::ErrorType;
 use pingora_proxy::{FailToProxy, Session};
+use praxis_filter::ErrorResponseFormat;
 use tracing::{debug, error};
+
+use crate::http::pingora::context::PingoraRequestCtx;
 
 /// Classified proxy error with HTTP status and machine-readable fields.
 struct ProxyError {
@@ -24,20 +24,30 @@ struct ProxyError {
 /// Handle a fatal proxy error by writing a structured error response
 /// to the downstream client.
 ///
+/// The response format is determined by [`ErrorResponseFormat`] stored
+/// in the request extensions. AI classifier filters set this to
+/// [`OpenAi`] or [`Anthropic`] during request processing; all other
+/// requests get the default [`ProblemDetails`] (RFC 9457) format.
+///
 /// Guards against double-writes (filter rejections that already sent a
 /// response), dead downstream connections, and HEAD requests (body
 /// suppressed). Writable downstream failures (e.g. client body read
 /// timeout) receive a structured 400 response.
-pub(super) async fn execute(session: &mut Session, e: &pingora_core::Error) -> FailToProxy {
+///
+/// [`OpenAi`]: ErrorResponseFormat::OpenAi
+/// [`Anthropic`]: ErrorResponseFormat::Anthropic
+/// [`ProblemDetails`]: ErrorResponseFormat::ProblemDetails
+pub(super) async fn execute(session: &mut Session, e: &pingora_core::Error, ctx: &PingoraRequestCtx) -> FailToProxy {
     let etype = e.etype().clone();
+    let format = ctx.extensions.get::<ErrorResponseFormat>().copied().unwrap_or_default();
 
     if let ErrorType::HTTPStatus(code) = etype {
-        return handle_http_status(session, code).await;
+        return handle_http_status(session, code, format).await;
     }
 
     let source = e.esource();
     if matches!(source, pingora_core::ErrorSource::Downstream) {
-        return handle_downstream(session, &etype).await;
+        return handle_downstream(session, &etype, format).await;
     }
 
     let err = classify_error(&etype, source);
@@ -50,14 +60,14 @@ pub(super) async fn execute(session: &mut Session, e: &pingora_core::Error) -> F
         return done(err.status);
     }
 
-    write_error_response(session, err).await
+    write_error_response(session, err, format).await
 }
 
 /// Structured response for explicit HTTP status errors.
 ///
 /// Filter rejections typically write their own response before raising
 /// `HTTPStatus`; the double-write guard returns immediately in that case.
-async fn handle_http_status(session: &mut Session, code: u16) -> FailToProxy {
+async fn handle_http_status(session: &mut Session, code: u16, format: ErrorResponseFormat) -> FailToProxy {
     if final_response_written(session) {
         return done(code);
     }
@@ -66,7 +76,7 @@ async fn handle_http_status(session: &mut Session, code: u16) -> FailToProxy {
         message: status_title(code),
         status: code,
     };
-    write_error_response(session, err).await
+    write_error_response(session, err, format).await
 }
 
 /// Handle a downstream-origin error.
@@ -74,7 +84,7 @@ async fn handle_http_status(session: &mut Session, code: u16) -> FailToProxy {
 /// Dead connections (write failure, read failure, closed) are silently
 /// abandoned. Writable failures (e.g. body read timeout) receive a
 /// structured 400 response, matching Pingora's default status choice.
-async fn handle_downstream(session: &mut Session, etype: &ErrorType) -> FailToProxy {
+async fn handle_downstream(session: &mut Session, etype: &ErrorType, format: ErrorResponseFormat) -> FailToProxy {
     if is_connection_dead(etype) {
         debug!("downstream connection dead, skipping error response");
         return done(0);
@@ -87,7 +97,7 @@ async fn handle_downstream(session: &mut Session, etype: &ErrorType) -> FailToPr
         message: "Request error",
         status: 400,
     };
-    write_error_response(session, err).await
+    write_error_response(session, err, format).await
 }
 
 /// Whether the downstream connection is too broken to write a response.
@@ -99,24 +109,49 @@ fn is_connection_dead(etype: &ErrorType) -> bool {
 }
 
 /// Build and write the error response to the downstream session.
-async fn write_error_response(session: &mut Session, err: ProxyError) -> FailToProxy {
-    let body = format!(
-        r#"{{"type":"about:blank","title":"{}","status":{},"detail":"{}"}}"#,
-        status_title(err.status),
-        err.status,
-        err.message,
-    );
+async fn write_error_response(session: &mut Session, err: ProxyError, format: ErrorResponseFormat) -> FailToProxy {
+    let (body, content_type) = format_error_body(&err, format);
     let body_bytes = Bytes::from(body);
 
     session.set_keepalive(None);
 
-    let Some(header) = build_header(err.status, body_bytes.len()) else {
+    let Some(header) = build_header(err.status, body_bytes.len(), content_type) else {
         return done(err.status);
     };
 
     let is_head = session.req_header().method == http::Method::HEAD;
     send_error_response(session, header, body_bytes, is_head).await;
     done(err.status)
+}
+
+/// Format the error body and content-type for the given format.
+fn format_error_body(err: &ProxyError, format: ErrorResponseFormat) -> (String, &'static str) {
+    match format {
+        ErrorResponseFormat::OpenAi => (
+            format!(
+                r#"{{"error":{{"message":"{}","type":"proxy_error","code":"{}"}}}}"#,
+                err.message, err.code,
+            ),
+            "application/json",
+        ),
+        ErrorResponseFormat::Anthropic => (
+            format!(
+                r#"{{"type":"error","error":{{"type":"{}","message":"{}"}},"request_id":null}}"#,
+                anthropic_error_type(err.status),
+                err.message,
+            ),
+            "application/json",
+        ),
+        ErrorResponseFormat::ProblemDetails => (
+            format!(
+                r#"{{"type":"about:blank","title":"{}","status":{},"detail":"{}"}}"#,
+                status_title(err.status),
+                err.status,
+                err.message,
+            ),
+            "application/problem+json",
+        ),
+    }
 }
 
 /// RFC 9457 title for common proxy error status codes.
@@ -128,6 +163,17 @@ fn status_title(status: u16) -> &'static str {
         503 => "Service Unavailable",
         504 => "Gateway Timeout",
         _ => "Proxy Error",
+    }
+}
+
+/// Anthropic error type for the given HTTP status code.
+fn anthropic_error_type(status: u16) -> &'static str {
+    match status {
+        429 => "rate_limit_error",
+        500 => "api_error",
+        504 => "timeout_error",
+        529 => "overloaded_error",
+        _ => "api_error",
     }
 }
 
@@ -144,7 +190,7 @@ async fn send_error_response(session: &mut Session, header: pingora_http::Respon
 }
 
 /// Build a response header with content-type and content-length.
-fn build_header(status: u16, content_length: usize) -> Option<pingora_http::ResponseHeader> {
+fn build_header(status: u16, content_length: usize, content_type: &str) -> Option<pingora_http::ResponseHeader> {
     let mut header = match pingora_http::ResponseHeader::build(status, Some(2)) {
         Ok(h) => h,
         Err(err) => {
@@ -153,9 +199,7 @@ fn build_header(status: u16, content_length: usize) -> Option<pingora_http::Resp
         },
     };
 
-    if header
-        .insert_header("content-type", "application/problem+json")
-        .is_err()
+    if header.insert_header("content-type", content_type).is_err()
         || header
             .insert_header("content-length", content_length.to_string())
             .is_err()
@@ -236,16 +280,81 @@ mod tests {
     }
 
     #[test]
+    fn default_format_is_problem_details() {
+        assert_eq!(ErrorResponseFormat::default(), ErrorResponseFormat::ProblemDetails);
+    }
+
+    #[test]
     fn problem_details_body_has_rfc9457_fields() {
-        let status = 502;
-        let title = status_title(status);
-        let body = format!(
-            r#"{{"type":"about:blank","title":"{title}","status":{status},"detail":"Upstream connection refused"}}"#,
+        let err = ProxyError {
+            code: "upstream_connect_refused",
+            message: "Upstream connection refused",
+            status: 502,
+        };
+        let (body, ct) = format_error_body(&err, ErrorResponseFormat::ProblemDetails);
+        assert_eq!(ct, "application/problem+json");
+        assert!(body.contains(r#""type":"about:blank""#), "body: {body}");
+        assert!(body.contains(r#""title":"Bad Gateway""#), "body: {body}");
+        assert!(body.contains(r#""status":502"#), "body: {body}");
+        assert!(
+            body.contains(r#""detail":"Upstream connection refused""#),
+            "body: {body}"
         );
-        assert!(body.contains(r#""type":"about:blank""#));
-        assert!(body.contains(r#""title":"Bad Gateway""#));
-        assert!(body.contains(r#""status":502"#));
-        assert!(body.contains(r#""detail":"Upstream connection refused""#));
+    }
+
+    #[test]
+    fn openai_body_has_error_envelope() {
+        let err = ProxyError {
+            code: "upstream_connect_refused",
+            message: "Upstream connection refused",
+            status: 502,
+        };
+        let (body, ct) = format_error_body(&err, ErrorResponseFormat::OpenAi);
+        assert_eq!(ct, "application/json");
+        assert!(body.contains(r#""type":"proxy_error""#), "body: {body}");
+        assert!(body.contains(r#""code":"upstream_connect_refused""#), "body: {body}");
+        assert!(
+            body.contains(r#""message":"Upstream connection refused""#),
+            "body: {body}"
+        );
+    }
+
+    #[test]
+    fn anthropic_body_has_error_envelope() {
+        let err = ProxyError {
+            code: "upstream_connect_refused",
+            message: "Upstream connection refused",
+            status: 502,
+        };
+        let (body, ct) = format_error_body(&err, ErrorResponseFormat::Anthropic);
+        assert_eq!(ct, "application/json");
+        assert!(body.contains(r#""type":"error""#), "body: {body}");
+        assert!(body.contains(r#""type":"api_error""#), "body: {body}");
+        assert!(body.contains(r#""request_id":null"#), "body: {body}");
+        assert!(
+            body.contains(r#""message":"Upstream connection refused""#),
+            "body: {body}"
+        );
+    }
+
+    #[test]
+    fn anthropic_timeout_uses_timeout_error_type() {
+        let err = ProxyError {
+            code: "upstream_read_timeout",
+            message: "Upstream read timed out",
+            status: 504,
+        };
+        let (body, _) = format_error_body(&err, ErrorResponseFormat::Anthropic);
+        assert!(body.contains(r#""type":"timeout_error""#), "body: {body}");
+    }
+
+    #[test]
+    fn anthropic_error_type_maps_status_codes() {
+        assert_eq!(anthropic_error_type(429), "rate_limit_error");
+        assert_eq!(anthropic_error_type(504), "timeout_error");
+        assert_eq!(anthropic_error_type(529), "overloaded_error");
+        assert_eq!(anthropic_error_type(500), "api_error");
+        assert_eq!(anthropic_error_type(502), "api_error");
     }
 
     #[test]

--- a/protocol/src/http/pingora/handler/fail_to_proxy.rs
+++ b/protocol/src/http/pingora/handler/fail_to_proxy.rs
@@ -252,30 +252,6 @@ fn classify_error_tuple(etype: &ErrorType, source: &pingora_core::ErrorSource) -
 mod tests {
     use super::*;
 
-    /// Test formatter proving the protocol delegates classified errors.
-    struct TestFormatter;
-
-    impl praxis_filter::ErrorResponseFormatter for TestFormatter {
-        fn format(&self, context: &ErrorResponseContext<'_>) -> FormattedErrorResponse {
-            FormattedErrorResponse::new(
-                format!(r#"{{"code":"{}","status":{}}}"#, context.code, context.status),
-                HeaderValue::from_static("application/vnd.praxis.test+json"),
-            )
-        }
-    }
-
-    fn check(etype: &ErrorType, source: &pingora_core::ErrorSource, expected_status: u16, expected_code: &str) {
-        let err = classify_error(etype, source);
-        assert_eq!(
-            err.status, expected_status,
-            "{etype:?}/{source:?} should map to status {expected_status}"
-        );
-        assert_eq!(
-            err.code, expected_code,
-            "{etype:?}/{source:?} should map to code {expected_code}"
-        );
-    }
-
     #[test]
     fn problem_details_body_has_rfc9457_fields() {
         let err = ProxyError {
@@ -537,8 +513,6 @@ mod tests {
         );
     }
 
-    // ---- is_connection_dead --------------------------------------------------
-
     #[test]
     fn write_error_is_dead() {
         assert!(is_connection_dead(&ErrorType::WriteError));
@@ -562,5 +536,32 @@ mod tests {
     #[test]
     fn connect_refused_is_not_dead() {
         assert!(!is_connection_dead(&ErrorType::ConnectRefused));
+    }
+
+    // -------------------------------------------------------------------------
+    // Test Utilities
+    // -------------------------------------------------------------------------
+
+    struct TestFormatter;
+
+    impl praxis_filter::ErrorResponseFormatter for TestFormatter {
+        fn format(&self, context: &ErrorResponseContext<'_>) -> FormattedErrorResponse {
+            FormattedErrorResponse::new(
+                format!(r#"{{"code":"{}","status":{}}}"#, context.code, context.status),
+                HeaderValue::from_static("application/vnd.praxis.test+json"),
+            )
+        }
+    }
+
+    fn check(etype: &ErrorType, source: &pingora_core::ErrorSource, expected_status: u16, expected_code: &str) {
+        let err = classify_error(etype, source);
+        assert_eq!(
+            err.status, expected_status,
+            "{etype:?}/{source:?} should map to status {expected_status}"
+        );
+        assert_eq!(
+            err.code, expected_code,
+            "{etype:?}/{source:?} should map to code {expected_code}"
+        );
     }
 }

--- a/protocol/src/http/pingora/handler/fail_to_proxy.rs
+++ b/protocol/src/http/pingora/handler/fail_to_proxy.rs
@@ -170,7 +170,6 @@ fn status_title(status: u16) -> &'static str {
 fn anthropic_error_type(status: u16) -> &'static str {
     match status {
         429 => "rate_limit_error",
-        500 => "api_error",
         504 => "timeout_error",
         529 => "overloaded_error",
         _ => "api_error",
@@ -191,7 +190,7 @@ async fn send_error_response(session: &mut Session, header: pingora_http::Respon
 
 /// Build a response header with content-type and content-length.
 fn build_header(status: u16, content_length: usize, content_type: &str) -> Option<pingora_http::ResponseHeader> {
-    let mut header = match pingora_http::ResponseHeader::build(status, Some(2)) {
+    let mut header = match pingora_http::ResponseHeader::build(status, Some(3)) {
         Ok(h) => h,
         Err(err) => {
             error!(status, error = %err, "failed to build error response header");
@@ -199,10 +198,14 @@ fn build_header(status: u16, content_length: usize, content_type: &str) -> Optio
         },
     };
 
+    // no-transform: synthetic error bodies bypass Pingora's response
+    // compression pipeline (written directly to the session), so tell
+    // downstream intermediaries not to re-encode them either.
     if header.insert_header("content-type", content_type).is_err()
         || header
             .insert_header("content-length", content_length.to_string())
             .is_err()
+        || header.insert_header("cache-control", "no-transform").is_err()
     {
         error!("failed to set error response headers");
         return None;

--- a/protocol/src/http/pingora/handler/fail_to_proxy.rs
+++ b/protocol/src/http/pingora/handler/fail_to_proxy.rs
@@ -13,34 +13,31 @@ use tracing::{debug, error};
 
 /// Classified proxy error with HTTP status and machine-readable fields.
 struct ProxyError {
-    /// HTTP status code (e.g. 502, 504).
-    status: u16,
     /// Machine-readable error code (e.g. `upstream_connect_refused`).
     code: &'static str,
     /// Human-readable error message.
     message: &'static str,
+    /// HTTP status code (e.g. 502, 504).
+    status: u16,
 }
 
-/// Handle a fatal proxy error by writing an RFC 9457 Problem Details
-/// response to the downstream client.
+/// Handle a fatal proxy error by writing a structured error response
+/// to the downstream client.
 ///
 /// Guards against double-writes (filter rejections that already sent a
-/// response), downstream errors (client already gone), and HEAD requests
-/// (body suppressed).
+/// response), dead downstream connections, and HEAD requests (body
+/// suppressed). Writable downstream failures (e.g. client body read
+/// timeout) receive a structured 400 response.
 pub(super) async fn execute(session: &mut Session, e: &pingora_core::Error) -> FailToProxy {
     let etype = e.etype().clone();
 
     if let ErrorType::HTTPStatus(code) = etype {
-        if final_response_written(session) {
-            return done(code);
-        }
-        return write_status_error(session, code).await;
+        return handle_http_status(session, code).await;
     }
 
     let source = e.esource();
     if matches!(source, pingora_core::ErrorSource::Downstream) {
-        debug!("downstream error, skipping error response");
-        return done(0);
+        return handle_downstream(session, &etype).await;
     }
 
     let err = classify_error(&etype, source);
@@ -56,12 +53,49 @@ pub(super) async fn execute(session: &mut Session, e: &pingora_core::Error) -> F
     write_error_response(session, err).await
 }
 
-/// Write Pingora's default status response for explicit HTTP status errors.
-async fn write_status_error(session: &mut Session, status: u16) -> FailToProxy {
-    if let Err(e) = session.respond_error(status).await {
-        debug!(error = %e, "failed to write status error response");
+/// Structured response for explicit HTTP status errors.
+///
+/// Filter rejections typically write their own response before raising
+/// `HTTPStatus`; the double-write guard returns immediately in that case.
+async fn handle_http_status(session: &mut Session, code: u16) -> FailToProxy {
+    if final_response_written(session) {
+        return done(code);
     }
-    done(status)
+    let err = ProxyError {
+        code: "proxy_status_error",
+        message: status_title(code),
+        status: code,
+    };
+    write_error_response(session, err).await
+}
+
+/// Handle a downstream-origin error.
+///
+/// Dead connections (write failure, read failure, closed) are silently
+/// abandoned. Writable failures (e.g. body read timeout) receive a
+/// structured 400 response, matching Pingora's default status choice.
+async fn handle_downstream(session: &mut Session, etype: &ErrorType) -> FailToProxy {
+    if is_connection_dead(etype) {
+        debug!("downstream connection dead, skipping error response");
+        return done(0);
+    }
+    if final_response_written(session) {
+        return done(400);
+    }
+    let err = ProxyError {
+        code: "downstream_request_error",
+        message: "Request error",
+        status: 400,
+    };
+    write_error_response(session, err).await
+}
+
+/// Whether the downstream connection is too broken to write a response.
+fn is_connection_dead(etype: &ErrorType) -> bool {
+    matches!(
+        etype,
+        ErrorType::WriteError | ErrorType::ReadError | ErrorType::ConnectionClosed
+    )
 }
 
 /// Build and write the error response to the downstream session.
@@ -154,7 +188,7 @@ const fn done(error_code: u16) -> FailToProxy {
 /// Map a Pingora error type and source to a classified proxy error.
 fn classify_error(etype: &ErrorType, source: &pingora_core::ErrorSource) -> ProxyError {
     let (status, code, message) = classify_error_tuple(etype, source);
-    ProxyError { status, code, message }
+    ProxyError { code, message, status }
 }
 
 /// Error classification lookup table.
@@ -421,5 +455,32 @@ mod tests {
             500,
             "internal_proxy_error",
         );
+    }
+
+    // ---- is_connection_dead --------------------------------------------------
+
+    #[test]
+    fn write_error_is_dead() {
+        assert!(is_connection_dead(&ErrorType::WriteError));
+    }
+
+    #[test]
+    fn read_error_is_dead() {
+        assert!(is_connection_dead(&ErrorType::ReadError));
+    }
+
+    #[test]
+    fn connection_closed_is_dead() {
+        assert!(is_connection_dead(&ErrorType::ConnectionClosed));
+    }
+
+    #[test]
+    fn read_timeout_is_not_dead() {
+        assert!(!is_connection_dead(&ErrorType::ReadTimedout));
+    }
+
+    #[test]
+    fn connect_refused_is_not_dead() {
+        assert!(!is_connection_dead(&ErrorType::ConnectRefused));
     }
 }

--- a/protocol/src/http/pingora/handler/fail_to_proxy.rs
+++ b/protocol/src/http/pingora/handler/fail_to_proxy.rs
@@ -1,0 +1,425 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Structured error responses for fatal proxy errors.
+//!
+//! Produces RFC 9457 Problem Details (`application/problem+json`)
+//! responses when the proxy cannot reach the upstream.
+
+use bytes::Bytes;
+use pingora_core::ErrorType;
+use pingora_proxy::{FailToProxy, Session};
+use tracing::{debug, error};
+
+/// Classified proxy error with HTTP status and machine-readable fields.
+struct ProxyError {
+    /// HTTP status code (e.g. 502, 504).
+    status: u16,
+    /// Machine-readable error code (e.g. `upstream_connect_refused`).
+    code: &'static str,
+    /// Human-readable error message.
+    message: &'static str,
+}
+
+/// Handle a fatal proxy error by writing an RFC 9457 Problem Details
+/// response to the downstream client.
+///
+/// Guards against double-writes (filter rejections that already sent a
+/// response), downstream errors (client already gone), and HEAD requests
+/// (body suppressed).
+pub(super) async fn execute(session: &mut Session, e: &pingora_core::Error) -> FailToProxy {
+    let etype = e.etype().clone();
+
+    if let ErrorType::HTTPStatus(code) = etype {
+        if final_response_written(session) {
+            return done(code);
+        }
+        return write_status_error(session, code).await;
+    }
+
+    let source = e.esource();
+    if matches!(source, pingora_core::ErrorSource::Downstream) {
+        debug!("downstream error, skipping error response");
+        return done(0);
+    }
+
+    let err = classify_error(&etype, source);
+
+    if final_response_written(session) {
+        debug!(
+            status = err.status,
+            err.code, "response already written, skipping proxy error body"
+        );
+        return done(err.status);
+    }
+
+    write_error_response(session, err).await
+}
+
+/// Write Pingora's default status response for explicit HTTP status errors.
+async fn write_status_error(session: &mut Session, status: u16) -> FailToProxy {
+    if let Err(e) = session.respond_error(status).await {
+        debug!(error = %e, "failed to write status error response");
+    }
+    done(status)
+}
+
+/// Build and write the error response to the downstream session.
+async fn write_error_response(session: &mut Session, err: ProxyError) -> FailToProxy {
+    let body = format!(
+        r#"{{"type":"about:blank","title":"{}","status":{},"detail":"{}"}}"#,
+        status_title(err.status),
+        err.status,
+        err.message,
+    );
+    let body_bytes = Bytes::from(body);
+
+    session.set_keepalive(None);
+
+    let Some(header) = build_header(err.status, body_bytes.len()) else {
+        return done(err.status);
+    };
+
+    let is_head = session.req_header().method == http::Method::HEAD;
+    send_error_response(session, header, body_bytes, is_head).await;
+    done(err.status)
+}
+
+/// RFC 9457 title for common proxy error status codes.
+fn status_title(status: u16) -> &'static str {
+    match status {
+        400 => "Bad Request",
+        500 => "Internal Server Error",
+        502 => "Bad Gateway",
+        503 => "Service Unavailable",
+        504 => "Gateway Timeout",
+        _ => "Proxy Error",
+    }
+}
+
+/// Write the error response header and optional body to the downstream session.
+async fn send_error_response(session: &mut Session, header: pingora_http::ResponseHeader, body: Bytes, is_head: bool) {
+    let end_of_stream = is_head;
+    if let Err(e) = session.write_response_header(Box::new(header), end_of_stream).await {
+        debug!(error = %e, "failed to write error response header");
+        return;
+    }
+    if !is_head && let Err(e) = session.write_response_body(Some(body), true).await {
+        debug!(error = %e, "failed to write error response body");
+    }
+}
+
+/// Build a response header with content-type and content-length.
+fn build_header(status: u16, content_length: usize) -> Option<pingora_http::ResponseHeader> {
+    let mut header = match pingora_http::ResponseHeader::build(status, Some(2)) {
+        Ok(h) => h,
+        Err(err) => {
+            error!(status, error = %err, "failed to build error response header");
+            return None;
+        },
+    };
+
+    if header
+        .insert_header("content-type", "application/problem+json")
+        .is_err()
+        || header
+            .insert_header("content-length", content_length.to_string())
+            .is_err()
+    {
+        error!("failed to set error response headers");
+        return None;
+    }
+
+    Some(header)
+}
+
+/// Whether a final downstream response has already been written.
+fn final_response_written(session: &Session) -> bool {
+    session.response_written().is_some_and(is_final_response)
+}
+
+/// Whether a response header blocks a later final error response.
+fn is_final_response(header: &pingora_http::ResponseHeader) -> bool {
+    !header.status.is_informational() || header.status == http::StatusCode::SWITCHING_PROTOCOLS
+}
+
+/// Construct a `FailToProxy` result.
+const fn done(error_code: u16) -> FailToProxy {
+    FailToProxy {
+        error_code,
+        can_reuse_downstream: false,
+    }
+}
+
+/// Map a Pingora error type and source to a classified proxy error.
+fn classify_error(etype: &ErrorType, source: &pingora_core::ErrorSource) -> ProxyError {
+    let (status, code, message) = classify_error_tuple(etype, source);
+    ProxyError { status, code, message }
+}
+
+/// Error classification lookup table.
+fn classify_error_tuple(etype: &ErrorType, source: &pingora_core::ErrorSource) -> (u16, &'static str, &'static str) {
+    use pingora_core::ErrorSource::{Internal, Unset, Upstream};
+    match (etype, source) {
+        (ErrorType::ConnectRefused, _) => (502, "upstream_connect_refused", "Upstream connection refused"),
+        (ErrorType::ConnectTimedout, _) => (504, "upstream_connect_timeout", "Upstream connection timed out"),
+        (ErrorType::ConnectNoRoute, _) => (502, "upstream_connect_no_route", "No route to upstream"),
+        (ErrorType::ConnectError, _) => (502, "upstream_connect_error", "Upstream connection error"),
+        (ErrorType::TLSHandshakeFailure, _) => (502, "upstream_tls_failure", "Upstream TLS handshake failed"),
+        (ErrorType::TLSHandshakeTimedout, _) => (504, "upstream_tls_timeout", "Upstream TLS handshake timed out"),
+        (ErrorType::InvalidCert, _) => (502, "upstream_invalid_cert", "Upstream certificate invalid"),
+        (ErrorType::ReadTimedout, Upstream) => (504, "upstream_read_timeout", "Upstream read timed out"),
+        (ErrorType::WriteTimedout, Upstream) => (504, "upstream_write_timeout", "Upstream write timed out"),
+        (ErrorType::ReadError, Upstream) => (502, "upstream_read_error", "Upstream read error"),
+        (ErrorType::WriteError, Upstream) => (502, "upstream_write_error", "Upstream write error"),
+        (ErrorType::ConnectionClosed, Upstream) => (502, "upstream_connection_closed", "Upstream connection closed"),
+        (ErrorType::H2Error | ErrorType::InvalidH2, Upstream) => (502, "upstream_h2_error", "Upstream HTTP/2 error"),
+        (_, Internal | Unset) => (500, "internal_proxy_error", "Internal proxy error"),
+        _ => (502, "upstream_error", "Upstream error"),
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+#[expect(clippy::allow_attributes, reason = "blanket test suppressions")]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    fn check(etype: &ErrorType, source: &pingora_core::ErrorSource, expected_status: u16, expected_code: &str) {
+        let err = classify_error(etype, source);
+        assert_eq!(
+            err.status, expected_status,
+            "{etype:?}/{source:?} should map to status {expected_status}"
+        );
+        assert_eq!(
+            err.code, expected_code,
+            "{etype:?}/{source:?} should map to code {expected_code}"
+        );
+    }
+
+    #[test]
+    fn problem_details_body_has_rfc9457_fields() {
+        let status = 502;
+        let title = status_title(status);
+        let body = format!(
+            r#"{{"type":"about:blank","title":"{title}","status":{status},"detail":"Upstream connection refused"}}"#,
+        );
+        assert!(body.contains(r#""type":"about:blank""#));
+        assert!(body.contains(r#""title":"Bad Gateway""#));
+        assert!(body.contains(r#""status":502"#));
+        assert!(body.contains(r#""detail":"Upstream connection refused""#));
+    }
+
+    #[test]
+    fn status_title_maps_common_codes() {
+        assert_eq!(status_title(502), "Bad Gateway");
+        assert_eq!(status_title(504), "Gateway Timeout");
+        assert_eq!(status_title(500), "Internal Server Error");
+        assert_eq!(status_title(503), "Service Unavailable");
+        assert_eq!(status_title(418), "Proxy Error");
+    }
+
+    #[test]
+    fn informational_100_allows_later_final_error() {
+        let header = pingora_http::ResponseHeader::build(100, None).unwrap();
+
+        assert!(
+            !is_final_response(&header),
+            "100 Continue should not block a later final error response"
+        );
+    }
+
+    #[test]
+    fn switching_protocols_counts_as_final_response() {
+        let header = pingora_http::ResponseHeader::build(101, None).unwrap();
+
+        assert!(
+            is_final_response(&header),
+            "101 Switching Protocols should block later error responses"
+        );
+    }
+
+    #[test]
+    fn non_informational_counts_as_final_response() {
+        let header = pingora_http::ResponseHeader::build(200, None).unwrap();
+
+        assert!(
+            is_final_response(&header),
+            "200 response should block later error responses"
+        );
+    }
+
+    #[test]
+    fn connect_refused_maps_to_502() {
+        check(
+            &ErrorType::ConnectRefused,
+            &pingora_core::ErrorSource::Upstream,
+            502,
+            "upstream_connect_refused",
+        );
+    }
+
+    #[test]
+    fn connect_timeout_maps_to_504() {
+        check(
+            &ErrorType::ConnectTimedout,
+            &pingora_core::ErrorSource::Upstream,
+            504,
+            "upstream_connect_timeout",
+        );
+    }
+
+    #[test]
+    fn read_timeout_upstream_maps_to_504() {
+        check(
+            &ErrorType::ReadTimedout,
+            &pingora_core::ErrorSource::Upstream,
+            504,
+            "upstream_read_timeout",
+        );
+    }
+
+    #[test]
+    fn write_timeout_upstream_maps_to_504() {
+        check(
+            &ErrorType::WriteTimedout,
+            &pingora_core::ErrorSource::Upstream,
+            504,
+            "upstream_write_timeout",
+        );
+    }
+
+    #[test]
+    fn read_error_upstream_maps_to_502() {
+        check(
+            &ErrorType::ReadError,
+            &pingora_core::ErrorSource::Upstream,
+            502,
+            "upstream_read_error",
+        );
+    }
+
+    #[test]
+    fn write_error_upstream_maps_to_502() {
+        check(
+            &ErrorType::WriteError,
+            &pingora_core::ErrorSource::Upstream,
+            502,
+            "upstream_write_error",
+        );
+    }
+
+    #[test]
+    fn connection_closed_upstream_maps_to_502() {
+        check(
+            &ErrorType::ConnectionClosed,
+            &pingora_core::ErrorSource::Upstream,
+            502,
+            "upstream_connection_closed",
+        );
+    }
+
+    #[test]
+    fn tls_failure_maps_to_502() {
+        check(
+            &ErrorType::TLSHandshakeFailure,
+            &pingora_core::ErrorSource::Upstream,
+            502,
+            "upstream_tls_failure",
+        );
+    }
+
+    #[test]
+    fn tls_timeout_maps_to_504() {
+        check(
+            &ErrorType::TLSHandshakeTimedout,
+            &pingora_core::ErrorSource::Upstream,
+            504,
+            "upstream_tls_timeout",
+        );
+    }
+
+    #[test]
+    fn invalid_cert_maps_to_502() {
+        check(
+            &ErrorType::InvalidCert,
+            &pingora_core::ErrorSource::Upstream,
+            502,
+            "upstream_invalid_cert",
+        );
+    }
+
+    #[test]
+    fn h2_error_upstream_maps_to_502() {
+        check(
+            &ErrorType::H2Error,
+            &pingora_core::ErrorSource::Upstream,
+            502,
+            "upstream_h2_error",
+        );
+    }
+
+    #[test]
+    fn connect_no_route_maps_to_502() {
+        check(
+            &ErrorType::ConnectNoRoute,
+            &pingora_core::ErrorSource::Upstream,
+            502,
+            "upstream_connect_no_route",
+        );
+    }
+
+    #[test]
+    fn connect_error_maps_to_502() {
+        check(
+            &ErrorType::ConnectError,
+            &pingora_core::ErrorSource::Upstream,
+            502,
+            "upstream_connect_error",
+        );
+    }
+
+    #[test]
+    fn internal_error_maps_to_500() {
+        check(
+            &ErrorType::InternalError,
+            &pingora_core::ErrorSource::Internal,
+            500,
+            "internal_proxy_error",
+        );
+    }
+
+    #[test]
+    fn unset_source_maps_to_500() {
+        check(
+            &ErrorType::InternalError,
+            &pingora_core::ErrorSource::Unset,
+            500,
+            "internal_proxy_error",
+        );
+    }
+
+    #[test]
+    fn unknown_upstream_error_maps_to_502() {
+        check(
+            &ErrorType::UnknownError,
+            &pingora_core::ErrorSource::Upstream,
+            502,
+            "upstream_error",
+        );
+    }
+
+    #[test]
+    fn read_error_with_non_upstream_source_falls_through() {
+        check(
+            &ErrorType::ReadError,
+            &pingora_core::ErrorSource::Internal,
+            500,
+            "internal_proxy_error",
+        );
+    }
+}

--- a/protocol/src/http/pingora/handler/mod.rs
+++ b/protocol/src/http/pingora/handler/mod.rs
@@ -27,6 +27,8 @@ use tracing::{debug, warn};
 
 use super::{context::PingoraRequestCtx, metrics};
 
+/// Structured error responses for fatal proxy errors.
+mod fail_to_proxy;
 /// Shared hop-by-hop header stripping logic.
 mod hop_by_hop;
 /// HTTP handler without body filter hooks.

--- a/protocol/src/http/pingora/handler/no_body.rs
+++ b/protocol/src/http/pingora/handler/no_body.rs
@@ -16,14 +16,14 @@ use pingora_core::{
     modules::http::{HttpModules, compression::ResponseCompressionBuilder},
     upstreams::peer::HttpPeer,
 };
-use pingora_proxy::{ProxyHttp, Session};
+use pingora_proxy::{FailToProxy, ProxyHttp, Session};
 use praxis_filter::{CompressionConfig, FilterPipeline};
 use tokio::sync::Semaphore;
 use tracing::debug;
 
 use super::{
-    adjust_compression, emit_request_metrics, handle_connect_failure, logging_cleanup, record_passive_health,
-    request_filter, response_filter, upstream_peer, upstream_request, via,
+    adjust_compression, emit_request_metrics, fail_to_proxy, handle_connect_failure, logging_cleanup,
+    record_passive_health, request_filter, response_filter, upstream_peer, upstream_request, via,
 };
 use crate::http::pingora::context::PingoraRequestCtx;
 
@@ -161,6 +161,13 @@ impl ProxyHttp for PingoraHttpHandlerNoBody {
         e: Box<pingora_core::Error>,
     ) -> Box<pingora_core::Error> {
         handle_connect_failure(ctx, e)
+    }
+
+    async fn fail_to_proxy(&self, session: &mut Session, e: &pingora_core::Error, _ctx: &mut Self::CTX) -> FailToProxy
+    where
+        Self::CTX: Send + Sync,
+    {
+        fail_to_proxy::execute(session, e).await
     }
 
     async fn upstream_request_filter(

--- a/protocol/src/http/pingora/handler/no_body.rs
+++ b/protocol/src/http/pingora/handler/no_body.rs
@@ -163,11 +163,11 @@ impl ProxyHttp for PingoraHttpHandlerNoBody {
         handle_connect_failure(ctx, e)
     }
 
-    async fn fail_to_proxy(&self, session: &mut Session, e: &pingora_core::Error, _ctx: &mut Self::CTX) -> FailToProxy
+    async fn fail_to_proxy(&self, session: &mut Session, e: &pingora_core::Error, ctx: &mut Self::CTX) -> FailToProxy
     where
         Self::CTX: Send + Sync,
     {
-        fail_to_proxy::execute(session, e).await
+        fail_to_proxy::execute(session, e, ctx).await
     }
 
     async fn upstream_request_filter(

--- a/protocol/src/http/pingora/handler/with_body.rs
+++ b/protocol/src/http/pingora/handler/with_body.rs
@@ -21,14 +21,15 @@ use pingora_core::{
     modules::http::{HttpModules, compression::ResponseCompressionBuilder},
     upstreams::peer::HttpPeer,
 };
-use pingora_proxy::{ProxyHttp, Session};
+use pingora_proxy::{FailToProxy, ProxyHttp, Session};
 use praxis_filter::{CompressionConfig, FilterPipeline};
 use tokio::sync::Semaphore;
 use tracing::debug;
 
 use super::{
-    adjust_compression, emit_request_metrics, handle_connect_failure, logging_cleanup, record_passive_health,
-    request_body_filter, request_filter, response_body_filter, response_filter, upstream_peer, upstream_request, via,
+    adjust_compression, emit_request_metrics, fail_to_proxy, handle_connect_failure, logging_cleanup,
+    record_passive_health, request_body_filter, request_filter, response_body_filter, response_filter, upstream_peer,
+    upstream_request, via,
 };
 use crate::http::pingora::context::PingoraRequestCtx;
 
@@ -196,6 +197,13 @@ impl ProxyHttp for PingoraHttpHandler {
         e: Box<pingora_core::Error>,
     ) -> Box<pingora_core::Error> {
         handle_connect_failure(ctx, e)
+    }
+
+    async fn fail_to_proxy(&self, session: &mut Session, e: &pingora_core::Error, _ctx: &mut Self::CTX) -> FailToProxy
+    where
+        Self::CTX: Send + Sync,
+    {
+        fail_to_proxy::execute(session, e).await
     }
 
     async fn upstream_request_filter(

--- a/protocol/src/http/pingora/handler/with_body.rs
+++ b/protocol/src/http/pingora/handler/with_body.rs
@@ -199,11 +199,11 @@ impl ProxyHttp for PingoraHttpHandler {
         handle_connect_failure(ctx, e)
     }
 
-    async fn fail_to_proxy(&self, session: &mut Session, e: &pingora_core::Error, _ctx: &mut Self::CTX) -> FailToProxy
+    async fn fail_to_proxy(&self, session: &mut Session, e: &pingora_core::Error, ctx: &mut Self::CTX) -> FailToProxy
     where
         Self::CTX: Send + Sync,
     {
-        fail_to_proxy::execute(session, e).await
+        fail_to_proxy::execute(session, e, ctx).await
     }
 
     async fn upstream_request_filter(

--- a/tests/integration/tests/suite/error_response.rs
+++ b/tests/integration/tests/suite/error_response.rs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Praxis Contributors
+
+//! Tests for structured error responses on upstream failures.
+
+use praxis_core::config::Config;
+use praxis_test_utils::{
+    free_port, http_get, http_send, parse_body, parse_header, parse_status, simple_proxy_yaml, start_proxy,
+};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[test]
+fn dead_backend_returns_problem_details_body() {
+    let dead_port = free_port();
+    let proxy_port = free_port();
+    let yaml = simple_proxy_yaml(proxy_port, dead_port);
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let (status, body) = http_get(proxy.addr(), "/", None);
+
+    assert_eq!(status, 502, "dead backend should return 502");
+    assert!(
+        body.contains(r#""type":"about:blank""#),
+        "body should contain RFC 9457 type field, got: {body}"
+    );
+    assert!(
+        body.contains(r#""title":"Bad Gateway""#),
+        "body should contain RFC 9457 title, got: {body}"
+    );
+    assert!(
+        body.contains(r#""status":502"#),
+        "body should contain RFC 9457 status, got: {body}"
+    );
+    assert!(
+        body.contains(r#""detail":"Upstream connection refused""#),
+        "body should contain human-readable detail, got: {body}"
+    );
+}
+
+#[test]
+fn dead_backend_returns_problem_json_content_type() {
+    let dead_port = free_port();
+    let proxy_port = free_port();
+    let yaml = simple_proxy_yaml(proxy_port, dead_port);
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+    );
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 502, "dead backend should return 502");
+
+    let ct = parse_header(&raw, "content-type");
+    assert_eq!(
+        ct.as_deref(),
+        Some("application/problem+json"),
+        "error response should have application/problem+json content-type"
+    );
+}
+
+#[test]
+fn dead_backend_head_request_has_no_body() {
+    let dead_port = free_port();
+    let proxy_port = free_port();
+    let yaml = simple_proxy_yaml(proxy_port, dead_port);
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        "HEAD / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+    );
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 502, "HEAD to dead backend should return 502");
+
+    let body = parse_body(&raw);
+    assert!(body.is_empty(), "HEAD response should have no body, got: {body}");
+
+    let ct = parse_header(&raw, "content-type");
+    assert_eq!(
+        ct.as_deref(),
+        Some("application/problem+json"),
+        "HEAD error response should still have content-type header"
+    );
+}
+
+#[test]
+fn dead_backend_post_returns_problem_details_body() {
+    let dead_port = free_port();
+    let proxy_port = free_port();
+    let yaml = simple_proxy_yaml(proxy_port, dead_port);
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        "POST /v1/responses HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: 2\r\n\
+         Connection: close\r\n\r\n\
+         {}",
+    );
+
+    let status = parse_status(&raw);
+    assert_eq!(status, 502, "POST to dead backend should return 502");
+
+    let body = parse_body(&raw);
+    assert!(
+        body.contains(r#""type":"about:blank""#),
+        "POST error body should contain RFC 9457 type, got: {body}"
+    );
+}
+
+#[test]
+fn error_response_is_valid_json() {
+    let dead_port = free_port();
+    let proxy_port = free_port();
+    let yaml = simple_proxy_yaml(proxy_port, dead_port);
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let (_status, body) = http_get(proxy.addr(), "/", None);
+
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap_or_else(|e| {
+        panic!("error response body should be valid JSON: {e}\nbody: {body}");
+    });
+
+    assert!(parsed.get("type").is_some(), "should have 'type' field");
+    assert!(parsed.get("title").is_some(), "should have 'title' field");
+    assert!(parsed.get("status").is_some(), "should have 'status' field");
+    assert!(parsed.get("detail").is_some(), "should have 'detail' field");
+}

--- a/tests/integration/tests/suite/error_response.rs
+++ b/tests/integration/tests/suite/error_response.rs
@@ -3,9 +3,15 @@
 
 //! Tests for structured error responses on upstream failures.
 
+use http::HeaderValue;
 use praxis_core::config::Config;
+use praxis_filter::{
+    ErrorResponseContext, ErrorResponseFormatter, ErrorResponseFormatterHandle, FilterAction, FilterError,
+    FormattedErrorResponse, HttpFilter, HttpFilterContext,
+};
 use praxis_test_utils::{
-    free_port, http_get, http_send, parse_body, parse_header, parse_status, simple_proxy_yaml, start_proxy,
+    custom_filter_yaml, free_port, http_get, http_send, parse_body, parse_header, parse_status, registry_with,
+    simple_proxy_yaml, start_proxy, start_proxy_with_registry,
 };
 
 // -----------------------------------------------------------------------------
@@ -138,4 +144,110 @@ fn error_response_is_valid_json() {
     assert!(parsed.get("title").is_some(), "should have 'title' field");
     assert!(parsed.get("status").is_some(), "should have 'status' field");
     assert!(parsed.get("detail").is_some(), "should have 'detail' field");
+}
+
+#[test]
+fn external_filter_controls_error_response_envelope() {
+    let dead_port = free_port();
+    let proxy_port = free_port();
+    let yaml = custom_filter_yaml(proxy_port, dead_port, "test_error_formatter");
+    let config = Config::from_yaml(&yaml).unwrap();
+    let registry = registry_with("test_error_formatter", || Box::new(InstallErrorFormatterFilter));
+    let proxy = start_proxy_with_registry(&config, &registry);
+
+    let raw = http_send(
+        proxy.addr(),
+        "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+    );
+
+    assert_eq!(parse_status(&raw), 502, "dead backend should return 502");
+    assert_eq!(
+        parse_header(&raw, "content-type").as_deref(),
+        Some("application/vnd.praxis.test+json")
+    );
+    assert_eq!(
+        parse_body(&raw),
+        r#"{"error":{"code":"upstream_connect_refused","status":502}}"#
+    );
+}
+
+#[test]
+fn error_response_bypasses_compression_module() {
+    let dead_port = free_port();
+    let proxy_port = free_port();
+    let yaml = format!(
+        r#"
+listeners:
+  - name: default
+    address: "127.0.0.1:{proxy_port}"
+    filter_chains: [main]
+filter_chains:
+  - name: main
+    filters:
+      - filter: compression
+        min_size_bytes: 1
+      - filter: router
+        routes:
+          - path_prefix: "/"
+            cluster: backend
+      - filter: load_balancer
+        clusters:
+          - name: backend
+            endpoints:
+              - "127.0.0.1:{dead_port}"
+"#
+    );
+    let config = Config::from_yaml(&yaml).unwrap();
+    let proxy = start_proxy(&config);
+
+    let raw = http_send(
+        proxy.addr(),
+        "GET / HTTP/1.1\r\nHost: localhost\r\nAccept-Encoding: gzip\r\nConnection: close\r\n\r\n",
+    );
+
+    assert_eq!(parse_status(&raw), 502, "dead backend should return 502");
+    assert!(
+        parse_header(&raw, "content-encoding").is_none(),
+        "synthetic error response must not be compressed"
+    );
+    let body = parse_body(&raw);
+    assert!(
+        body.contains(r#""status":502"#),
+        "body should remain plain JSON: {body}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Test Utilities
+// -----------------------------------------------------------------------------
+
+/// Filter that installs a test-owned error response formatter.
+struct InstallErrorFormatterFilter;
+
+#[async_trait::async_trait]
+impl HttpFilter for InstallErrorFormatterFilter {
+    fn name(&self) -> &'static str {
+        "test_error_formatter"
+    }
+
+    async fn on_request(&self, ctx: &mut HttpFilterContext<'_>) -> Result<FilterAction, FilterError> {
+        ctx.extensions
+            .insert(ErrorResponseFormatterHandle::new(TestErrorFormatter));
+        Ok(FilterAction::Continue)
+    }
+}
+
+/// Test formatter standing in for a provider-specific external filter.
+struct TestErrorFormatter;
+
+impl ErrorResponseFormatter for TestErrorFormatter {
+    fn format(&self, context: &ErrorResponseContext<'_>) -> FormattedErrorResponse {
+        FormattedErrorResponse::new(
+            format!(
+                r#"{{"error":{{"code":"{}","status":{}}}}}"#,
+                context.code, context.status
+            ),
+            HeaderValue::from_static("application/vnd.praxis.test+json"),
+        )
+    }
 }

--- a/tests/integration/tests/suite/error_response.rs
+++ b/tests/integration/tests/suite/error_response.rs
@@ -210,6 +210,11 @@ filter_chains:
         parse_header(&raw, "content-encoding").is_none(),
         "synthetic error response must not be compressed"
     );
+    assert_eq!(
+        parse_header(&raw, "cache-control").as_deref(),
+        Some("no-transform"),
+        "synthetic error response should include no-transform cache directive"
+    );
     let body = parse_body(&raw);
     assert!(
         body.contains(r#""status":502"#),

--- a/tests/integration/tests/suite/main.rs
+++ b/tests/integration/tests/suite/main.rs
@@ -45,6 +45,7 @@ mod conditions;
 mod cors;
 mod csrf;
 mod downstream_read_timeout;
+mod error_response;
 mod examples;
 mod failure_mode;
 mod filter_composition;

--- a/tests/resilience/tests/suite/backend_failure.rs
+++ b/tests/resilience/tests/suite/backend_failure.rs
@@ -68,7 +68,7 @@ fn partial_response_backend_returns_502() {
 }
 
 #[test]
-fn slow_backend_with_read_timeout_returns_502() {
+fn slow_backend_with_read_timeout_returns_504() {
     let slow_port = start_slow_backend("slow", Duration::from_secs(5));
     let proxy_port = free_port();
     let yaml = read_timeout_proxy_yaml(proxy_port, slow_port, 500);
@@ -79,7 +79,7 @@ fn slow_backend_with_read_timeout_returns_502() {
     let (status, _) = http_get(proxy.addr(), "/", None);
     let elapsed = start.elapsed();
 
-    assert_eq!(status, 502, "slow backend with read timeout should return 502");
+    assert_eq!(status, 504, "slow backend with read timeout should return 504");
     assert!(
         elapsed < Duration::from_secs(3),
         "read timeout should fire quickly, not wait for full backend delay; took {elapsed:?}"


### PR DESCRIPTION
### What does this PR do?

When upstream servers are unreachable, Praxis now returns structured JSON error responses instead of empty bodies. By default, responses use RFC 9457 Problem Details (`application/problem+json`). External filter crates can install a custom `ErrorResponseFormatter` via request extensions to produce provider-specific envelopes (e.g. OpenAI, Anthropic).

Key behaviors:
- Classifies Pingora error types into machine-readable codes and appropriate HTTP status codes (502/504/500)
- Guards against double-writes when filters have already sent a response
- Distinguishes dead downstream connections (silent abandon) from writable failures (structured 400)
- Suppresses body on HEAD requests while preserving headers
- Adds `cache-control: no-transform` since synthetic error bodies bypass Pingora's compression pipeline
- Uses `http::StatusCode::canonical_reason()` for RFC 9457 titles per §4.2.1

### Which issue(s) does this relate to?

N/A

### Checklist

- [x] Signed off all commits (`git commit -s`)
- [x] Tests added or updated
- [x] Documentation updated (if applicable)
- [x] `make lint && make test` passes locally

### Does this introduce a breaking change?

No. This adds a new `fail_to_proxy` hook implementation and `ErrorResponseFormatter` trait. Existing behavior is preserved — requests without a custom formatter get RFC 9457 Problem Details by default.