### PR TITLE
ci: add parallel experimental-features matrix job

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -79,8 +79,6 @@ jobs:
 
   experimental-features:
     runs-on: ubuntu-24.04
-    # Non-voting: feature-gated code may lag behind the default path.
-    continue-on-error: true
     permissions:
       contents: read
     strategy:
@@ -102,11 +100,11 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cargo/bin/cargo-hack
-          key: cargo-hack-${{ runner.os }}
+          key: cargo-hack-0.6.45-${{ runner.os }}
 
       - name: Install cargo-hack
         if: steps.cache-hack.outputs.cache-hit != 'true'
-        run: cargo install cargo-hack --locked
+        run: cargo install cargo-hack@0.6.45 --locked
 
       - name: Clippy non-default features
         run: >

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -72,3 +72,51 @@ jobs:
 
       - name: Unit tests
         run: make test-unit
+
+  # ----------------------------------------------------------------------------
+  # Non-default feature verification (per crate, parallel)
+  # ----------------------------------------------------------------------------
+
+  experimental-features:
+    runs-on: ubuntu-24.04
+    # Non-voting: feature-gated code may lag behind the default path.
+    continue-on-error: true
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        crate:
+          - praxis-proxy-core
+          - praxis-proxy-filter
+          - praxis-proxy-tls
+          - praxis-proxy
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Rust
+        uses: praxis-proxy/conventions/.github/actions/setup-rust@dc77dbd3a55ce96e8e31a3c8d36cea4952617dd3 # v0.1.0
+
+      - name: Cache cargo-hack
+        id: cache-hack
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cargo/bin/cargo-hack
+          key: cargo-hack-${{ runner.os }}
+
+      - name: Install cargo-hack
+        if: steps.cache-hack.outputs.cache-hit != 'true'
+        run: cargo install cargo-hack --locked
+
+      - name: Clippy non-default features
+        run: >
+          cargo hack clippy --each-feature
+          --exclude-no-default-features --exclude-features default
+          -p ${{ matrix.crate }}
+          -- -D warnings
+
+      - name: Test non-default features
+        run: >
+          cargo hack test --each-feature
+          --exclude-no-default-features --exclude-features default
+          -p ${{ matrix.crate }}


### PR DESCRIPTION
## What

Add per-crate matrix job that verifies non-default feature
combinations lint and pass tests using `cargo-hack --each-feature`.

## Why

Code behind `#[cfg(feature = "...")]` is invisible to the default
CI pipeline. The existing #909 approach runs all crates sequentially
in one job (~19 min). This splits into parallel matrix jobs for
faster feedback (~5 min wall-clock).

## How

Matrix strategy spawns 4 parallel runners, one per crate:

- `experimental-features (praxis-proxy-core)` — otel
- `experimental-features (praxis-proxy-filter)` — basic-auth-filter, cpex-policy-engine
- `experimental-features (praxis-proxy-tls)` — hot-reload
- `experimental-features (praxis-proxy)` — otel, dev, basic-auth-filter, cpex-policy-engine, experimental

Each job runs two steps using `cargo-hack --each-feature`:

1. **Clippy** — lint each non-default feature in isolation
2. **Test** — run tests per non-default feature

Flags:
- `--exclude-no-default-features` skips the zero-features run
- `--exclude-features default` skips the default-features run

Non-voting (`continue-on-error: true`, `fail-fast: false`) until
all feature-gated paths stabilize.

Supersedes #909 with parallel execution.

Depends on #836 (merged).